### PR TITLE
Add foundational register model classes

### DIFF
--- a/pyuvm/__init__.py
+++ b/pyuvm/__init__.py
@@ -16,7 +16,5 @@ from pyuvm.s12_uvm_tlm_interfaces import *
 from pyuvm.s13_predefined_component_classes import *
 # Section 14, 15 (Done as fresh Python design)
 from pyuvm.s14_15_python_sequences import *
-
-
-
-
+# Section 18
+from pyuvm.s18_register_model import *

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -26,15 +26,23 @@ class uvm_reg_map(uvm_object):
     # TODO Fix signature
     def __init__(self):
         self._parent = None
+        self._base_addr = None
 
     # 18.2.3.2
     # TODO Fix signature
-    def configure(self, parent):
+    # TODO Support binary and hex values for 'base_addr'
+    def configure(self, parent, base_addr):
         self._parent = parent
+        self._base_addr = base_addr
 
     # 18.2.4.2
     def get_parent(self):
         return self._parent
+
+    # 18.2.4.4
+    # TODO Fix signature
+    def get_base_addr(self):
+        return self._base_addr
 
 
 # 18.4.1 Class declaration

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -3,7 +3,19 @@ from pyuvm import uvm_object
 
 # 18.1.1 Class declaration
 class uvm_reg_block(uvm_object):
-    pass
+
+    # 18.1.2.1
+    # TODO Fix signature
+    def __init__(self):
+        self._regs = []
+
+    # 18.1.3.7
+    # TODO Fix signature
+    def get_registers(self):
+        return self._regs
+
+    def _add_register(self, reg):
+        self._regs.append(reg)
 
 
 # 18.2.1 Class declaration
@@ -24,6 +36,7 @@ class uvm_reg(uvm_object):
     # 18.4.2.2
     def configure(self, parent):
         self._parent = parent
+        parent._add_register(self)
 
     # 18.4.3.1
     def get_parent(self):

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -13,7 +13,19 @@ class uvm_reg_map(uvm_object):
 
 # 18.4.1 Class declaration
 class uvm_reg(uvm_object):
-    pass
+
+    # 18.3.2.1
+    # TODO Fix signature
+    def __init__(self):
+        self._parent = None
+
+    # 18.4.2.2
+    def configure(self, parent):
+        self._parent = parent
+
+    # 18.4.3.1
+    def get_parent(self):
+        return self._parent
 
 
 # 18.5.1 Class declaration

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -23,12 +23,18 @@ class uvm_reg_field(uvm_object):
     # TODO Fix signature
     def __init__(self):
         self._parent = None
+        self._size = None
 
     # 18.5.3.2
     # TODO Fix signature
-    def configure(self, parent):
+    def configure(self, parent, size):
         self._parent = parent
+        self._size = size
 
     # 18.5.4.1
     def get_parent(self):
         return self._parent
+
+    # 18.5.4.3
+    def get_n_bits(self):
+        return self._size

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -9,3 +9,8 @@ class uvm_reg_block(uvm_object):
 # 18.2.1 Class declaration
 class uvm_reg_map(uvm_object):
     pass
+
+
+# 18.4.1 Class declaration
+class uvm_reg(uvm_object):
+    pass

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -27,7 +27,7 @@ class uvm_reg_map(uvm_object):
         super().__init__(name)
         self._parent = None
         self._base_addr = None
-        self._regs = []
+        self._regs = {}
 
     # 18.2.3.2
     # TODO Fix signature
@@ -48,12 +48,18 @@ class uvm_reg_map(uvm_object):
     # 18.2.3.3
     # TODO Fix signature
     # TODO Perform validation (e.g. reg not already added)
-    def add_reg(self, reg):
-        self._regs.append(reg)
+    def add_reg(self, reg, offset):
+        self._regs[offset] = reg
 
     # 18.2.4.11
     def get_registers(self):
