### PR TITLE
Enable CI for ral_dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - ral_dev
   pull_request:
     branches:
     - master
+    - ral_dev
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
as we have flake8 fixes coming in, Lets enable CI on `ral_dev` to make sure tests pass on CI before merge