### PR TITLE
Fix environment variable definition in TinyALU Makefile

### DIFF
--- a/examples/TinyALU/Makefile
+++ b/examples/TinyALU/Makefile
@@ -1,5 +1,5 @@
 CWD=$(shell pwd)
-COCOTB_REDUCED_LOG_FMT = True
+export COCOTB_REDUCED_LOG_FMT = 1
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 ifeq ($(TOPLEVEL_LANG),verilog)


### PR DESCRIPTION
cocotb documentation makes a distinction between Makefile variables and environment variables. The former are used in cocotb Makefiles while the latter are read in the Python code as environment variables. The latter types need the Make directive `export` to make them environment variables. What makes it confusing is that a few of the environment variables are already either exported or passed as command-line parameters by cocotb, like `MODULE`, but the rest need to be exported by the user.

`COCOTB_REDUCED_LOG_FMT` is one of those that need the `export` directive so I added it. Also, only integer values are accepted for it, so I changed its value from `True` to `1`. The default value is 1 so functionally this PR changes nothing.