-        return self._regs
+        return list(self._regs.values())
+
+    # 18.2.4.17
+    # TODO Fix signature
+    # TODO Handle case where no register exists at offset
+    def get_reg_by_offset(self, offset):
+        return self._regs[offset]
 
 
 # 18.4.1 Class declaration

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -19,6 +19,7 @@ class uvm_reg(uvm_object):
     def __init__(self, name=""):
         super().__init__(name)
         self._parent = None
+        self._fields = []
 
     # 18.4.2.2
     def configure(self, parent):
@@ -27,6 +28,20 @@ class uvm_reg(uvm_object):
     # 18.4.3.1
     def get_parent(self):
         return self._parent
+
+    # 18.4.3.11
+    # TODO Return fields in canonical order (LSB to MSB)
+    def get_fields(self):
+        return self._fields
+
+    # TODO Add validation
+    # - field not None
+    # - field not already added
+    # - field fits in reg
+    # - field doesn't overlap with any other field
+    # - etc.
+    def _add_field(self, field):
+        self._fields.append(field)
 
 
 # 18.5.1 Class declaration
@@ -48,6 +63,7 @@ class uvm_reg_field(uvm_object):
         # TODO Add validation of arguments
         # TODO Support binary and hex values for 'reset'
         self._parent = parent
+        parent._add_field(self)
         self._size = size
         self._lsb_pos = lsb_pos
         self._access = access

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -16,7 +16,8 @@ class uvm_reg(uvm_object):
 
     # 18.3.2.1
     # TODO Fix signature
-    def __init__(self):
+    def __init__(self, name=""):
+        super().__init__(name)
         self._parent = None
 
     # 18.4.2.2

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -23,8 +23,8 @@ class uvm_reg_block(uvm_object):
 class uvm_reg_map(uvm_object):
 
     # 18.2.3.1
-    # TODO Fix signature
-    def __init__(self):
+    def __init__(self, name="uvm_reg_map"):
+        super().__init__(name)
         self._parent = None
         self._base_addr = None
 

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -4,3 +4,8 @@ from pyuvm import uvm_object
 # 18.1.1 Class declaration
 class uvm_reg_block(uvm_object):
     pass
+
+
+# 18.2.1 Class declaration
+class uvm_reg_map(uvm_object):
+    pass

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -20,8 +20,8 @@ class uvm_reg(uvm_object):
 class uvm_reg_field(uvm_object):
 
     # 18.5.3.1
-    # TODO Fix signature
-    def __init__(self):
+    def __init__(self, name='uvm_reg_field'):
+        super().__init__(name)
         self._parent = None
         self._size = None
         self._lsb_pos = None

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -24,18 +24,25 @@ class uvm_reg_field(uvm_object):
     def __init__(self):
         self._parent = None
         self._size = None
+        self._lsb_pos = None
 
     # 18.5.3.2
     # TODO Fix signature
-    def configure(self, parent, size):
+    def configure(self, parent, size, lsb_pos):
         # TODO Add validation of arguments
         self._parent = parent
         self._size = size
+        self._lsb_pos = lsb_pos
 
     # 18.5.4.1
     def get_parent(self):
         # TODO Check that 'configure' was called
         return self._parent
+
+    # 18.5.4.2
+    def get_lsb_pos(self):
+        # TODO Check that 'configure' was called
+        return self._lsb_pos
 
     # 18.5.4.3
     def get_n_bits(self):

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -6,7 +6,8 @@ class uvm_reg_block(uvm_object):
 
     # 18.1.2.1
     # TODO Fix signature
-    def __init__(self):
+    def __init__(self, name=""):
+        super().__init__(name)
         self._regs = []
 
     # 18.1.3.7

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -18,4 +18,17 @@ class uvm_reg(uvm_object):
 
 # 18.5.1 Class declaration
 class uvm_reg_field(uvm_object):
