### PR TITLE
Objection fixes

### DIFF
--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -409,6 +409,7 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
 
         factory = uvm_factory()
         self.clear_children()
+        utility_classes.ObjectionHandler().clear()
         self.uvm_test_top = factory.create_component_by_name(
             test_name, "", "uvm_test_top", self)
         for self.running_phase in uvm_common_phases:

--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -217,7 +217,8 @@ class ObjectionHandler(metaclass=Singleton):
 
     def clear(self):
         if len(self.__objections) != 0:
-            logging.warning("Clearing objections raised by %s", ', '.join(self.__objections.values()))
+            logging.warning("Clearing objections raised by %s",
+                            ', '.join(self.__objections.values()))
             self.__objections = {}
         self.objection_raised = False
 

--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -219,6 +219,8 @@ class ObjectionHandler(metaclass=Singleton):
         if len(self.__objections) != 0:
             logging.warning("Clearing objections raised by %s", ', '.join(self.__objections.values()))
             self.__objections = {}
+        self.objection_raised = False
+
     def raise_objection(self, raiser):
         self.__objections[raiser] = raiser.get_full_name()
         self.objection_raised = True

--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -215,6 +215,10 @@ class ObjectionHandler(metaclass=Singleton):
             ss += f"{self.__objections[cc]}\n"
         return ss
 
+    def clear(self):
+        if len(self.__objections) != 0:
+            logging.warning("Clearing objections raised by %s", ', '.join(self.__objections.values()))
+            self.__objections = {}
     def raise_objection(self, raiser):
         self.__objections[raiser] = raiser.get_full_name()
         self.objection_raised = True

--- a/tests/cocotb_tests/run_phase/test.py
+++ b/tests/cocotb_tests/run_phase/test.py
@@ -17,7 +17,7 @@ class my_error(uvm_test):
 
 @cocotb.test()
 async def run_test(dut):
-    """Test the various nowait flavors"""
+    """Test basic run_phase operation with objection"""
     await uvm_root().run_test("my_test")
     assert True
 
@@ -26,3 +26,9 @@ async def run_test(dut):
 async def error(dut):
     """Test that raising exceptions creates cocotb errors"""
     await uvm_root().run_test("my_error")
+
+@cocotb.test()
+async def run_after_error(dut):
+    """Test run_phase operation after previous test raised exception"""
+    await uvm_root().run_test("my_test")
+    assert True

--- a/tests/cocotb_tests/run_phase/test.py
+++ b/tests/cocotb_tests/run_phase/test.py
@@ -14,6 +14,9 @@ class my_error(uvm_test):
         self.raise_objection()
         raise UVMError("This is an error")
 
+class my_no_objection(uvm_test):
+    async def run_phase(self):
+        print("Running without using objections")
 
 @cocotb.test()
 async def run_test(dut):
@@ -32,3 +35,9 @@ async def run_after_error(dut):
     """Test run_phase operation after previous test raised exception"""
     await uvm_root().run_test("my_test")
     assert True
+
+@cocotb.test()
+async def run_no_objection(dut):
+    """Test using no objections, after a test that did use them"""
+    # Expect a warning message. Can that be tested for?
+    await uvm_root().run_test("my_no_objection")


### PR DESCRIPTION
Test cases and fixes for a couple of objection issues.
The main one being that a crashing test would leave raised objections, causing a following test to never end.

I added a "test" to see if a warning is printed, but it doesn't actually test if the warning gets printed - I don't know how to do that. It needs some kind of mocking of the logger, I guess.