### PR TITLE
Nested drop_objection() in same object existed early

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,17 +31,14 @@ jobs:
 
   tests:
 
-    name: Python ${{matrix.python-version}} | ${{matrix.sim}} 
+    name: Python ${{matrix.python-version}}
     runs-on: ubuntu-20.04
-    env:
-      SIM: ${{matrix.sim}}
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - sim: icarus
-            python-version: 3.8
+          - python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2
@@ -55,9 +52,12 @@ jobs:
         pip install tox tox-gh-actions
 
     - name: Install Icarus Verilog
-      if: matrix.sim == 'icarus'
       run: |
         sudo apt install -y --no-install-recommends iverilog
+
+    - name: Install GHDL 
+      run: |
+        sudo apt install -y --no-install-recommends ghdl-mcode ghdl
 
     - name: Test
       run: |

--- a/examples/TinyALU/Makefile
+++ b/examples/TinyALU/Makefile
@@ -1,11 +1,20 @@
 CWD=$(shell pwd)
 COCOTB_REDUCED_LOG_FMT = True
 SIM ?= icarus
-VERILOG_SOURCES =$(CWD)/hdl/verilog/tinyalu.sv
+TOPLEVEL_LANG ?= verilog
+ifeq ($(TOPLEVEL_LANG),verilog)
+	VERILOG_SOURCES =$(CWD)/hdl/verilog/tinyalu.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+	VHDL_SOURCES=$(CWD)/hdl/vhdl/single_cycle_add_and_xor.vhd \
+				$(CWD)/hdl/vhdl/three_cycle_mult.vhd \
+				$(CWD)/hdl/vhdl/tinyalu.vhd
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
 MODULE := testbench
-TOPLEVEL=tinyalu
-TOPLEVEL_LANG=verilog
-COCOTB_HDL_TIMEUNIT=1us
-COCOTB_HDL_TIMEPRECISION=1us
+TOPLEVEL = tinyalu
+GHDL_ARGS := --ieee=synopsys
+COCOTB_HDL_TIMEUNIT = 1us
+COCOTB_HDL_TIMEPRECISION = 1us
 include $(shell cocotb-config --makefiles)/Makefile.sim
 include ../../cleanall.mk

--- a/examples/TinyALU/hdl/vhdl/tinyalu.vhd
+++ b/examples/TinyALU/hdl/vhdl/tinyalu.vhd
@@ -19,7 +19,7 @@ entity tinyalu is
   port(
     A       : in  unsigned ( 7 downto 0 );
     B       : in  unsigned ( 7 downto 0 );
-    clk     : in  std_logic;
+    -- clk     : in  std_logic;
     op      : in  std_logic_vector ( 2 downto 0 );
     reset_n : in  std_logic;
     start   : in  std_logic;
@@ -48,6 +48,7 @@ architecture rtl of tinyalu is
   signal result_mult : unsigned(15 downto 0);
   signal start_single : std_logic;      -- Start signal for single cycle ops
   signal start_mult : std_logic;        -- start signal for multiply
+  signal clk: std_logic := '0';
 
   -- Implicit buffer signal declarations
   signal done_internal : std_logic;
@@ -87,6 +88,10 @@ architecture rtl of tinyalu is
 
 
 begin
+
+CLOCK:
+clk <=  '1' after 0.5 ns when clk = '0' else
+        '0' after 0.5 ns when clk = '1';
 
 -- purpose: This block shunts the start signal to the correct block. 
 -- The multiply only sees the start signal when op(2) is '1'

--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -220,6 +220,7 @@ class Scoreboard(uvm_component):
                     passed = False
         assert passed
 
+
 class Monitor(uvm_component):
     def __init__(self, name, parent, method_name):
         super().__init__(name, parent)

--- a/pyuvm/s05_base_classes.py
+++ b/pyuvm/s05_base_classes.py
@@ -174,13 +174,9 @@ class uvm_object(utility_classes.uvm_void):
     # 5.3.8.2
     def do_copy(self, rhs):
         """
-        Must be overridden to implement UVM copy().
+        Copies name. Override to copy additional data members
         """
-        raise error_classes.UVMError("Implement do_copy to copy "
-                                     "fields from rhs into self. This is "
-                                     "not really needed in Python in which "
-                                     "copy.copy() and copy.deepcopy() return a"
-                                     " new object with copied data.")
+        self.set_name(rhs.get_name())
 
     # 5.3.9.1
     def compare(self, rhs):

--- a/pyuvm/s05_base_classes.py
+++ b/pyuvm/s05_base_classes.py
@@ -114,7 +114,9 @@ class uvm_object(utility_classes.uvm_void):
         uses copy.deepcopy so the user does not need to override
         do_copy()
         """
-        raise error_classes.UVMNotImplemented("Use copy.deepcopy()")
+        new = self.__class__(self.get_name())
+        new.copy(self)
+        return new
 
     # 5.3.6.1
     def print(self):

--- a/pyuvm/s09_phasing.py
+++ b/pyuvm/s09_phasing.py
@@ -44,6 +44,9 @@ class uvm_phase(uvm_object):
                 f"{comp.get_name()} is missing {method_name} function")
         method()
 
+    def __str__(self):
+        return self.__name__[4:]
+
 
 class uvm_topdown_phase(uvm_phase):
     """

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -412,6 +412,8 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
         self.uvm_test_top = factory.create_component_by_name(
             test_name, "", "uvm_test_top", self)
         for self.running_phase in uvm_common_phases:
+            self.logger.log(utility_classes.PYUVM_DEBUG,
+                            str(self.running_phase))
             self.running_phase.traverse(self.uvm_test_top)
             if self.running_phase == uvm_run_phase:
                 await utility_classes.ObjectionHandler().run_phase_complete()  # noqa: E501

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -374,7 +374,6 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
 
     @classmethod
     def clear_singletons(cls, keep_set={}):
-        cls.singleton = None
         keepers = {uvm_factory, utility_classes.FactoryData}.union(keep_set)
         utility_classes.Singleton.clear_singletons(keep=keepers)
 

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -1,7 +1,7 @@
 from pyuvm.s06_reporting_classes import uvm_report_object
 from pyuvm.s08_factory_classes import uvm_factory
 from pyuvm.s09_phasing import uvm_common_phases, uvm_run_phase, uvm_build_phase
-from pyuvm import error_classes
+from pyuvm import error_classes, INFO
 from pyuvm import utility_classes
 import logging
 import fnmatch
@@ -404,6 +404,7 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
         """
         factory = uvm_factory()
         if not keep_singletons:
+            uvm_report_object.set_default_logging_level(INFO)
             self.clear_singletons(keep_set)
             factory.clear_overrides()
         self.clear_children()

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -395,7 +395,7 @@ class uvm_root(uvm_component, metaclass=utility_classes.UVM_ROOT_Singleton):
 # is using it, and in fact it is recommended that people
 # stick to the basic phases.  So this implementation loops
 # through the hierarchy and runs the phases.
-    async def run_test(self, test_name, keep_singletons=False, keep_set={}):
+    async def run_test(self, test_name, keep_singletons=False, keep_set=set()):
         """
         :param test_name: The uvm test name or test class
         :param keep_singletons: If True do not clear singletons (default False)

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -562,11 +562,11 @@ class ConfigDB(metaclass=utility_classes.Singleton):
 
         except TypeError:
             raise error_classes.UVMConfigItemNotFound(
-                f'"{inst_name}" is not a in ConfigDB().')
+                f'"{inst_name}" is not in ConfigDB().')
         finally:
             if len(key_matches) == 0:
                 raise error_classes.UVMConfigItemNotFound(
-                    f'"{inst_name}" is not a in ConfigDB().')
+                    f'"{inst_name}" is not in ConfigDB().')
         # Here we sort the list of paths by which paths are "in" other
         # paths. That is A comes before '*'  A.B comes before A.*, etc.
         # We use an insertion sort. A path is inserted in front of the

