### PR TITLE
Add pyuvm.test decorator

### DIFF
--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -255,7 +255,10 @@ class AluEnv(uvm_env):
         self.driver.ap.connect(self.scoreboard.result_export)
 
 
+@test()
 class AluTest(uvm_test):
+    """Test ALU with random and max values"""
+
     def build_phase(self):
         self.env = AluEnv("env", self)
 
@@ -268,43 +271,28 @@ class AluTest(uvm_test):
         self.drop_objection()
 
 
+@test()
 class ParallelTest(AluTest):
+    """Test ALU random and max forked"""
+
     def build_phase(self):
         uvm_factory().set_type_override_by_type(TestAllSeq, TestAllForkSeq)
         super().build_phase()
 
 
+@test()
 class FibonacciTest(AluTest):
+    """Run Fibonacci program"""
+
     def build_phase(self):
         ConfigDB().set(None, "*", "DISABLE_COVERAGE_ERRORS", True)
         uvm_factory().set_type_override_by_type(TestAllSeq, FibonacciSeq)
         return super().build_phase()
 
 
+@test(expect_fail=True)
 class AluTestErrors(AluTest):
+    """Test ALU with errors on all operations"""
+
     def start_of_simulation_phase(self):
         ConfigDB().set(None, "*", "CREATE_ERRORS", True)
-
-
-@cocotb.test()
-async def alu_test(_):
-    """Test ALU with random and max values"""
-    await uvm_root().run_test(AluTest)
-
-
-@cocotb.test(expect_error=AssertionError)
-async def alu_test_with_errors(_):
-    """Test ALU with errors on all operations"""
-    await uvm_root().run_test(AluTestErrors)
-
-
-@cocotb.test()
-async def parallel_alu_test(_):
-    """Test ALU random and max forked"""
-    await uvm_root().run_test(ParallelTest)
-
-
-@cocotb.test()
-async def fibonacci_sim(_):
-    """Run Fibonacci program"""
-    await uvm_root().run_test(FibonacciTest)

--- a/pyuvm/__init__.py
+++ b/pyuvm/__init__.py
@@ -18,3 +18,5 @@ from pyuvm.s13_predefined_component_classes import *
 from pyuvm.s14_15_python_sequences import *
 # Section 18
 from pyuvm.s18_register_model import *
+# Extension Modules
+from pyuvm.extension_classes import *

--- a/pyuvm/extension_classes.py
+++ b/pyuvm/extension_classes.py
@@ -1,0 +1,40 @@
+import functools
+import inspect
+
+import cocotb
+
+from pyuvm import uvm_root
+
+
+def test(
+    timeout_time=None,
+    timeout_unit="step",
+    expect_fail=False,
+    expect_error=(),
+    skip=False,
+    stage=0,
+):
+    def decorator(cls):
+
+        # create cocotb.test object to be picked up RegressionManager
+        @cocotb.test(
+            timeout_time=timeout_time,
+            timeout_unit=timeout_unit,
+            expect_fail=expect_fail,
+            expect_error=expect_error,
+            skip=skip,
+            stage=stage,
+        )
+        @functools.wraps(cls)
+        async def test(_):
+            await uvm_root().run_test(cls)
+
+        # adds cocotb.test object to caller's module
+        caller_frame = inspect.stack()[1]
+        caller_module = inspect.getmodule(caller_frame[0])
+        setattr(caller_module, f"test_{test._id}", test)
+
+        # returns decorator class unmodified
+        return cls
+
+    return decorator


### PR DESCRIPTION
This simplifies the process of creating tests. Instead of having to
create a coroutine stub that calls uvm_root().run_test(), this is done
for the user with a decorator that directly wraps the uvm_test class
definition.

Closes #89.