-    pass
+
+    # 18.5.3.1
+    # TODO Fix signature
+    def __init__(self):
+        self._parent = None
+
+    # 18.5.3.2
+    # TODO Fix signature
+    def configure(self, parent):
+        self._parent = parent
+
+    # 18.5.4.1
+    def get_parent(self):
+        return self._parent

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -27,6 +27,7 @@ class uvm_reg_map(uvm_object):
         super().__init__(name)
         self._parent = None
         self._base_addr = None
+        self._regs = []
 
     # 18.2.3.2
     # TODO Fix signature
@@ -43,6 +44,16 @@ class uvm_reg_map(uvm_object):
     # TODO Fix signature
     def get_base_addr(self):
         return self._base_addr
+
+    # 18.2.3.3
+    # TODO Fix signature
+    # TODO Perform validation (e.g. reg not already added)
+    def add_reg(self, reg):
+        self._regs.append(reg)
+
+    # 18.2.4.11
+    def get_registers(self):
+        return self._regs
 
 
 # 18.4.1 Class declaration

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -28,13 +28,16 @@ class uvm_reg_field(uvm_object):
     # 18.5.3.2
     # TODO Fix signature
     def configure(self, parent, size):
+        # TODO Add validation of arguments
         self._parent = parent
         self._size = size
 
     # 18.5.4.1
     def get_parent(self):
+        # TODO Check that 'configure' was called
         return self._parent
 
     # 18.5.4.3
     def get_n_bits(self):
+        # TODO Check that 'configure' was called
         return self._size

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -25,14 +25,16 @@ class uvm_reg_field(uvm_object):
         self._parent = None
         self._size = None
         self._lsb_pos = None
+        self._access = None
 
     # 18.5.3.2
     # TODO Fix signature
-    def configure(self, parent, size, lsb_pos):
+    def configure(self, parent, size, lsb_pos, access):
         # TODO Add validation of arguments
         self._parent = parent
         self._size = size
         self._lsb_pos = lsb_pos
+        self._access = access
 
     # 18.5.4.1
     def get_parent(self):
@@ -48,3 +50,8 @@ class uvm_reg_field(uvm_object):
     def get_n_bits(self):
         # TODO Check that 'configure' was called
         return self._size
+
+    # 18.5.4.5
+    def get_access(self):
+        # TODO Check that 'configure' was called
+        return self._access

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -21,7 +21,20 @@ class uvm_reg_block(uvm_object):
 
 # 18.2.1 Class declaration
 class uvm_reg_map(uvm_object):
-    pass
+
+    # 18.2.3.1
+    # TODO Fix signature
+    def __init__(self):
+        self._parent = None
+
+    # 18.2.3.2
+    # TODO Fix signature
+    def configure(self, parent):
+        self._parent = parent
+
+    # 18.2.4.2
+    def get_parent(self):
+        return self._parent
 
 
 # 18.4.1 Class declaration

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -27,16 +27,19 @@ class uvm_reg_field(uvm_object):
         self._lsb_pos = None
         self._access = None
         self._is_volatile = None
+        self._reset = None
 
     # 18.5.3.2
     # TODO Fix signature
-    def configure(self, parent, size, lsb_pos, access, is_volatile):
+    def configure(self, parent, size, lsb_pos, access, is_volatile, reset):
         # TODO Add validation of arguments
+        # TODO Support binary and hex values for 'reset'
         self._parent = parent
         self._size = size
         self._lsb_pos = lsb_pos
         self._access = access
         self._is_volatile = is_volatile
+        self._reset = reset
 
     # 18.5.4.1
     def get_parent(self):
@@ -62,3 +65,8 @@ class uvm_reg_field(uvm_object):
     def is_volatile(self):
         # TODO Check that 'configure' was called
         return self._is_volatile
