### PR TITLE
Add EditorConfig settings

### DIFF
--- a/tests/pytests/.editorconfig
+++ b/tests/pytests/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
Can be used with any editor (assuming the plugin is available) to
configure code style. Can also be used to lint.

Indent style and size were extrapolated from existing code.
PEP8 mandates final newlines.
Trailing whitespace is just a nuisance.
Line length is the default that PyCharm suggested.