### PR TITLE
Use int instead of string for storing RAL values

### DIFF
--- a/pyuvm/s20_uvm_reg.py
+++ b/pyuvm/s20_uvm_reg.py
@@ -22,7 +22,7 @@ class uvm_reg(uvm_object):
         self._sum: int = 0
         self._name: str = name
         self._header: str = name + " -- "
-        self._address: str = "0x0"
+        self._address: int = 0
         self._path: str = ""
         self._width = reg_width
         # If set those 2 flags will override fields values, and if set to True
@@ -42,7 +42,7 @@ class uvm_reg(uvm_object):
     # configure
     def configure(self,
                   parent,
-                  address: str,
+                  address: int,
                   hdl_path: str,
                   throw_error_on_read: bool = False,
                   throw_error_on_write: bool = False):

--- a/pyuvm/s21_uvm_reg_map.py
+++ b/pyuvm/s21_uvm_reg_map.py
@@ -62,14 +62,6 @@ class uvm_reg_map(uvm_object):
             uvm_error(self.header, "add_parent_map -- cannot add parent map \
                 if the parentmap is already set")
 
-    # str2int
-    def _str2int(self, istr: str = "") -> int:
-        return int(istr, 16)
-
-    # int2hex
-    def _int2hex(self, ival: int = 0) -> str:
-        return hex(ival)
-
     # gen_message
     def gen_message(self, txt="") -> str:
         return f"{self.header} {txt}"
@@ -86,11 +78,11 @@ class uvm_reg_map(uvm_object):
             return self._offset
 
     # add_reg
-    def add_reg(self, reg, offset: str = "0x0", rigths: str = "RW"):
+    def add_reg(self, reg, offset: int = 0x0, rigths: str = "RW"):
         reg.add_map(self)
-        sum_offset = self._str2int(offset) + self._str2int(reg.get_address())
+        sum_offset = reg.get_address() + offset
         reg.set_access_policy(rigths)
-        self._regs[self._int2hex(sum_offset)] = reg
+        self._regs[sum_offset] = reg
 
     # get_registers
     def get_registers(self, as_dict=False):
@@ -378,8 +370,8 @@ class uvm_reg_map(uvm_object):
 
     # print of uvm_reg_map similar to convert2string
     def __str__(self) -> str:
-        return f"   {self.header} \
-                    self._parent    : {self._parent} \
-                    self._offset    : {self._offset} \
-                    self._regs      : {self._regs} \
-                    self.name       : {self.name }"
+        return f"{self.header} \
+                 self._parent   : {self._parent} \
+                 self._offset   : {hex(self._offset)} \
+                 self._regs     : { {hex(k):v for k,v in self._regs.items()} }\
+                 self.name      : {self.name }"

--- a/tests/pytests/test_uvm_ral.py
+++ b/tests/pytests/test_uvm_ral.py
@@ -74,16 +74,16 @@ def test_simple_reg_model():
             self.map = uvm_reg_map('map')
             self.map.configure(self, 0)
             self.LCR = LineControlRegister('LCR')
-            self.LCR.configure(self, "0x100c", "")
-            self.map.add_reg(self.LCR, "0x0")
+            self.LCR.configure(self, 0x100c, "")
+            self.map.add_reg(self.LCR, 0x0)
             self.LSR = LineStatusRegister('LSR')
-            self.LSR.configure(self, "0x1014", "")
-            self.map.add_reg(self.LSR, "0x0")
+            self.LSR.configure(self, 0x1014, "")
+            self.map.add_reg(self.LSR, 0x0)
 
     regs = Regs('regs')
     assert regs.get_name() == 'regs'
-    assert regs.map.get_reg_by_offset("0x100c") == regs.LCR
-    assert regs.map.get_reg_by_offset("0x1014") == regs.LSR
+    assert regs.map.get_reg_by_offset(0x100c) == regs.LCR
+    assert regs.map.get_reg_by_offset(0x1014) == regs.LSR
 
     LCR = regs.LCR
     assert LCR.get_name() == 'LCR'

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -51,7 +51,7 @@ def test_reg_block_with_single_reg():
     # START
     block = uvm_reg_block()
     reg = temp_reg()
-    reg.configure(block, "0x4", "")
+    reg.configure(block, 0x4, "")
     block.set_lock()
     assert block._get_registers() == [reg]
 
@@ -68,9 +68,9 @@ def test_reg_block_with_multiple_regs():
     # START
     block = uvm_reg_block()
     reg0 = temp_reg()
-    reg0.configure(block, "0x4", "")
+    reg0.configure(block, 0x4, "")
     reg1 = temp_reg()
-    reg1.configure(block, "0x8", "")
+    reg1.configure(block, 0x8, "")
     block.set_lock()
     assert block._get_registers() == [reg0, reg1]
 
@@ -93,19 +93,19 @@ def test_reg_map_configure():
 def test_reg_map_with_single_reg():
     reg_map = uvm_reg_map()
     reg = uvm_reg()
-    reg_map.add_reg(reg, "0x0")
+    reg_map.add_reg(reg, 0x0)
     assert reg_map.get_registers() == [reg]
 
 
 def test_reg_map_with_multiple_regs():
     reg_map = uvm_reg_map()
     reg0 = uvm_reg()
-    reg_map.add_reg(reg0, "0xf")
+    reg_map.add_reg(reg0, 0xf)
     reg1 = uvm_reg()
-    reg_map.add_reg(reg1, "0xff")
+    reg_map.add_reg(reg1, 0xff)
     assert reg_map.get_registers() == [reg0, reg1]
