### PR TITLE
Fix test decorator to work with cocotb 1.7

### DIFF
--- a/pyuvm/extension_classes.py
+++ b/pyuvm/extension_classes.py
@@ -11,6 +11,11 @@ def test(
     skip=False,
     stage=None,
 ):
+    version_info = tuple(int(n) for n in cocotb.__version__.split("."))
+    print(version_info)
+    if version_info >= (1, 7, 0) and stage is None:
+        stage = 0
+
     def decorator(cls):
 
         # create cocotb.test object to be picked up RegressionManager


### PR DESCRIPTION
The `stage` variable was changed in 1.7. This version condition allows the existing value to work for version both before and after 1.7.