+
+    # 18.5.5.6
+    def get_reset(self):
+        # TODO Check that 'configure' was called
+        return self._reset

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -1,0 +1,6 @@
+from pyuvm import uvm_object
+
+
+# 18.1.1 Class declaration
+class uvm_reg_block(uvm_object):
+    pass

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -14,3 +14,8 @@ class uvm_reg_map(uvm_object):
 # 18.4.1 Class declaration
 class uvm_reg(uvm_object):
     pass
+
+
+# 18.5.1 Class declaration
+class uvm_reg_field(uvm_object):
+    pass

--- a/pyuvm/s18_register_model.py
+++ b/pyuvm/s18_register_model.py
@@ -26,15 +26,17 @@ class uvm_reg_field(uvm_object):
         self._size = None
         self._lsb_pos = None
         self._access = None
+        self._is_volatile = None
 
     # 18.5.3.2
     # TODO Fix signature
-    def configure(self, parent, size, lsb_pos, access):
+    def configure(self, parent, size, lsb_pos, access, is_volatile):
         # TODO Add validation of arguments
         self._parent = parent
         self._size = size
         self._lsb_pos = lsb_pos
         self._access = access
+        self._is_volatile = is_volatile
 
     # 18.5.4.1
     def get_parent(self):
@@ -55,3 +57,8 @@ class uvm_reg_field(uvm_object):
     def get_access(self):
         # TODO Check that 'configure' was called
         return self._access
+
+    # 18.5.4.10
+    def is_volatile(self):
+        # TODO Check that 'configure' was called
+        return self._is_volatile

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -7,3 +7,7 @@ def test_reg_block():
 
 def test_reg_map():
     assert uvm_reg_map()
+
+
+def test_reg():
+    assert uvm_reg()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -1,6 +1,11 @@
 from pyuvm import *
 
 
+def test_reg_block_get_name():
+    block = uvm_reg_block('some_block')
+    assert block.get_name() == 'some_block'
+
+
 def test_reg_block_with_single_reg():
     block = uvm_reg_block()
     reg = uvm_reg()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -22,6 +22,13 @@ def test_reg_block_with_multiple_regs():
     assert block.get_registers() == [reg0, reg1]
 
 
+def test_reg_map_get_name():
+    map_with_explicit_name = uvm_reg_map('some_map')
+    assert map_with_explicit_name.get_name() == 'some_map'
+    map_with_implicit_name = uvm_reg_map()
+    assert map_with_implicit_name.get_name() == 'uvm_reg_map'
+
+
 def test_reg_map_configure():
     reg_map = uvm_reg_map()
     parent = uvm_reg_block()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -9,6 +9,11 @@ def test_reg_map():
     assert uvm_reg_map()
 
 
+def test_reg_get_name():
+    reg = uvm_reg('some_reg')
+    assert reg.get_name() == 'some_reg'
+
+
 def test_reg_configure():
     reg = uvm_reg()
     parent = uvm_reg_block()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -1,0 +1,5 @@
+from pyuvm import *
+
+
+def test_reg_block():
+    assert uvm_reg_block()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -1,8 +1,20 @@
 from pyuvm import *
 
 
-def test_reg_block():
-    assert uvm_reg_block()
+def test_reg_block_with_single_reg():
+    block = uvm_reg_block()
+    reg = uvm_reg()
+    reg.configure(block)
+    assert block.get_registers() == [reg]
+
+
+def test_reg_block_with_multiple_regs():
+    block = uvm_reg_block()
+    reg0 = uvm_reg()
+    reg0.configure(block)
+    reg1 = uvm_reg()
+    reg1.configure(block)
+    assert block.get_registers() == [reg0, reg1]
 
 
 def test_reg_map():

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -16,7 +16,8 @@ def test_reg():
 def test_reg_field_configure():
     field = uvm_reg_field()
     parent = uvm_reg()
-    field.configure(parent, 8, 16)
+    field.configure(parent, 8, 16, 'RW')
     assert field.get_parent() == parent
     assert field.get_n_bits() == 8
     assert field.get_lsb_pos() == 16
