### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/examples/TinyALU/.gitignore
+++ b/examples/TinyALU/.gitignore
@@ -2,3 +2,5 @@ sim_build
 __pycache__
 results.xml
 
+# VCS outputs
+ucli.key

--- a/examples/TinyALU/tinyalu_cocotb.py
+++ b/examples/TinyALU/tinyalu_cocotb.py
@@ -1,8 +1,3 @@
-from cocotb.triggers import FallingEdge
-import cocotb
-from cocotb.queue import QueueEmpty
-from tinyalu_uvm import *
-
 """
 import debugpy
 
@@ -18,6 +13,15 @@ debugpy.wait_for_client()
 # Break into debugger for user control
 breakpoint()  # or debugpy.breakpoint() on 3.6 and below
 """
+
+
+import cocotb
+from cocotb.queue import QueueEmpty
+from cocotb.triggers import FallingEdge
+
+from pyuvm import *
+
+from tinyalu_uvm import AluTest
 
 
 class CocotbProxy:
@@ -66,7 +70,7 @@ class CocotbProxy:
                     pass
             elif self.dut.start == 1:
                 if self.dut.done.value == 1:
-                    self.dut.start = 0
+                    self.dut.start.value = 0
 
     async def cmd_mon_bfm(self):
         prev_start = 0

--- a/examples/TinyALU/tinyalu_uvm.py
+++ b/examples/TinyALU/tinyalu_uvm.py
@@ -1,7 +1,10 @@
-from pyuvm import *
-from cocotb.triggers import ClockCycles
 import enum
+import logging
 import random
+
+from cocotb.triggers import ClockCycles
+
+from pyuvm import *
 
 
 @enum.unique
@@ -40,8 +43,8 @@ class AluSeqItem(uvm_sequence_item):
         return same
 
     def __str__(self):
-        return f"{self.get_name()} : A: 0x{self.A:02x} "
-        f"OP: {self.op.name} ({self.op.value}) B: 0x{self.B:02x}"
+        return (f"{self.get_name()} : A: 0x{self.A:02x} "
+                f"OP: {self.op.name} ({self.op.value}) B: 0x{self.B:02x}")
 
     def randomize(self):
         self.A = random.randint(0, 255)


### PR DESCRIPTION
Was seeing this:

pyuvm/examples/TinyALU/tinyalu_cocotb.py:69:
DeprecationWarning: Setting values on handles
using the ``dut.handle = value`` syntax is deprecated.
Instead use the ``handle.value = value`` syntax

Also get rid of discouraged glob import style.
According to PEP8, "Wildcard imports ... should be avoided".