### PR TITLE
Tweeked example to import pyuvm

### DIFF
--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -2,6 +2,7 @@ from cocotb.triggers import Join, Combine
 from pyuvm import *
 import random
 import cocotb
+import pyuvm
 # All testbenches use tinyalu_utils, so store it in a central
 # place and add its path to the sys path so we can import it
 import sys
@@ -255,7 +256,7 @@ class AluEnv(uvm_env):
         self.driver.ap.connect(self.scoreboard.result_export)
 
 
-@test()
+@pyuvm.test()
 class AluTest(uvm_test):
     """Test ALU with random and max values"""
 
@@ -271,7 +272,7 @@ class AluTest(uvm_test):
         self.drop_objection()
 
 
-@test()
+@pyuvm.test()
 class ParallelTest(AluTest):
     """Test ALU random and max forked"""
 
@@ -280,7 +281,7 @@ class ParallelTest(AluTest):
         super().build_phase()
 
 
-@test()
+@pyuvm.test()
 class FibonacciTest(AluTest):
     """Run Fibonacci program"""
 
@@ -290,7 +291,7 @@ class FibonacciTest(AluTest):
         return super().build_phase()
 
 
-@test(expect_fail=True)
+@pyuvm.test(expect_fail=True)
 class AluTestErrors(AluTest):
     """Test ALU with errors on all operations"""
 

--- a/tests/cocotb_tests/t12_tlm/test.py
+++ b/tests/cocotb_tests/t12_tlm/test.py
@@ -65,7 +65,7 @@ class Export(uvm_analysis_export):
     def write(self, datum):
         self.data.append(datum)
 
-
+@test()
 class AnalysisTest(uvm_test):
     def build_phase(self):
         self.gp = uvm_get_port("gp", self)
@@ -100,7 +100,7 @@ async def test_12_tlm(dut):
     await run_tests(dut)
 
 
-@cocotb.test()
-async def analysis_test(_):
-    """Test analysis ports"""
-    await uvm_root().run_test("AnalysisTest")
+#@cocotb.test()
+#async def analysis_test(_):
+#    """Test analysis ports"""
+#    await uvm_root().run_test("AnalysisTest")


### PR DESCRIPTION
Now we want 


```
import cocotb
import pyuvm
```
At the top even if we import other resources directly.

This gives us
```
@pyuvm.test()
```
 
Which is clearer than just `@test()`

