### PR TITLE
Generate passthrough interface

### DIFF
--- a/examples/TinyALU_reg/hdl/verilog/TinyALUreg.sv
+++ b/examples/TinyALU_reg/hdl/verilog/TinyALUreg.sv
@@ -5,14 +5,18 @@ module TinyALUreg (
         input wire clk,
         input wire rst,
 
-        input wire s_apb_psel,
-        input wire s_apb_penable,
-        input wire s_apb_pwrite,
-        input wire [2:0] s_apb_paddr,
-        input wire [15:0] s_apb_pwdata,
-        output logic s_apb_pready,
-        output logic [15:0] s_apb_prdata,
-        output logic s_apb_pslverr,
+        input wire s_cpuif_req,
+        input wire s_cpuif_req_is_wr,
+        input wire [2:0] s_cpuif_addr,
+        input wire [15:0] s_cpuif_wr_data,
+        input wire [15:0] s_cpuif_wr_biten,
+        output wire s_cpuif_req_stall_wr,
+        output wire s_cpuif_req_stall_rd,
+        output wire s_cpuif_rd_ack,
+        output wire s_cpuif_rd_err,
+        output wire [15:0] s_cpuif_rd_data,
+        output wire s_cpuif_wr_ack,
+        output wire s_cpuif_wr_err,
 
         input TinyALUreg_pkg::TinyALUreg__in_t hwif_in,
         output TinyALUreg_pkg::TinyALUreg__out_t hwif_out
@@ -36,38 +40,18 @@ module TinyALUreg (
     logic cpuif_wr_ack;
     logic cpuif_wr_err;
 
-    // Request
-    logic is_active;
-    always_ff @(posedge clk) begin
-        if(rst) begin
-            is_active <= '0;
-            cpuif_req <= '0;
-            cpuif_req_is_wr <= '0;
-            cpuif_addr <= '0;
-            cpuif_wr_data <= '0;
-        end else begin
-            if(~is_active) begin
-                if(s_apb_psel) begin
-                    is_active <= '1;
-                    cpuif_req <= '1;
-                    cpuif_req_is_wr <= s_apb_pwrite;
-                    cpuif_addr <= {s_apb_paddr[2:1], 1'b0};
-                    cpuif_wr_data <= s_apb_pwdata;
-                end
-            end else begin
-                cpuif_req <= '0;
-                if(cpuif_rd_ack || cpuif_wr_ack) begin
-                    is_active <= '0;
-                end
-            end
-        end
-    end
-    assign cpuif_wr_biten = '1;
-
-    // Response
-    assign s_apb_pready = cpuif_rd_ack | cpuif_wr_ack;
-    assign s_apb_prdata = cpuif_rd_data;
-    assign s_apb_pslverr = cpuif_rd_err | cpuif_wr_err;
+    assign cpuif_req = s_cpuif_req;
+    assign cpuif_req_is_wr = s_cpuif_req_is_wr;
+    assign cpuif_addr = s_cpuif_addr;
+    assign cpuif_wr_data = s_cpuif_wr_data;
+    assign cpuif_wr_biten = s_cpuif_wr_biten;
+    assign s_cpuif_req_stall_wr = cpuif_req_stall_wr;
+    assign s_cpuif_req_stall_rd = cpuif_req_stall_rd;
+    assign s_cpuif_rd_ack = cpuif_rd_ack;
+    assign s_cpuif_rd_err = cpuif_rd_err;
+    assign s_cpuif_rd_data = cpuif_rd_data;
+    assign s_cpuif_wr_ack = cpuif_wr_ack;
+    assign s_cpuif_wr_err = cpuif_wr_err;
 
     logic cpuif_req_masked;
 

--- a/examples/TinyALU_reg/hdl/verilog/tinyalu.sv
+++ b/examples/TinyALU_reg/hdl/verilog/tinyalu.sv
@@ -8,15 +8,19 @@ module tinyalu (input [7:0] A,
 		input start,
 		output done,
 		output [15:0] result,
-		// APB interface
-        input wire s_apb_psel,
-        input wire s_apb_penable,
-        input wire s_apb_pwrite,
-        input wire [2:0] s_apb_paddr,
-        input wire [15:0] s_apb_pwdata,
-        output logic s_apb_pready,
-        output logic [15:0] s_apb_prdata,
-        output logic s_apb_pslverr
+    // cpuif
+    input wire cpuif_req,
+    input wire cpuif_req_is_wr,
+    input wire [2:0] cpuif_addr,
+    input wire [15:0] cpuif_wr_data,
+    input wire [15:0] cpuif_wr_biten,
+    output wire cpuif_req_stall_wr,
+    output wire cpuif_req_stall_rd,
+    output wire cpuif_rd_ack,
+    output wire cpuif_rd_err,
+    output wire [15:0] cpuif_rd_data,
+    output wire cpuif_wr_ack,
+    output wire cpuif_wr_err,
 		);
 
    wire [15:0] 		      result_aax, result_mult;
@@ -53,20 +57,24 @@ module tinyalu (input [7:0] A,
    assign reg_in.CMD.reserved.next = '0;
 
 
-	TinyALUreg regblock(
-    	.clk (clk),
-    	.rst (reset_n),
-    	.s_apb_psel (s_apb_psel),
-    	.s_apb_penable (s_apb_penable),
-    	.s_apb_pwrite (s_apb_pwrite),
-    	.s_apb_paddr (s_apb_paddr),
-    	.s_apb_pwdata (s_apb_pwdata),
-    	.s_apb_pready (s_apb_pready),
-    	.s_apb_prdata (s_apb_prdata),
-    	.s_apb_pslverr (s_apb_pslverr),
-    	.hwif_in (reg_in),
-    	.hwif_out (reg_out)
-    	);
+  TinyALUreg regblock(
+    .clk                  (clk),
+    .rst                  (reset_n),
+    .s_cpuif_req          (cpuif_req),
+    .s_cpuif_req_is_wr    (cpuif_req_is_wr),
+    .s_cpuif_addr         (cpuif_addr),
+    .s_cpuif_wr_data      (cpuif_wr_data),
+    .s_cpuif_wr_biten     (cpuif_wr_biten),
+    .s_cpuif_req_stall_wr (cpuif_req_stall_wr),
+    .s_cpuif_req_stall_rd (cpuif_req_stall_rd),
+    .s_cpuif_rd_ack       (cpuif_rd_ack),
+    .s_cpuif_rd_err       (cpuif_rd_err),
+    .s_cpuif_rd_data      (cpuif_rd_data),
+    .s_cpuif_wr_ack       (cpuif_wr_ack),
+    .s_cpuif_wr_err       (cpuif_wr_err),
+    .hwif_in              (reg_in),
+    .hwif_out             (reg_out)
+  );
 
 endmodule // tinyalu
 


### PR DESCRIPTION
Generate a passthrough interface instead of APB for easy testing of RAL

generate command:
```
peakrdl regblock ../../TinyALUreg.rdl -o ./ --cpuif passthrough --hwif-report
```