### PR TITLE
phasing: replace fork() with start_soon()

### DIFF
--- a/pyuvm/s09_phasing.py
+++ b/pyuvm/s09_phasing.py
@@ -91,7 +91,7 @@ class uvm_threaded_execute_phase(uvm_phase):
         except AttributeError:
             raise error_classes.UVMBadPhase(
                 f"{comp.get_name()} is missing {method_name} function")
-        cocotb.fork(method())
+        cocotb.start_soon(method())
 
 
 # 9.8 Predefined Phases

--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import logging
 import fnmatch
 import cocotb.queue
-from cocotb.triggers import Event
+from cocotb.triggers import Event, NullTrigger
 from cocotb.queue import QueueEmpty
 
 FIFO_DEBUG = 5
@@ -230,6 +230,8 @@ class ObjectionHandler(metaclass=Singleton):
             self._objection_event.set()
 
     async def run_phase_complete(self):
+        # Allow the run_phase coros to get scheduled and raise objections:
+        await NullTrigger()
         if self.objection_raised:
             await self._objection_event.wait()
         else:


### PR DESCRIPTION
fork() is deprecated, also it causes a simulator crash if a forked
coroutine raises an exception before await-ing.
See https://github.com/cocotb/cocotb/issues/2804