+    assert field.get_access() == 'RW'

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -9,8 +9,11 @@ def test_reg_map():
     assert uvm_reg_map()
 
 
-def test_reg():
-    assert uvm_reg()
+def test_reg_configure():
+    reg = uvm_reg()
+    parent = uvm_reg_block()
+    reg.configure(parent)
+    assert reg.get_parent() == parent
 
 
 def test_reg_field_get_name():

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -175,7 +175,8 @@ def test_simple_reg_model():
 
     assert LCR.get_fields()[0].get_lsb_pos() == 0
     for prev_field, field in pairwise(LCR.get_fields()):
-        assert field.get_lsb_pos() == prev_field.get_lsb_pos() + prev_field.get_n_bits()
+        assert (field.get_lsb_pos()
+               == prev_field.get_lsb_pos() + prev_field.get_n_bits())
 
     for field in LCR.get_fields():
         assert field.get_access() == 'RW'
@@ -196,4 +197,5 @@ def test_simple_reg_model():
 
     assert LSR.get_fields()[0].get_lsb_pos() == 0
     for prev_field, field in pairwise(LSR.get_fields()):
-        assert field.get_lsb_pos() == prev_field.get_lsb_pos() + prev_field.get_n_bits()
+        assert (field.get_lsb_pos()
+                == prev_field.get_lsb_pos() + prev_field.get_n_bits())

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -1,3 +1,4 @@
+import itertools
 from pyuvm import *
 
 
@@ -168,9 +169,14 @@ def test_simple_reg_model():
             continue
         assert field.get_n_bits() == 1
 
+    def pairwise(iterable):
+        "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+        a, b = itertools.tee(iterable)
+        next(b, None)
+        return zip(a, b)
+
     assert LCR.get_fields()[0].get_lsb_pos() == 0
-    for i, field in enumerate(LCR.get_fields()[1:]):
-        prev_field = LCR.get_fields()[i]  # i starts from 1
+    for prev_field, field in pairwise(LCR.get_fields()):
         assert field.get_lsb_pos() == prev_field.get_lsb_pos() + prev_field.get_n_bits()
 
     for field in LCR.get_fields():
@@ -191,6 +197,5 @@ def test_simple_reg_model():
         assert field.get_reset() == 0
 
     assert LSR.get_fields()[0].get_lsb_pos() == 0
-    for i, field in enumerate(LSR.get_fields()[1:]):
-        prev_field = LSR.get_fields()[i]  # i starts from 1
+    for prev_field, field in pairwise(LSR.get_fields()):
         assert field.get_lsb_pos() == prev_field.get_lsb_pos() + prev_field.get_n_bits()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -16,5 +16,6 @@ def test_reg():
 def test_reg_field_configure():
     field = uvm_reg_field()
     parent = uvm_reg()
-    field.configure(parent)
+    field.configure(parent, 8)
     assert field.get_parent() == parent
+    assert field.get_n_bits() == 8

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -37,6 +37,22 @@ def test_reg_map_configure():
     assert reg_map.get_base_addr() == 1024
 
 
+def test_reg_map_with_single_reg():
+    reg_map = uvm_reg_map()
+    reg = uvm_reg()
+    reg_map.add_reg(reg)
+    assert reg_map.get_registers() == [reg]
+
+
+def test_reg_map_with_multiple_regs():
+    reg_map = uvm_reg_map()
+    reg0 = uvm_reg()
+    reg_map.add_reg(reg0)
+    reg1 = uvm_reg()
+    reg_map.add_reg(reg1)
+    assert reg_map.get_registers() == [reg0, reg1]
+
+
 def test_reg_get_name():
     reg = uvm_reg('some_reg')
     assert reg.get_name() == 'some_reg'

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -11,3 +11,7 @@ def test_reg_map():
 
 def test_reg():
     assert uvm_reg()
+
+
+def test_reg_field():
+    assert uvm_reg_field()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -3,3 +3,7 @@ from pyuvm import *
 
 def test_reg_block():
     assert uvm_reg_block()
