### PR TITLE
fix: predicton in uvm_reg_field

### DIFF
--- a/pyuvm/s19_uvm_reg_field.py
+++ b/pyuvm/s19_uvm_reg_field.py
@@ -358,7 +358,7 @@ class uvm_reg_field(uvm_object):
         if self.get_access() == "RO":
             self._field_mirrored = self._reset
         if self.get_access() == "RW":
-            self._field_mirrored = wr_val & _mask
+            self._field_mirrored = wr_val
         if self.get_access() == "RC":
             self._field_mirrored = self._field_mirrored
         if self.get_access() == "RS":
@@ -396,7 +396,7 @@ class uvm_reg_field(uvm_object):
         if self.get_access() == "W0CRS":
             self._field_mirrored = self._field_mirrored & wr_val
         if self.get_access() == "WO":
-            self._field_mirrored = wr_val & _mask
+            self._field_mirrored = wr_val
         if self.get_access() == "WOC":
             self._field_mirrored = 0
         if self.get_access() == "WOS":

--- a/pyuvm/s19_uvm_reg_field.py
+++ b/pyuvm/s19_uvm_reg_field.py
@@ -358,7 +358,7 @@ class uvm_reg_field(uvm_object):
         if self.get_access() == "RO":
             self._field_mirrored = self._reset
         if self.get_access() == "RW":
-            self._field_mirrored = wr_val
+            self._field_mirrored = wr_val & _mask
         if self.get_access() == "RC":
             self._field_mirrored = self._field_mirrored
         if self.get_access() == "RS":
@@ -396,7 +396,7 @@ class uvm_reg_field(uvm_object):
         if self.get_access() == "W0CRS":
             self._field_mirrored = self._field_mirrored & wr_val
         if self.get_access() == "WO":
-            self._field_mirrored = wr_val
+            self._field_mirrored = wr_val & _mask
         if self.get_access() == "WOC":
             self._field_mirrored = 0
         if self.get_access() == "WOS":

--- a/pyuvm/s20_uvm_reg.py
+++ b/pyuvm/s20_uvm_reg.py
@@ -165,7 +165,7 @@ class uvm_reg(uvm_object):
     def predict(self, value: int, direction: access_e):
         for f in self.get_fields():
             f.field_predict((
-                value >> f.get_lsb_pos()), path_t.FRONTDOOR, direction)
+                value >> f.get_lsb_pos() & ((1 << f.get_n_bits())-1)), path_t.FRONTDOOR, direction)
 
     # set prediction from parent to fields
     def set_prediction(self, pred_type: predict_t):

--- a/tests/pytests/test_uvm_ral.py
+++ b/tests/pytests/test_uvm_ral.py
@@ -135,7 +135,7 @@ def test_simple_reg_model():
 
     LSR.reset()
     assert LSR.get_mirrored_value() == 0
-    LSR.predict(32, access_e.UVM_WRITE)
-    assert LSR.get_mirrored_value() == 32
+    LSR.predict(12, access_e.UVM_WRITE)
+    assert LSR.get_mirrored_value() == 12
     for field in LSR.get_fields():
         print(field.get_value())

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -285,7 +285,7 @@ def test_simple_reg_model():
 
     LSR.reset()
     assert LSR.get_mirrored_value() == 0
-    LSR.predict(32, access_e.UVM_WRITE)
-    assert LSR.get_mirrored_value() == 32
+    LSR.predict(12, access_e.UVM_WRITE)
+    assert LSR.get_mirrored_value() == 12
     for field in LSR.get_fields():
         print(field.get_value())

--- a/tests/pytests/test_uvm_reg_map.py
+++ b/tests/pytests/test_uvm_reg_map.py
@@ -289,7 +289,7 @@ def test_simple_reg_model():
 
     LSR.reset()
     assert LSR.get_mirrored_value() == 0
-    LSR.predict(32, access_e.UVM_WRITE)
-    assert LSR.get_mirrored_value() == 32
+    LSR.predict(12, access_e.UVM_WRITE)
+    assert LSR.get_mirrored_value() == 12
     for field in LSR.get_fields():
         print(field.get_value())


### PR DESCRIPTION
Hello. I ran into a problem when using the automatic predictor in uvm_reg.  So, for example, I have a SCR__CTRL register containing two fields ARM [0] [RW] and RESERVED [31:1][RO]. When using uvm_reg.predict (0xFFFFFFFF, access_e.UVM_WRITE), I expect to get the value 0x1 from reg.get_mirrored_value(), but I get 0xFFFFFFFF. The problem is that an value is passed for each field in the register and for RW/WO it is not trimmed to the size of the field.  When predicting the ARM field, in its field.get_value we get 0xFFFF_FFFF, but we should get 0x1, since the field is one-bit. This received value overwrites the upper reserved bits [31:1] when calling reg.get_mirrored_value()

Here is an example of a verification scenario:

```
from pyuvm import *
import logging
import cocotb
class SCR__CTRL (uvm_reg):
    def __init__(self, name = "SCR__CTRL", reg_width = 32):
        super().__init__(name, reg_width)

    def build(self):
        self.ARM = uvm_reg_field("ARM")
        self.RESERVED = uvm_reg_field("RESERVED")
        self.ARM.configure(self, 1, 0, "RW", 1, 0x0)    
        self.RESERVED.configure(self, 31, 1, "RO", 1, 0x0)
        self.has_reset = 1

class REGBLOCK (uvm_reg_block):
    def __init__(self, name = "REGBLOCK"):
        super().__init__(name)
        self.default_map = uvm_reg_map('reg_map')
        self.default_map.configure(self, "0x0")
        self.CTRL = SCR__CTRL("CTRL")
        self.CTRL.configure(self, "0x10", "", False, False)
        self.default_map.add_reg(self.CTRL, "0x0", "RW")

reg_block = REGBLOCK("reg_block")
map       = reg_block.default_map
reg_dict  = map.get_registers()
map.reset("HARD")

for reg in reg_dict:
    if reg.get_access_policy() == "RW":
        write_data = 0xFFFF_FFFF
        reg.set_prediction(predict_t.PREDICT_DIRECT)
        reg.predict(write_data, access_e.UVM_WRITE)
        data_from_predict  = reg.get_mirrored_value()
        print(f"Write  data for register {reg.get_name()}  - {hex(write_data)} and prediction is  {hex(data_from_predict)}")
        for field in reg.get_fields():
            print(field)   
        assert data_from_predict == 0x1, f'data_from_predict {hex(data_from_predict)} is unvalid, expected 0x1'
```

![image](https://github.com/user-attachments/assets/a53c2cbd-2e7b-4496-b9e6-f5740cac981f)


![image](https://github.com/user-attachments/assets/444ec585-6763-4972-96a7-f3314be76183)
![image](https://github.com/user-attachments/assets/8db96a71-8c79-40b4-bd8b-2a1aa17ff775)

