### PR TITLE
Add TLM methods to uvm_tlm_fifo_base

### DIFF
--- a/pyuvm/s12_uvm_tlm_interfaces.py
+++ b/pyuvm/s12_uvm_tlm_interfaces.py
@@ -685,6 +685,33 @@ class uvm_tlm_fifo_base(uvm_component):
                                                                              self.queue, self.get_ap)  # noqa: E501
         self.get_peek_export = self.uvm_GetPeekExport("get_peek_export", self, self.queue, self.get_ap)  # noqa: E501
 
+    async def put(self, item):
+        await self.put_export.put(item)
+
+    def can_put(self):
+        return self.put_export.can_put()
+
+    def try_put(self, item):
+        return self.put_export.try_put(item)
+
+    async def get(self):
+        return await self.get_export.get()
+
+    def can_get(self):
+        return self.get_export.can_get()
+
+    def try_get(self):
+        return self.get_export.try_get()
+
+    async def peek(self):
+        return await self.peek_export.peek()
+
+    def can_peek(self):
+        return self.peek_export.can_peek()
+
+    def try_peek(self):
+        return self.peek_export.try_peek()
+
 
 class uvm_tlm_fifo(uvm_tlm_fifo_base):
 

--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -24,7 +24,7 @@ class Singleton(type):
         classes = list(cls._instances.keys())
         for del_cls in classes:
             if del_cls not in keep:
-                del(cls._instances[del_cls])
+                del (cls._instances[del_cls])
 
 
 class Override:


### PR DESCRIPTION
Adds possibility to call TLM methods directly with FIFOs.
```python
self.my_fifo = uvm_tlm_analysis_fifo("my_fifo", self)
item = await self.my_fifo.get()
```
Tests probably need updating but I cannot run them in my environment.

Closes #107