### PR TITLE
Default to parent's logging level, if any

### DIFF
--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -29,13 +29,17 @@ class PyuvmFormatter(SimColourLogFormatter):
 class uvm_report_object(uvm_object):
     """ The basis of all classes that can report """
 
-    def __init__(self, name):
+    def __init__(self, name, parent=None):
         super().__init__(name)
         uvm_root_logger = logging.getLogger('uvm')
         # Every object gets its own logger
         logger_name = self.get_full_name() + str(id(self))
         self.logger = uvm_root_logger.getChild(logger_name)
-        self.logger.setLevel(level=logging.INFO)  # Default is to print INFO
+        # Default to parent's logging level, else INFO
+        if parent is not None:
+            self.logger.setLevel(level=parent.logger.level)
+        else:
+            self.logger.setLevel(level=logging.INFO)
         # We are not sending log messages up the hierarchy
         self.logger.propagate = False
         self._streaming_handler = logging.StreamHandler(sys.stdout)

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -44,7 +44,7 @@ is really going on.  We've opted for the latter.
         if parent is not None:
             parent.add_child(name, self)
         self.print_enabled = True  # 13.1.2.2
-        super().__init__(name)
+        super().__init__(name, parent)
 
         # Cache the hierarchy for easy access
         if name != 'uvm_root':


### PR DESCRIPTION
This allows e.g. enabling debug level messages during build_phase of
child components.

Use case, approx:
```
class MyTest(uvm_test):
    def build_phase(self):
        self.set_logging_level_hier(logging.DEBUG)
        self.logger.debug('in build phase')
        self.env = MyEnv.create('env', self)

class MyEnv(uvm_env):
    def build_phase(self):
        self.logger.debug('I want this to be seen')
```