--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -227,17 +227,20 @@ class ObjectionHandler(metaclass=Singleton):
         self.objection_raised = False
 
     def raise_objection(self, raiser):
-        self.__objections[raiser] = raiser.get_full_name()
+        name = raiser.get_full_name()
+        self.__objections[name] = self.__objections.setdefault(name, 0) + 1
         self.objection_raised = True
         self._objection_event.clear()
 
     def drop_objection(self, dropper):
+        name = dropper.get_full_name()
         try:
-            del self.__objections[dropper]
+            self.__objections[name] -= 1
         except KeyError:
             self.objection_raised = True
             pass
-        if len(self.__objections) == 0:
+        if self.__objections[name] == 0:
+            del self.__objections[name]
             self._objection_event.set()
 
     async def run_phase_complete(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyuvm",
-    version="2.6.0",
+    version="2.6.1",
     author="Ray Salemi",
     author_email="ray@raysalemi.com",
     description="A Python implementation of the UVM using cocotb",

--- a/tests/cocotb_tests/t08_factories/factory_tests.py
+++ b/tests/cocotb_tests/t08_factories/factory_tests.py
@@ -35,6 +35,7 @@ class s08_factory_classes_TestCase():
 
     def setUp(self):
         self.fd = utility_classes.FactoryData()
+        uvm_root().clear_children()
         self.top = uvm_component("top", None)
         self.mid = uvm_component("mid", self.top)
         self.sib = uvm_component("sib", self.top)

--- a/tests/pytests/test_05_base_classes.py
+++ b/tests/pytests/test_05_base_classes.py
@@ -17,6 +17,9 @@ class my_object(uvm_object):
     def __str__(self):
         return "Hello"
 
+    def do_copy(self, other):
+        self.val = other.val
+
 
 def test_basic_creation():
     """
@@ -131,11 +134,9 @@ def test_copying():
     mo = my_object("mo")
     rhs = my_object("rhs")
     # 5.3.8.1
-    with pytest.raises(error_classes.UVMError):
-        mo.copy(rhs)
+    mo.copy(rhs)
     # 5.3.8.2
-    with pytest.raises(error_classes.UVMError):
-        mo.do_copy(rhs)
+    assert mo.val == rhs.val
 
 
 def test_comparing():
@@ -287,3 +288,10 @@ def test_transaction_recording():
         tr.get_begin_time()
     with pytest.raises(error_classes.UVMNotImplemented):
         tr.get_end_time()
+
+
+def test_clone():
+    orig = my_object("orig")
+    clone = orig.clone()
+    assert id(orig) != id(clone)
+    assert orig.val == clone.val

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ commands =
     make -C tests/cocotb_tests/config_db sim cleanall
     make -C tests/cocotb_tests/t14_15_sequences cleanall
     make -C examples/TinyALU sim cleanall
+    make SIM=ghdl TOPLEVEL_LANG=vhdl -C examples/TinyALU sim cleanall
 
 whitelist_externals =
     make


### PR DESCRIPTION
Fix #87 

`drop_objection()` assumed that each instance of a component would only call `raise_objection()`/`drop_objection()` once.  But if you awaited `super.run_phase()` the first call to `drop_objection()` would end run phase.