### PR TITLE
Update example TinyALY to work with Verilator 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ run_questa:
 run_vcs:
 	make -C examples/TinyALU SIM=vcs
 
+.PHONY: run_verilator
+run_verilator:
+	make -C examples/TinyALU SIM=verilator
+
 .PHONY: init
 init:
 	pip install -r requirements.txt

--- a/examples/TinyALU/Makefile
+++ b/examples/TinyALU/Makefile
@@ -11,6 +11,10 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
+ifeq ($(SIM), verilator)
+    # Enable processing of #delay statements
+    COMPILE_ARGS += --timing
+endif
 MODULE := testbench
 TOPLEVEL = tinyalu
 GHDL_ARGS := --ieee=synopsys

--- a/examples/TinyALU/hdl/verilog/tinyalu.sv
+++ b/examples/TinyALU/hdl/verilog/tinyalu.sv
@@ -8,12 +8,13 @@ module tinyalu (input [7:0] A,
 		output [15:0] result);
 
    wire [15:0] 		      result_aax, result_mult;
-   wire 		      start_single, start_mult;
-	bit clk;
+   wire 		          start_single, start_mult;
+   wire                   done_aax;
+   wire                   done_mult;
+   bit                    clk;
 
-	initial clk = 0;
-	always #5 clk = ~clk;
-
+   initial clk = 0;
+   always #5 clk = ~clk;
 
    assign start_single = start & ~op[2];
    assign start_mult   = start & op[2];
@@ -46,9 +47,10 @@ module single_cycle(input [7:0] A,
       result <= 0;
     else
       case(op)
-		3'b001 : result <= A + B;
-		3'b010 : result <= A & B;
-		3'b011 : result <= A ^ B;
+		3'b001 : result <= {8'd0,A} + {8'd0,B};
+		3'b010 : result <= {8'd0,A} & {8'd0,B};
+		3'b011 : result <= {8'd0,A} ^ {8'd0,B};
+		default : result <= {A,B};
       endcase // case (op)
 
    always @(posedge clk)


### PR DESCRIPTION
Indentation change in TinayALU

Tried TinayALU with **Verilator 5.006 2023-01-22 rev v5.006** and **cocotb-1.8.0.dev0**.  The change to TinayALU fixes ventilator errors related to width mismatch.