+
+
+def test_reg_map():
+    assert uvm_reg_map()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -164,9 +164,7 @@ def test_simple_reg_model():
     assert LCR.EPS.get_name() == 'EPS'
 
     assert LCR.WLS.get_n_bits() == 2
-    for field in LCR.get_fields():
-        if field == LCR.WLS:
-            continue
+    for field in [field for field in LCR.get_fields() if field != LCR.WLS]:
         assert field.get_n_bits() == 1
 
     def pairwise(iterable):

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -16,6 +16,7 @@ def test_reg():
 def test_reg_field_configure():
     field = uvm_reg_field()
     parent = uvm_reg()
-    field.configure(parent, 8)
+    field.configure(parent, 8, 16)
     assert field.get_parent() == parent
     assert field.get_n_bits() == 8
+    assert field.get_lsb_pos() == 16

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -40,17 +40,19 @@ def test_reg_map_configure():
 def test_reg_map_with_single_reg():
     reg_map = uvm_reg_map()
     reg = uvm_reg()
-    reg_map.add_reg(reg)
+    reg_map.add_reg(reg, 0)
     assert reg_map.get_registers() == [reg]
 
 
 def test_reg_map_with_multiple_regs():
     reg_map = uvm_reg_map()
     reg0 = uvm_reg()
-    reg_map.add_reg(reg0)
+    reg_map.add_reg(reg0, 128)
     reg1 = uvm_reg()
-    reg_map.add_reg(reg1)
+    reg_map.add_reg(reg1, 256)
     assert reg_map.get_registers() == [reg0, reg1]
+    assert reg_map.get_reg_by_offset(128) == reg0
+    assert reg_map.get_reg_by_offset(256) == reg1
 
 
 def test_reg_get_name():

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -16,17 +16,18 @@ def test_reg():
 def test_reg_field_configure():
     field = uvm_reg_field()
     parent = uvm_reg()
-    field.configure(parent, 8, 16, 'RW', True)
+    field.configure(parent, 8, 16, 'RW', True, 15)
     assert field.get_parent() == parent
     assert field.get_n_bits() == 8
     assert field.get_lsb_pos() == 16
     assert field.get_access() == 'RW'
     assert field.is_volatile()
+    assert field.get_reset() == 15
 
 
 def test_reg_field_is_volatile():
     field = uvm_reg_field()
-    field.configure(uvm_reg(), 8, 16, 'RW', True)
+    field.configure(uvm_reg(), 8, 16, 'RW', True, 15)
     assert field.is_volatile()
-    field.configure(uvm_reg(), 8, 16, 'RW', False)
+    field.configure(uvm_reg(), 8, 16, 'RW', False, 15)
     assert not field.is_volatile()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -16,8 +16,17 @@ def test_reg():
 def test_reg_field_configure():
     field = uvm_reg_field()
     parent = uvm_reg()
-    field.configure(parent, 8, 16, 'RW')
+    field.configure(parent, 8, 16, 'RW', True)
     assert field.get_parent() == parent
     assert field.get_n_bits() == 8
     assert field.get_lsb_pos() == 16
     assert field.get_access() == 'RW'
+    assert field.is_volatile()
+
+
+def test_reg_field_is_volatile():
+    field = uvm_reg_field()
+    field.configure(uvm_reg(), 8, 16, 'RW', True)
+    assert field.is_volatile()
+    field.configure(uvm_reg(), 8, 16, 'RW', False)
+    assert not field.is_volatile()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -21,6 +21,22 @@ def test_reg_configure():
     assert reg.get_parent() == parent
 
 
