### PR TITLE
Change how pyuvm.test decorator works

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ class AluTest(uvm_test):
 We extend the `AluTest` class to create a parallel version of the test and a Fibonacci program. You can find these sequences in `testbench.py`
 ```
 @pyuvm.test()
-class ParallelTest(AluTest):
+class ParallelTest(AluTest.class_):
     def build_phase(self):
         uvm_factory().set_type_override_by_type(TestAllSeq, TestAllForkSeq)
         super().build_phase()
 
 @pyuvm.test()
-class FibonacciTest(AluTest):
+class FibonacciTest(AluTest.class_):
     def build_phase(self):
         ConfigDB().set(None, "*", "DISABLE_COVERAGE_ERRORS", True)
         uvm_factory().set_type_override_by_type(TestAllSeq, FibonacciSeq)
@@ -450,6 +450,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-
-

--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -273,7 +273,7 @@ class AluTest(uvm_test):
 
 
 @pyuvm.test()
-class ParallelTest(AluTest):
+class ParallelTest(AluTest.class_):
     """Test ALU random and max forked"""
 
     def build_phase(self):
@@ -282,7 +282,7 @@ class ParallelTest(AluTest):
 
 
 @pyuvm.test()
-class FibonacciTest(AluTest):
+class FibonacciTest(AluTest.class_):
     """Run Fibonacci program"""
 
     def build_phase(self):
@@ -292,7 +292,7 @@ class FibonacciTest(AluTest):
 
 
 @pyuvm.test(expect_fail=True)
-class AluTestErrors(AluTest):
+class AluTestErrors(AluTest.class_):
     """Test ALU with errors on all operations"""
 
     def start_of_simulation_phase(self):

--- a/pyuvm/extension_classes.py
+++ b/pyuvm/extension_classes.py
@@ -1,6 +1,3 @@
-import functools
-import inspect
-
 import cocotb
 
 from pyuvm import uvm_root
@@ -25,16 +22,16 @@ def test(
             skip=skip,
             stage=stage,
         )
-        @functools.wraps(cls)
         async def test(_):
             await uvm_root().run_test(cls)
 
-        # adds cocotb.test object to caller's module
-        caller_frame = inspect.stack()[1]
-        caller_module = inspect.getmodule(caller_frame[0])
-        setattr(caller_module, f"test_{test._id}", test)
+        test.class_ = cls
+        test.__name__ = cls.__name__
+        test.__qualname__ = cls.__qualname__
+        test.__doc__ = cls.__doc__
+        test.__module__ = cls.__module__
 
         # returns decorator class unmodified
-        return cls
+        return test
 
     return decorator


### PR DESCRIPTION
Closes #109. This PR changes how the `pyuvm.test` decorator works so that it returns the test object rather than the test class. This has two effects:
1. test can now be specified using TESTCASE
2. inheriting from decorated test now requires getting the `class_` attribute from the parent test object

Some effort was put into trying to alleviate point 2, but it does not seem this is possible in Python with the current cocotb RegressionManager implementation.