### PR TITLE
Await task directly, instead of await'ing Join

### DIFF
--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -1,4 +1,4 @@
-from cocotb.triggers import Join, Combine
+from cocotb.triggers import Combine
 from pyuvm import *
 import random
 import cocotb
@@ -73,7 +73,7 @@ class TestAllForkSeq(uvm_sequence):
         max = MaxSeq("max")
         random_task = cocotb.start_soon(random.start(seqr))
         max_task = cocotb.start_soon(max.start(seqr))
-        await Combine(Join(random_task), Join(max_task))
+        await Combine(random_task, max_task)
 
 # Sequence library example
 

--- a/examples/TinyALU_reg/testbench.py
+++ b/examples/TinyALU_reg/testbench.py
@@ -17,7 +17,7 @@ from pyuvm import UVMNotImplemented
 from pyuvm import ConfigDB, uvm_root
 from pyuvm import CRITICAL
 from cocotb.clock import Clock
-from cocotb.triggers import Join, Combine
+from cocotb.triggers import Combine
 import random
 import cocotb
 import pyuvm
@@ -342,7 +342,7 @@ class TestAllForkSeq(AluReg_base_sequence):
         max = MaxSeq("max")
         random_task = cocotb.start_soon(random.start())
         max_task = cocotb.start_soon(max.start())
-        await Combine(Join(random_task), Join(max_task))
+        await Combine(random_task, max_task)
 
 
 class OpSeq(AluReg_base_sequence):


### PR DESCRIPTION
as this will be deprecated in cocotb 2.0, see cocotb commit 579bfa682cf9ec76646654fc8c7544d812c0cfc1

Fixes #232