### PR TITLE
Fix colored output when COCOTB_ANSI_OUTPUT is set 0

### DIFF
--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -9,7 +9,8 @@
 from pyuvm.s05_base_classes import uvm_object
 import logging
 import sys
-from cocotb.log import SimColourLogFormatter, SimTimeContextFilter
+from cocotb.log import SimLogFormatter, SimColourLogFormatter, SimTimeContextFilter
+from cocotb.utils import want_color_output
 from logging import DEBUG, CRITICAL, ERROR, WARNING, INFO, NOTSET, NullHandler   # noqa: F401, E501
 
 
@@ -23,7 +24,10 @@ class PyuvmFormatter(SimColourLogFormatter):
         record.msg = new_msg
         name_temp = record.name
         record.name = f"{record.pathname}({record.lineno})"
-        formatted_msg = super().format(record)
+        if want_color_output():
+            formatted_msg = super().format(record)
+        else:
+            formatted_msg = SimLogFormatter.format(self, record)
         record.name = name_temp
         return formatted_msg
 

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -9,7 +9,8 @@
 from pyuvm.s05_base_classes import uvm_object
 import logging
 import sys
-from cocotb.log import SimLogFormatter, SimColourLogFormatter, SimTimeContextFilter
+from cocotb.log import SimTimeContextFilter
+from cocotb.log import SimLogFormatter, SimColourLogFormatter
 from cocotb.utils import want_color_output
 from logging import DEBUG, CRITICAL, ERROR, WARNING, INFO, NOTSET, NullHandler   # noqa: F401, E501
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,9 @@ ignore = F405,F403
 
 
 [testenv]
+allowlist_externals=
+    make
+
 platform =
     linux: linux|cygwin
     macos: darwin
@@ -35,9 +38,6 @@ platform =
 setenv =
    PYTHONPATH = {toxinidir}:{toxinidir}/tests/pytests
    COCOTB_REDUCED_LOG_FMT=1
-
-
-
 
 passenv =
   SIM


### PR DESCRIPTION
pyuvm colored output can not be disabled as it always uses the _SimColourLogFormatter_

For post-processing of log files normally is desirable to have a plain log file without colors. For this purpose cocotb provides the COCOTB_ANSI_OUTPUT Environment variable.

Fix adds support for the COCOTB_ANSI_OUTPUT Environment variable to pyuvm logging. 