### PR TITLE
Fix issue with stage on test decorator

### DIFF
--- a/pyuvm/extension_classes.py
+++ b/pyuvm/extension_classes.py
@@ -12,7 +12,7 @@ def test(
     expect_fail=False,
     expect_error=(),
     skip=False,
-    stage=0,
+    stage=None,
 ):
     def decorator(cls):
 


### PR DESCRIPTION
The stage variable on the test decorator defaults to None, which is broken and we are changing it upstream. But until that percolates the default here will have to stay `None` to prevent issues when `cocotb.test` and `pyuvm.test` are used in the same module and the stages on each are `None` and `0`, which fail to compare.