### PR TITLE
Cocotb record.name deletion in LOG

### DIFF
--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -71,8 +71,8 @@ class TestAllForkSeq(uvm_sequence):
         seqr = ConfigDB().get(None, "", "SEQR")
         random = RandomSeq("random")
         max = MaxSeq("max")
-        random_task = cocotb.fork(random.start(seqr))
-        max_task = cocotb.fork(max.start(seqr))
+        random_task = cocotb.start_soon(random.start(seqr))
+        max_task = cocotb.start_soon(max.start(seqr))
         await Combine(Join(random_task), Join(max_task))
 
 # Sequence library example

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -72,10 +72,10 @@ class PyuvmSimLogFormatter(logging.Formatter):
 
         if not _suppress:
             prefix += (
-                self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) +
-		":" +
-		self.ljust(str(record.lineno), _LINENO_CHARS) + " in " +
-                self.ljust(str(record.funcName), _FUNCNAME_CHARS) + " "
+                self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) 
+                + ":" 
+                + self.ljust(str(record.lineno), _LINENO_CHARS) + " in " 
+                + self.ljust(str(record.funcName), _FUNCNAME_CHARS) + " "
             )
 
         # these lines are copied from the builtin logger
@@ -125,7 +125,7 @@ class PyuvmSimColourLogFormatter(PyuvmSimLogFormatter):
         msg = "\n".join(
             [
                 SimColourLogFormatter.loglevel2colour.get(
-                  record.levelno, "%s") % line
+                    record.levelno, "%s") % line
                 for line in msg.split("\n")
             ]
         )

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -13,7 +13,7 @@ import os
 
 from cocotb.log import SimColourLogFormatter, SimTimeContextFilter
 from logging import DEBUG, CRITICAL, ERROR, WARNING, INFO, NOTSET, NullHandler   # noqa: F401, E501
-from cocotb.utils import get_sim_time, get_time_from_sim_steps, want_color_output
+from cocotb.utils import get_time_from_sim_steps
 import cocotb.ANSI as ANSI
 
 try:
@@ -27,6 +27,7 @@ _LEVEL_CHARS = len("UVM_WARNING")
 _FILENAME_CHARS = 200
 _LINENO_CHARS = 5
 _FUNCNAME_CHARS = 100
