### PR TITLE
Fix #112, run_phase now waits for objections from all components

### DIFF
--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -241,7 +241,10 @@ class ObjectionHandler(metaclass=Singleton):
             pass
         if self.__objections[name] == 0:
             del self.__objections[name]
-            self._objection_event.set()
+
+            # only signal all objections done if none exist anywhere
+            if len(self.__objections) == 0:
+                self._objection_event.set()
 
     async def run_phase_complete(self):
         # Allow the run_phase coros to get scheduled and raise objections:

--- a/tests/cocotb_tests/run_phase/test.py
+++ b/tests/cocotb_tests/run_phase/test.py
@@ -15,9 +15,11 @@ class my_error(uvm_test):
         self.raise_objection()
         raise UVMError("This is an error")
 
+
 class my_no_objection(uvm_test):
     async def run_phase(self):
         print("Running without using objections")
+
 
 class nested_parent(uvm_test):
     async def run_phase(self):
@@ -35,7 +37,33 @@ class nested_objections(nested_parent):
 
     def check_phase(self):
         assert get_sim_time(units="ms") > 10
-        
+
+
+class TopTest(uvm_test):
+    def build_phase(self):
+        # super().build_phase()
+        self.sub_component = SubComponent('sub_component', self)
+
+    async def run_phase(self):
+        self.raise_objection()
+        await Timer(10, units="ms")
+        self.drop_objection()
+
+
+class SubComponent(uvm_component):
+    def __init__(self, name, parent):
+        super().__init__(name, parent)
+
+    async def run_phase(self):
+        self.raise_objection()
+
+        # sub component takes longer than TopTest
+        await Timer(50, units="ms")
+
+        self.drop_objection()
+
+    def check_phase(self):
+        assert get_sim_time(units="ms") >= 50
 
 
 @cocotb.test()
@@ -50,11 +78,13 @@ async def error(dut):
     """Test that raising exceptions creates cocotb errors"""
     await uvm_root().run_test("my_error")
 
+
 @cocotb.test()
 async def run_after_error(dut):
     """Test run_phase operation after previous test raised exception"""
     await uvm_root().run_test("my_test")
     assert True
+
 
 @cocotb.test()
 async def run_no_objection(dut):
@@ -62,6 +92,16 @@ async def run_no_objection(dut):
     # Expect a warning message. Can that be tested for?
     await uvm_root().run_test("my_no_objection")
 
+
 @cocotb.test()
 async def test_nested_objections(_):
     await uvm_root().run_test(nested_objections)
+
+
+@cocotb.test()
+async def test_sub_component_objections(_):
+    """
+    Test that all objections from all components are waited for
+    regardless of the order in which they are raised or dropped.
+    """
+    await uvm_root().run_test(TopTest)


### PR DESCRIPTION
Fix #112, bug where `run_phase` could end before all objections were dropped from all components.  Also added a new test to protect functionality.  Confirmed test fails without the fix and passes with it.