+def test_reg_with_single_field():
+    reg = uvm_reg()
+    field = uvm_reg_field()
+    field.configure(reg, 8, 0, 'RW', 0, 0)
+    assert reg.get_fields() == [field]
+
+
+def test_reg_with_multiple_fields():
+    reg = uvm_reg()
+    field0 = uvm_reg_field()
+    field0.configure(reg, 8, 0, 'RW', 0, 0)
+    field1 = uvm_reg_field()
+    field1.configure(reg, 8, 0, 'RW', 0, 0)
+    assert reg.get_fields() == [field0, field1]
+
+
 def test_reg_field_get_name():
     field_with_explicit_name = uvm_reg_field('some_field')
     assert field_with_explicit_name.get_name() == 'some_field'

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -173,10 +173,15 @@ def test_simple_reg_model():
         next(b, None)
         return zip(a, b)
 
+    def get_msb_pos(field):
+        return field.get_lsb_pos() + field.get_n_bits() - 1
+
+    def are_adjacent(prev_field, field):
+        return field.get_lsb_pos() == get_msb_pos(prev_field) + 1
+
     assert LCR.get_fields()[0].get_lsb_pos() == 0
     for prev_field, field in pairwise(LCR.get_fields()):
-        assert (field.get_lsb_pos()
-               == prev_field.get_lsb_pos() + prev_field.get_n_bits())
+        assert are_adjacent(prev_field, field)
 
     for field in LCR.get_fields():
         assert field.get_access() == 'RW'
@@ -197,5 +202,4 @@ def test_simple_reg_model():
 
     assert LSR.get_fields()[0].get_lsb_pos() == 0
     for prev_field, field in pairwise(LSR.get_fields()):
-        assert (field.get_lsb_pos()
-                == prev_field.get_lsb_pos() + prev_field.get_n_bits())
+        assert are_adjacent(prev_field, field)

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -13,6 +13,13 @@ def test_reg():
     assert uvm_reg()
 
 
+def test_reg_field_get_name():
+    field_with_explicit_name = uvm_reg_field('some_field')
+    assert field_with_explicit_name.get_name() == 'some_field'
+    field_with_implicit_name = uvm_reg_field()
+    assert field_with_implicit_name.get_name() == 'uvm_reg_field'
+
+
 def test_reg_field_configure():
     field = uvm_reg_field()
     parent = uvm_reg()

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -22,8 +22,11 @@ def test_reg_block_with_multiple_regs():
     assert block.get_registers() == [reg0, reg1]
 
 
-def test_reg_map():
-    assert uvm_reg_map()
+def test_reg_map_configure():
+    reg_map = uvm_reg_map()
+    parent = uvm_reg_block()
+    reg_map.configure(parent)
+    assert reg_map.get_parent() == parent
 
 
 def test_reg_get_name():

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -25,8 +25,9 @@ def test_reg_block_with_multiple_regs():
 def test_reg_map_configure():
     reg_map = uvm_reg_map()
     parent = uvm_reg_block()
-    reg_map.configure(parent)
+    reg_map.configure(parent, 1024)
     assert reg_map.get_parent() == parent
+    assert reg_map.get_base_addr() == 1024
 
 
 def test_reg_get_name():

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -168,7 +168,7 @@ def test_simple_reg_model():
         assert field.get_n_bits() == 1
 
     def pairwise(iterable):
-        "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+        """s -> (s0,s1), (s1,s2), (s2, s3), ..."""
         a, b = itertools.tee(iterable)
         next(b, None)
         return zip(a, b)

--- a/tests/pytests/test_18_register_model.py
+++ b/tests/pytests/test_18_register_model.py
@@ -13,5 +13,8 @@ def test_reg():
     assert uvm_reg()
 
 
-def test_reg_field():
-    assert uvm_reg_field()
+def test_reg_field_configure():
+    field = uvm_reg_field()
+    parent = uvm_reg()
+    field.configure(parent)
+    assert field.get_parent() == parent


### PR DESCRIPTION
Add support for foundational UVM register layer classes: `uvm_reg_block`, `uvm_reg_map`, `uvm_reg` and `uvm_reg_field`.