+
 
 class PyuvmSimLogFormatter(logging.Formatter):
     """Log formatter to provide consistent UVM like log message handling.
@@ -46,19 +47,19 @@ class PyuvmSimLogFormatter(logging.Formatter):
     @staticmethod
     def ljust(string, chars):
         if len(string) > chars:
-            return ".." + string[(chars - 2) * -1 :]
+            return ".." + string[(chars - 2) * -1:]
         return string.ljust(chars)
 
     @staticmethod
     def rjust(string, chars):
         if len(string) > chars:
-            return ".." + string[(chars - 2) * -1 :]
+            return ".." + string[(chars - 2) * -1:]
         return string.rjust(chars)
 
     def _format(self, level, record, msg, coloured=False):
 
         # Wait for Ray Salemi's buy-in uvm_level_str = 'UVM_' + level
-        uvm_level_str =  level
+        uvm_level_str = level
         sim_time = getattr(record, "created_sim_time", None)
         if sim_time is None:
             sim_time_str = "  -.--ns"
@@ -66,20 +67,15 @@ class PyuvmSimLogFormatter(logging.Formatter):
             time_ns = get_time_from_sim_steps(sim_time, "ns")
             sim_time_str = f"{time_ns:6.2f}ns"
         prefix = (
-            sim_time_str.rjust(11)
-            + " "
-            + uvm_level_str
-            + " "
+            sim_time_str.rjust(11) + " " + uvm_level_str + " "
         )
 
         if not _suppress:
             prefix += (
-                self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS)
-                + ":"
-                + self.ljust(str(record.lineno), _LINENO_CHARS)
-                + " in "
-                + self.ljust(str(record.funcName), _FUNCNAME_CHARS)
-                + " "
+                self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) +
+		":" +
+		self.ljust(str(record.lineno), _LINENO_CHARS) + " in " +
+                self.ljust(str(record.funcName), _FUNCNAME_CHARS) + " "
             )
 
         # these lines are copied from the builtin logger
@@ -107,6 +103,7 @@ class PyuvmSimLogFormatter(logging.Formatter):
 
         return self._format(level, record, msg)
 
+
 class PyuvmSimColourLogFormatter(PyuvmSimLogFormatter):
     """Log formatter to provide consistent log message handling."""
 
@@ -127,7 +124,8 @@ class PyuvmSimColourLogFormatter(PyuvmSimLogFormatter):
         # Need to colour each line in case coloring is applied in the message
         msg = "\n".join(
             [
-                SimColourLogFormatter.loglevel2colour.get(record.levelno, "%s") % line
+                SimColourLogFormatter.loglevel2colour.get(
+                  record.levelno, "%s") % line
                 for line in msg.split("\n")
             ]
         )
@@ -138,14 +136,14 @@ class PyuvmSimColourLogFormatter(PyuvmSimLogFormatter):
         return self._format(level, record, msg, coloured=True)
 
 
-#class PyuvmFormatter(SimColourLogFormatter):
+# class PyuvmFormatter(SimColourLogFormatter):
 class PyuvmFormatter(PyuvmSimColourLogFormatter):
     def __init__(self, full_name):
         self.full_name = full_name
         super().__init__()
 
     def format(self, record):
-        new_msg = f"{record.filename}({record.lineno})" 
+        new_msg = f"{record.filename}({record.lineno})"
         new_msg += f"[{self.full_name}]: " + record.msg
         record.msg = new_msg
         return super().format(record)

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -9,17 +9,143 @@
 from pyuvm.s05_base_classes import uvm_object
 import logging
 import sys
+import os
+
 from cocotb.log import SimColourLogFormatter, SimTimeContextFilter
 from logging import DEBUG, CRITICAL, ERROR, WARNING, INFO, NOTSET, NullHandler   # noqa: F401, E501
+from cocotb.utils import get_sim_time, get_time_from_sim_steps, want_color_output
+import cocotb.ANSI as ANSI
+
+try:
+    _suppress = int(os.environ.get("COCOTB_REDUCED_LOG_FMT", "1"))
+except ValueError:
+    _suppress = 1
 
 
-class PyuvmFormatter(SimColourLogFormatter):
+# Column alignment
+_LEVEL_CHARS = len("UVM_WARNING")
+_FILENAME_CHARS = 200
+_LINENO_CHARS = 5
+_FUNCNAME_CHARS = 100
+
+class PyuvmSimLogFormatter(logging.Formatter):
+    """Log formatter to provide consistent UVM like log message handling.
+
+    This will only add simulator timestamps if the handler object this
+    formatter is attached to has a :class:`SimTimeContextFilter` filter
+    attached, which cocotb ensures by default.
+    """
+
+    # Removes the arguments from the base class. Docstring needed to make
+    # sphinx happy.
+    def __init__(self):
+        """Takes no arguments."""
+        super().__init__()
+
+    # Justify and truncate
+    @staticmethod
+    def ljust(string, chars):
+        if len(string) > chars:
+            return ".." + string[(chars - 2) * -1 :]
+        return string.ljust(chars)
+
+    @staticmethod
+    def rjust(string, chars):
+        if len(string) > chars:
+            return ".." + string[(chars - 2) * -1 :]
+        return string.rjust(chars)
+
+    def _format(self, level, record, msg, coloured=False):
+
+        # Wait for Ray Salemi's buy-in uvm_level_str = 'UVM_' + level
+        uvm_level_str =  level
+        sim_time = getattr(record, "created_sim_time", None)
+        if sim_time is None:
+            sim_time_str = "  -.--ns"
+        else:
+            time_ns = get_time_from_sim_steps(sim_time, "ns")
+            sim_time_str = f"{time_ns:6.2f}ns"
+        prefix = (
+            sim_time_str.rjust(11)
+            + " "
+            + uvm_level_str
+            + " "
+        )
+
+        if not _suppress:
+            prefix += (
+                self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS)
+                + ":"
+                + self.ljust(str(record.lineno), _LINENO_CHARS)
+                + " in "
+                + self.ljust(str(record.funcName), _FUNCNAME_CHARS)
+                + " "
+            )
+
+        # these lines are copied from the builtin logger
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if msg[-1:] != "\n":
+                msg = msg + "\n"
+            msg = msg + record.exc_text
+
+        prefix_len = len(prefix)
+        if coloured:
+            prefix_len -= len(level) - _LEVEL_CHARS
+        pad = "\n" + " " * (prefix_len)
+        return prefix + pad.join(msg.split("\n"))
+
+    def format(self, record):
+        """Prettify the log output, annotate with simulation time"""
+
+        msg = record.getMessage()
+        level = record.levelname.ljust(_LEVEL_CHARS)
+
+        return self._format(level, record, msg)
+
+class PyuvmSimColourLogFormatter(PyuvmSimLogFormatter):
+    """Log formatter to provide consistent log message handling."""
+
+    loglevel2colour = {
+        logging.TRACE: "%s",
+        logging.DEBUG: "%s",
+        logging.INFO: "%s",
+        logging.WARNING: ANSI.COLOR_WARNING + "%s" + ANSI.COLOR_DEFAULT,
+        logging.ERROR: ANSI.COLOR_ERROR + "%s" + ANSI.COLOR_DEFAULT,
+        logging.CRITICAL: ANSI.COLOR_CRITICAL + "%s" + ANSI.COLOR_DEFAULT,
+    }
+
+    def format(self, record):
+        """Prettify the log output, annotate with simulation time"""
+
+        msg = record.getMessage()
+
+        # Need to colour each line in case coloring is applied in the message
+        msg = "\n".join(
+            [
+                SimColourLogFormatter.loglevel2colour.get(record.levelno, "%s") % line
+                for line in msg.split("\n")
+            ]
+        )
+        level = SimColourLogFormatter.loglevel2colour.get(
+            record.levelno, "%s"
+        ) % record.levelname.ljust(_LEVEL_CHARS)
+
+        return self._format(level, record, msg, coloured=True)
+
+
+#class PyuvmFormatter(SimColourLogFormatter):
+class PyuvmFormatter(PyuvmSimColourLogFormatter):
     def __init__(self, full_name):
         self.full_name = full_name
         super().__init__()
 
     def format(self, record):
-        new_msg = f"{record.filename}({record.lineno})"
+        new_msg = f"{record.filename}({record.lineno})" 
         new_msg += f"[{self.full_name}]: " + record.msg
         record.msg = new_msg
         return super().format(record)

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -59,7 +59,7 @@ class PyuvmSimLogFormatter(logging.Formatter):
     def _format(self, level, record, msg, coloured=False):
 
         # Wait for Ray Salemi's buy-in uvm_level_str = 'UVM_' + level
-	# Not using UVM_ prefix just yet
+        # Not using UVM_ prefix just yet
         uvm_level_str = level
         sim_time = getattr(record, "created_sim_time", None)
         if sim_time is None:

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -72,9 +72,9 @@ class PyuvmSimLogFormatter(logging.Formatter):
 
         if not _suppress:
             prefix += (
-                self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) 
-                + ":" 
-                + self.ljust(str(record.lineno), _LINENO_CHARS) + " in " 
+                self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS)
+                + ":"
+                + self.ljust(str(record.lineno), _LINENO_CHARS) + " in "
                 + self.ljust(str(record.funcName), _FUNCNAME_CHARS) + " "
             )
 

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -59,6 +59,7 @@ class PyuvmSimLogFormatter(logging.Formatter):
     def _format(self, level, record, msg, coloured=False):
 
         # Wait for Ray Salemi's buy-in uvm_level_str = 'UVM_' + level
+	# Not using UVM_ prefix just yet
         uvm_level_str = level
         sim_time = getattr(record, "created_sim_time", None)
         if sim_time is None:


### PR DESCRIPTION
As per ongoing discussion https://github.com/pyuvm/pyuvm/discussions/126

I am submitting the agreed fix for removing that redundant redcord.name/full_name. 

Also included is a minor fix for issue: https://github.com/pyuvm/pyuvm/issues/128