### PR TITLE
make analysis ports work again after class restructure

### DIFF
--- a/pyuvm/s12_uvm_tlm_interfaces.py
+++ b/pyuvm/s12_uvm_tlm_interfaces.py
@@ -428,6 +428,10 @@ class uvm_analysis_port(uvm_port_base):
                     f"No write() method in {export}. Did you connect it?")
             export.write(datum)
 
+    def connect(self, export):
+        self.check_export(export)
+        self.subscribers.append(export)
+
 
 class uvm_nonblocking_put_export(uvm_export_base):
     ...


### PR DESCRIPTION
My analysis components stopped working after the recent update.

`0ccf4ae` restructured port and export base classes, and removed connect()
from uvm_analysis_port. That needs to work differently to maintain the
subscribers list.

This is a quick fix but I think more needs to be done here:
`uvm_port_base` creates attribute `export` which only applies to the single-producer, single-consumer style ports. It looks like the class structure should be refactored some more so that analysis ports/exports don't inherit from a class that includes these single-consumer-specific features.
I am less sure about what should happen with `provided_to` and `connected_to`; at the moment nothing seems to use these.

Also I should probably figure out how pyuvm's regression tests work, and update them if I find future issues...