### PR TITLE
Automatic string conversion for log messages

### DIFF
--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -21,7 +21,7 @@ class PyuvmFormatter(SimColourLogFormatter):
         super().__init__()
 
     def format(self, record):
-        new_msg = f"[{self.full_name}]: " + record.msg
+        new_msg = f"[{self.full_name}]: {record.msg}"
         record.msg = new_msg
         name_temp = record.name
         record.name = f"{record.pathname}({record.lineno})"


### PR DESCRIPTION
Exception occurs when passing non-strings to the logger, this should let it print whatever comes in (as long as it has a string representation).