### PR TITLE
More helpful error when port is not connected

### DIFF
--- a/pyuvm/s14_15_python_sequences.py
+++ b/pyuvm/s14_15_python_sequences.py
@@ -237,7 +237,11 @@ class uvm_seq_item_port(uvm_port_base):
     async def get_next_item(self):
         """get the next sequence item from the request queue
         """
-        return await self.export.get_next_item()
+        try:
+            return await self.export.get_next_item()
+        except AttributeError:
+            assert self.export is not None, "export is not connected"
+            raise
 
     def item_done(self, rsp=None):
         """Notify finish_item that the item is complete"""


### PR DESCRIPTION
A minor modification for your consideration:

Print a more helpful error using an assertion if a driver tries to
get_next_item before it has been connected to an export.
Do this in a try/except block to avoid the cost of checking every time.

Changes this:
```
AttributeError: 'NoneType' object has no attribute 'get_next_item'
```
into this:
```
AssertionError: export is not connected
```