### PR TITLE
Add Pythonic method for raising and dropping objections

### DIFF
--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -82,7 +82,7 @@ class uvm_component(uvm_report_object):
 
             def __exit__(self, *args):
                 return self.component.drop_objection()
-            
+
         return Objection(self)
 
     def cdb_set(self, label, value, inst_path="*"):

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -72,6 +72,19 @@ class uvm_component(uvm_report_object):
     def drop_objection(self):
         utility_classes.ObjectionHandler().drop_objection(self)
 
+    def objection(self):
+        class Objection:
+            def __init__(self, component):
+                self.component = component
+
+            def __enter__(self):
+                return self.component.raise_objection()
+
+            def __exit__(self, *args):
+                return self.component.drop_objection()
+            
+        return Objection(self)
+
     def cdb_set(self, label, value, inst_path="*"):
         """
         Store an object in the config_db.


### PR DESCRIPTION
Adding this method allows users to raise objections using `with`, meaning that on any break from the loop, the objection will always be dropped.

Example usage:
```py
async def run_phase(self):
    with self.objection():
        print("run phase started")
        assert False
```

This also saves users from needing to debug a missing drop_objection, similar to Python's file opening and closing system.