### PR TITLE
Updated register base classes to use the uvm_object name properies and name methods instead of duplicates.

### DIFF
--- a/pyuvm/s19_uvm_reg_field.py
+++ b/pyuvm/s19_uvm_reg_field.py
@@ -80,7 +80,7 @@ class uvm_reg_field(uvm_object):
         # check the reset value is not beyond the MAX
         if (self._reset >= (2**self._size)):
             uvm_error(self._header, f"Reset value for REG \
-                      feild : {self._name} is [{self._reset}] \
+                      feild : {self.get_name()} is [{self._reset}] \
                       is beyond the MAX valoue given \
                       by the size [{((2**self._size)-1)}]")
         # Add field
@@ -122,7 +122,7 @@ class uvm_reg_field(uvm_object):
 
     # get_full_name
     def get_full_name(self):
-        return self._parent + "." + self._name
+        return self._parent.get_full_name() + "." + self.get_name()
 
     # get_parent
     def get_parent(self):

--- a/pyuvm/s20_uvm_reg.py
+++ b/pyuvm/s20_uvm_reg.py
@@ -20,7 +20,6 @@ class uvm_reg(uvm_object):
         self._desired: int = 0
         self._reset: int = 0
         self._sum: int = 0
-        self._name: str = name
         self._header: str = name + " -- "
         self._address: str = "0x0"
         self._path: str = ""
@@ -199,10 +198,6 @@ class uvm_reg(uvm_object):
             # placeholder to fix Flake8 line error
             value = (f.get_value() << f.get_lsb_pos())
             self._mirrored = self._mirrored | value
-
-    # get_name
-    def get_name(self) -> str:
-        return self._name
 
     # Build internal function
     def build(self):

--- a/pyuvm/s21_uvm_reg_map.py
+++ b/pyuvm/s21_uvm_reg_map.py
@@ -17,11 +17,10 @@ from pyuvm.s23_uvm_reg_item import uvm_reg_item
     4.  implement get_memories
     5.  implement get_virtual_registers
     6.  implement get_virtual_fields
-    7.  implement get_full_name
-    8.  implement get_mem_map_info
-    9.  implement get_reg_map_info
-    10. implement set_base_addr
-    11. implement get_size
+    7.  implement get_mem_map_info
+    8.  implement get_reg_map_info
+    9.  implement set_base_addr
+    10. implement get_size
 '''
 
 
@@ -35,7 +34,6 @@ class uvm_reg_map(uvm_object):
         # this is equivalent to offset in uvm map refernce
         self._offset = 0
         self._regs = {}
-        self.name = name
         self.header = name + " -- "
         self._submaps = {}
         # this is set in case of this map is a submap of another map
@@ -73,6 +71,10 @@ class uvm_reg_map(uvm_object):
     # gen_message
     def gen_message(self, txt="") -> str:
         return f"{self.header} {txt}"
+
+    # get_full_name
+    def get_full_name(self):
+        return self._parent.get_full_name() + "." + self.get_name()
 
     # get_parent
     def get_parent(self):
@@ -382,4 +384,4 @@ class uvm_reg_map(uvm_object):
                     self._parent    : {self._parent} \
                     self._offset    : {self._offset} \
                     self._regs      : {self._regs} \
-                    self.name       : {self.name }"
+                    self.name       : {self.get_name()}"


### PR DESCRIPTION
I ran into these problems when trying to read values from registers and logging the field names with the values. 
## `uvm_reg_field`
`uvm_reg_field` uses `self._name` as a duplicate of `uvm_object`'s `._obj_name`. This is changed to use `self.get_name()` method that every `uvm_object` has.
The method `self.get_full_name()` in `uvm_field_reg` called `self._parent` which produces the following error:
```bash
File "~/.venv/lib/python3.12/site-packages/pyuvm/s19_uvm_reg_field.py", line 125, in get_full_name
                                                            return self._parent + "." + self._name
                                                                   ~~~~~~~~~~~~~^~~~~
                                                        TypeError: unsupported operand type(s) for +: 'cl_dprio_reg' and 'str'
```
To fix this the `get_full_name()` method of the parent is called and the `get_name` method of the field.
## `uvm_reg_map`
`uvm_reg_map` also had a duplicate property `.name`, this was removed and the `get_full_name` method was updated.
## `uvm_reg`
`uvm_reg` also had a duplicate protpery `._name` this was removed and calls replaced with the `.get_name()` method