-    assert reg_map.get_reg_by_offset("0xf") == reg0
-    assert reg_map.get_reg_by_offset("0xff") == reg1
+    assert reg_map.get_reg_by_offset(0xf) == reg0
+    assert reg_map.get_reg_by_offset(0xff) == reg1
 
 ##############################################################################
 # TESTS UVM_REG
@@ -128,7 +128,7 @@ def test_reg_configure():
     # START
     reg = temp_reg()
     parent = uvm_reg_block()
-    reg.configure(parent, "0x4", "")
+    reg.configure(parent, 0x4, "")
     assert reg.get_parent() == parent
 
 
@@ -224,16 +224,16 @@ def test_simple_reg_model():
             self.map = uvm_reg_map('map')
             self.map.configure(self, 0)
             self.LCR = LineControlRegister('LCR')
-            self.LCR.configure(self, "0x100c", "")
-            self.map.add_reg(self.LCR, "0x0")
+            self.LCR.configure(self, 0x100c, "")
+            self.map.add_reg(self.LCR, 0x0)
             self.LSR = LineStatusRegister('LSR')
-            self.LSR.configure(self, "0x1014", "")
-            self.map.add_reg(self.LSR, "0x0")
+            self.LSR.configure(self, 0x1014, "")
+            self.map.add_reg(self.LSR, 0x0)
 
     regs = Regs('regs')
     assert regs.get_name() == 'regs'
-    assert regs.map.get_reg_by_offset("0x100c") == regs.LCR
-    assert regs.map.get_reg_by_offset("0x1014") == regs.LSR
+    assert regs.map.get_reg_by_offset(0x100c) == regs.LCR
+    assert regs.map.get_reg_by_offset(0x1014) == regs.LSR
 
     LCR = regs.LCR
     assert LCR.get_name() == 'LCR'

--- a/tests/pytests/test_uvm_reg_map.py
+++ b/tests/pytests/test_uvm_reg_map.py
@@ -51,7 +51,7 @@ def test_reg_block_with_single_reg():
     # START
     block = uvm_reg_block()
     reg = temp_reg()
-    reg.configure(block, "0x4", "")
+    reg.configure(block, 0x4, "")
     block.set_lock()
     assert block._get_registers() == [reg]
 
@@ -68,9 +68,9 @@ def test_reg_block_with_multiple_regs():
     # START
     block = uvm_reg_block()
     reg0 = temp_reg()
-    reg0.configure(block, "0x4", "")
+    reg0.configure(block, 0x4, "")
     reg1 = temp_reg()
-    reg1.configure(block, "0x8", "")
+    reg1.configure(block, 0x8, "")
     block.set_lock()
     assert block._get_registers() == [reg0, reg1]
 
@@ -96,7 +96,7 @@ def test_reg_map_configure():
 def test_reg_map_with_single_reg():
     reg_map = uvm_reg_map()
     reg = uvm_reg()
-    reg_map.add_reg(reg, "0", "RW")
+    reg_map.add_reg(reg, 0, "RW")
     assert reg_map.get_registers() == [reg]
 
 
@@ -104,12 +104,12 @@ def test_reg_map_with_single_reg():
 def test_reg_map_with_multiple_regs():
     reg_map = uvm_reg_map()
     reg0 = uvm_reg()
-    reg_map.add_reg(reg0, "0xf", "RW")
+    reg_map.add_reg(reg0, 0xf, "RW")
     reg1 = uvm_reg()
-    reg_map.add_reg(reg1, "0xff", "RW")
+    reg_map.add_reg(reg1, 0xff, "RW")
     assert reg_map.get_registers() == [reg0, reg1]
-    assert reg_map.get_reg_by_offset("0xf") == reg0
-    assert reg_map.get_reg_by_offset("0xff") == reg1
+    assert reg_map.get_reg_by_offset(0xf) == reg0
+    assert reg_map.get_reg_by_offset(0xff) == reg1
 
 ##############################################################################
 # TESTS UVM_REG
@@ -132,7 +132,7 @@ def test_reg_configure():
     # START
     reg = temp_reg()
     parent = uvm_reg_block()
-    reg.configure(parent, "0x4", "")
+    reg.configure(parent, 0x4, "")
     assert reg.get_parent() == parent
 
 
@@ -228,16 +228,16 @@ def test_simple_reg_model():
             self.map = uvm_reg_map('map')
             self.map.configure(self, 0)
             self.LCR = LineControlRegister('LCR')
-            self.LCR.configure(self, "0x100c", "")
-            self.map.add_reg(self.LCR, "0x0")
+            self.LCR.configure(self, 0x100c, "")
+            self.map.add_reg(self.LCR, 0x0)
             self.LSR = LineStatusRegister('LSR')
-            self.LSR.configure(self, "0x1014", "")
-            self.map.add_reg(self.LSR, "0x0")
+            self.LSR.configure(self, 0x1014, "")
+            self.map.add_reg(self.LSR, 0x0)
 
     regs = Regs('regs')
     assert regs.get_name() == 'regs'
-    assert regs.map.get_reg_by_offset("0x100c") == regs.LCR
-    assert regs.map.get_reg_by_offset("0x1014") == regs.LSR
+    assert regs.map.get_reg_by_offset(0x100c) == regs.LCR
+    assert regs.map.get_reg_by_offset(0x1014) == regs.LSR
 
     LCR = regs.LCR
     assert LCR.get_name() == 'LCR'


### PR DESCRIPTION
This removes the functions _int2str and _hex2int that were previously used to store register addresses. 
Instead, values are now stored as plain integers, and a call to hex() is used when printing register maps with __str__