### PR TITLE
2.6.1 release

### DIFF
--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -220,6 +220,7 @@ class Scoreboard(uvm_component):
                     passed = False
         assert passed
 
+
 class Monitor(uvm_component):
     def __init__(self, name, parent, method_name):
         super().__init__(name, parent)

--- a/pyuvm/s05_base_classes.py
+++ b/pyuvm/s05_base_classes.py
@@ -174,13 +174,9 @@ class uvm_object(utility_classes.uvm_void):
     # 5.3.8.2
     def do_copy(self, rhs):
         """
-        Must be overridden to implement UVM copy().
+        Copies name. Override to copy additional data members
         """
-        raise error_classes.UVMError("Implement do_copy to copy "
-                                     "fields from rhs into self. This is "
-                                     "not really needed in Python in which "
-                                     "copy.copy() and copy.deepcopy() return a"
-                                     " new object with copied data.")
+        self.set_name(rhs.get_name())
 
     # 5.3.9.1
     def compare(self, rhs):

--- a/pyuvm/s05_base_classes.py
+++ b/pyuvm/s05_base_classes.py
@@ -114,7 +114,9 @@ class uvm_object(utility_classes.uvm_void):
         uses copy.deepcopy so the user does not need to override
         do_copy()
         """
-        raise error_classes.UVMNotImplemented("Use copy.deepcopy()")
+        new = self.__class__(self.get_name())
+        new.copy(self)
+        return new
 
     # 5.3.6.1
     def print(self):

--- a/pyuvm/s09_phasing.py
+++ b/pyuvm/s09_phasing.py
@@ -44,6 +44,9 @@ class uvm_phase(uvm_object):
                 f"{comp.get_name()} is missing {method_name} function")
         method()
 
+    def __str__(self):
+        return self.__name__[4:]
+
 
 class uvm_topdown_phase(uvm_phase):
     """

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -412,6 +412,8 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
         self.uvm_test_top = factory.create_component_by_name(
             test_name, "", "uvm_test_top", self)
         for self.running_phase in uvm_common_phases:
+            self.logger.log(utility_classes.PYUVM_DEBUG,
+                            str(self.running_phase))
             self.running_phase.traverse(self.uvm_test_top)
             if self.running_phase == uvm_run_phase:
                 await utility_classes.ObjectionHandler().run_phase_complete()  # noqa: E501

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -374,7 +374,6 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
 
     @classmethod
     def clear_singletons(cls, keep_set={}):
-        cls.singleton = None
         keepers = {uvm_factory, utility_classes.FactoryData}.union(keep_set)
         utility_classes.Singleton.clear_singletons(keep=keepers)
 

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -1,7 +1,7 @@
 from pyuvm.s06_reporting_classes import uvm_report_object
 from pyuvm.s08_factory_classes import uvm_factory
 from pyuvm.s09_phasing import uvm_common_phases, uvm_run_phase, uvm_build_phase
-from pyuvm import error_classes
+from pyuvm import error_classes, INFO
 from pyuvm import utility_classes
 import logging
 import fnmatch
@@ -404,6 +404,7 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
         """
         factory = uvm_factory()
         if not keep_singletons:
+            uvm_report_object.set_default_logging_level(INFO)
             self.clear_singletons(keep_set)
             factory.clear_overrides()
         self.clear_children()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyuvm",
-    version="2.6.0",
+    version="2.6.1",
     author="Ray Salemi",
     author_email="ray@raysalemi.com",
     description="A Python implementation of the UVM using cocotb",

--- a/tests/cocotb_tests/t08_factories/factory_tests.py
+++ b/tests/cocotb_tests/t08_factories/factory_tests.py
@@ -35,6 +35,7 @@ class s08_factory_classes_TestCase():
 
     def setUp(self):
         self.fd = utility_classes.FactoryData()
+        uvm_root().clear_children()
         self.top = uvm_component("top", None)
         self.mid = uvm_component("mid", self.top)
         self.sib = uvm_component("sib", self.top)

--- a/tests/pytests/test_05_base_classes.py
+++ b/tests/pytests/test_05_base_classes.py
@@ -17,6 +17,9 @@ class my_object(uvm_object):
     def __str__(self):
         return "Hello"
 
+    def do_copy(self, other):
+        self.val = other.val
+
 
 def test_basic_creation():
     """
@@ -131,11 +134,9 @@ def test_copying():
     mo = my_object("mo")
     rhs = my_object("rhs")
     # 5.3.8.1
-    with pytest.raises(error_classes.UVMError):
-        mo.copy(rhs)
+    mo.copy(rhs)
     # 5.3.8.2
-    with pytest.raises(error_classes.UVMError):
-        mo.do_copy(rhs)
+    assert mo.val == rhs.val
 
 
 def test_comparing():
@@ -287,3 +288,10 @@ def test_transaction_recording():
         tr.get_begin_time()
     with pytest.raises(error_classes.UVMNotImplemented):
         tr.get_end_time()
+
+
+def test_clone():
+    orig = my_object("orig")
+    clone = orig.clone()
+    assert id(orig) != id(clone)
+    assert orig.val == clone.val


### PR DESCRIPTION
* fixed do_copy() and clone()
* run_test sets default log level to INFO
* Now you can turn on phase logging
* Fixed bug in uvm_root() when clearing singletons
* Fixed example to demonstrate errors