### PR TITLE
Fix issues with current 2.0 support

### DIFF
--- a/pyuvm/_utils.py
+++ b/pyuvm/_utils.py
@@ -1,0 +1,9 @@
+import cocotb
+
+_cocotb_version_info = []
+for xx in cocotb.__version__.split("."):
+    try:
+        _cocotb_version_info.append(int(xx))  # for strings like 'dev0'
+    except ValueError:
+        pass
+cocotb_version_info = tuple(_cocotb_version_info)

--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -6,13 +6,36 @@
 # uvm_warning, and uvm_fatal, but it would be best to
 # first see how the native Python logging system does the job.
 
-from pyuvm.s05_base_classes import uvm_object
 import logging
 import sys
-from cocotb.log import SimTimeContextFilter
-from cocotb.log import SimLogFormatter, SimColourLogFormatter
-from cocotb.utils import want_color_output
-from logging import DEBUG, CRITICAL, ERROR, WARNING, INFO, NOTSET, NullHandler   # noqa: F401, E501
+
+from pyuvm._utils import cocotb_version_info
+from pyuvm.s05_base_classes import uvm_object
+
+if cocotb_version_info < (2, 0):
+    from cocotb.log import (
+        SimColourLogFormatter,
+        SimLogFormatter,
+        SimTimeContextFilter,
+    )
+    from cocotb.utils import want_color_output
+else:
+    from cocotb._utils import want_color_output
+    from cocotb.logging import (
+        SimColourLogFormatter,
+        SimLogFormatter,
+        SimTimeContextFilter,
+    )
+
+from logging import (  # noqa: F401, E501
+    CRITICAL,
+    DEBUG,
+    ERROR,
+    INFO,
+    NOTSET,
+    WARNING,
+    NullHandler,
+)
 
 
 class PyuvmFormatter(SimColourLogFormatter):

--- a/pyuvm/s13_uvm_component.py
+++ b/pyuvm/s13_uvm_component.py
@@ -1,17 +1,21 @@
+import fnmatch
+import logging
+import string
+
+from pyuvm import INFO, error_classes, utility_classes
+from pyuvm._utils import cocotb_version_info
 from pyuvm.s06_reporting_classes import uvm_report_object
 from pyuvm.s08_factory_classes import uvm_factory
-from pyuvm.s09_phasing import uvm_common_phases, uvm_run_phase, uvm_build_phase
-from pyuvm import error_classes, INFO
-from pyuvm import utility_classes
-import logging
-import fnmatch
-import string
-from cocotb.log import SimColourLogFormatter, SimTimeContextFilter
+from pyuvm.s09_phasing import uvm_build_phase, uvm_common_phases, uvm_run_phase
+
+if cocotb_version_info < (2, 0):
+    from cocotb.log import SimColourLogFormatter, SimTimeContextFilter
+else:
+    from cocotb.logging import SimColourLogFormatter, SimTimeContextFilter
 
 
 # 13.1.1
 class uvm_component(uvm_report_object):
-
     component_dict = {}
 
     @classmethod

--- a/tests/cocotb_tests/ext_classes/test.py
+++ b/tests/cocotb_tests/ext_classes/test.py
@@ -94,8 +94,3 @@ class AnalysisTest(uvm_test):
         assert self.data_list == self.subscriber.data
         assert self.data_list == self.export.data
         assert self.data_list == self.fifo.data
-
-
-@cocotb.test()
-async def run_test(_):
-    uvm_root().run_test(AnalysisTest)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters=true
 #envlist = py{35,36,37,38,39}-{linux,macos,windows},docs
 #envlist = py{37, 38}-{linux,macos,windows}
 # Updated to support range of Python versions
-envlist = py{35,36,37,38,39}-{linux,macos,windows}
+envlist = py{35,36,37,38,39,310,311,312,313}-{linux,macos,windows}
 
 # for the requires key
 minversion = 3.2.0


### PR DESCRIPTION
* `cocotb.log` module was renamed to `cocotb.logging` module to prevent shadowing the `cocotb.log` variable.
* `cocotb.test` now works in a different way so we don't have to put the Test object into the module. This should also make `TESTCASE` work correctly.