### PR TITLE
Replace fork with start_soon in example

### DIFF
--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -71,8 +71,8 @@ class TestAllForkSeq(uvm_sequence):
         seqr = ConfigDB().get(None, "", "SEQR")
         random = RandomSeq("random")
         max = MaxSeq("max")
-        random_task = cocotb.fork(random.start(seqr))
-        max_task = cocotb.fork(max.start(seqr))
+        random_task = cocotb.start_soon(random.start(seqr))
+        max_task = cocotb.start_soon(max.start(seqr))
         await Combine(Join(random_task), Join(max_task))
 
 # Sequence library example


### PR DESCRIPTION
fork has been deprecated from cocotb 1.7.0
(https://github.com/cocotb/cocotb/issues/2663)

This PR resolves https://github.com/pyuvm/pyuvm/issues/128