### PR TITLE
Now log to sys.stdout instead of sys.stderr

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ insert_final_newline = true
 max_line_length = 120
 tab_width = 4
 trim_trailing_whitespace = true
+
+[{Makefile,**.mk}]
+# Use tabs for indentation (Makefiles require tabs)
+indent_style = tab

--- a/cleanall.mk
+++ b/cleanall.mk
@@ -1,0 +1,8 @@
+cleanall: clean
+	@rm -rf __pycache__
+	@rm -rf results.xml
+	@rm -rf log.txt
+	@rm -rf sim_build
+	@rm -rf modelsim.ini
+	@rm -rf transcript
+

--- a/examples/TinyALU/Makefile
+++ b/examples/TinyALU/Makefile
@@ -4,10 +4,8 @@ SIM ?= icarus
 VERILOG_SOURCES =$(CWD)/hdl/verilog/tinyalu.sv
 MODULE := tinyalu_cocotb
 TOPLEVEL := tinyalu
+TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm results.xml
+include ../../cleanall.mk

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -8,9 +8,9 @@
 
 from pyuvm.s05_base_classes import uvm_object
 import logging
+import sys
 from cocotb.log import SimColourLogFormatter, SimTimeContextFilter
-from logging import DEBUG, CRITICAL, ERROR, \
-    WARNING, INFO, NOTSET, NullHandler  # noqa: F401
+from logging import DEBUG, CRITICAL, ERROR, WARNING, INFO, NOTSET, NullHandler   # noqa: F401, E501
 
 
 class PyuvmFormatter(SimColourLogFormatter):
@@ -38,7 +38,7 @@ class uvm_report_object(uvm_object):
         self.logger.setLevel(level=logging.INFO)  # Default is to print INFO
         # We are not sending log messages up the hierarchy
         self.logger.propagate = False
-        self._streaming_handler = logging.StreamHandler()
+        self._streaming_handler = logging.StreamHandler(sys.stdout)
         self._streaming_handler.addFilter(SimTimeContextFilter())
         # Don't let the handler interfere with logger level
         self._streaming_handler.setLevel(logging.NOTSET)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyuvm",
-    version="2.1",
+    version="2.1a",
     author="Ray Salemi",
     author_email="ray@raysalemi.com",
     description="A Python implementation of the UVM using cocotb",

--- a/tests/cocotb_tests/config_db/Makefile
+++ b/tests/cocotb_tests/config_db/Makefile
@@ -8,7 +8,4 @@ TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm -rf results.xml
+include ../../../cleanall.mk

--- a/tests/cocotb_tests/queue/Makefile
+++ b/tests/cocotb_tests/queue/Makefile
@@ -8,7 +8,4 @@ TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm -rf results.xml
+include ../../../cleanall.mk

--- a/tests/cocotb_tests/run_phase/Makefile
+++ b/tests/cocotb_tests/run_phase/Makefile
@@ -8,7 +8,4 @@ TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm -rf results.xml
+include ../../../cleanall.mk

--- a/tests/cocotb_tests/t08_factories/Makefile
+++ b/tests/cocotb_tests/t08_factories/Makefile
@@ -8,7 +8,4 @@ TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm -rf results.xml
+include ../../../cleanall.mk

--- a/tests/cocotb_tests/t09_phasing/Makefile
+++ b/tests/cocotb_tests/t09_phasing/Makefile
@@ -8,7 +8,4 @@ TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm -rf results.xml
+include ../../../cleanall.mk

--- a/tests/cocotb_tests/t12_tlm/Makefile
+++ b/tests/cocotb_tests/t12_tlm/Makefile
@@ -8,7 +8,4 @@ TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm -rf results.xml
+include ../../../cleanall.mk

--- a/tests/cocotb_tests/t13_components/Makefile
+++ b/tests/cocotb_tests/t13_components/Makefile
@@ -8,7 +8,4 @@ TOPLEVEL_LANG=verilog
 COCOTB_HDL_TIMEUNIT=1us
 COCOTB_HDL_TIMEPRECISION=1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-cleanall: clean
-	@rm -rf __pycache__
-	@rm -rf results.xml
+include ../../../cleanall.mk


### PR DESCRIPTION
Logging to `sys.stdout` creates consistent behavior across all simulators.