### PR TITLE
Implement pre_body and post_body for sequences

### DIFF
--- a/pyuvm/s06_reporting_classes.py
+++ b/pyuvm/s06_reporting_classes.py
@@ -52,6 +52,7 @@ class PyuvmFormatter(SimColourLogFormatter):
         :param record: The log record
 
         """
+        msg_temp = record.msg
         new_msg = f"[{self.full_name}]: {record.msg}"
         record.msg = new_msg
         name_temp = record.name
@@ -60,6 +61,7 @@ class PyuvmFormatter(SimColourLogFormatter):
             formatted_msg = super().format(record)
         else:
             formatted_msg = SimLogFormatter.format(self, record)
+        record.msg = msg_temp
         record.name = name_temp
         return formatted_msg
 

--- a/pyuvm/s14_15_python_sequences.py
+++ b/pyuvm/s14_15_python_sequences.py
@@ -386,17 +386,31 @@ class uvm_sequence(uvm_object):
         self.running_item = None
         self.sequence_id = id(self)
 
+    async def pre_body(self):
+        """
+        This function gets launced BEFORE the function body() is started following a start() call.
+        This method should not be called directly by the user.
+        """
+
+    async def post_body(self):
+        """
+        This function gets launced AFTER the function body() is started following a start() call.
+        This method should not be called directly by the user.
+        """
+
     async def body(self):
         """
         This function gets launched in a thread when you run start()
         You generally override it.
         """
 
-    async def start(self, seqr=None):
+    async def start(self, seqr=None, call_pre_post = True):
         """
         Launch this sequence on the sequencer. Seqr cannot be None.
 
         :param seqr: The sequencer to launch this sequence on.
+        :param call_pre_post: If set to true (default), then the pre_body and post_body
+        tasks will be called before and after the sequence body is called.
         :raise AssertionError: If seqr is None
 
         """
@@ -404,7 +418,11 @@ class uvm_sequence(uvm_object):
             assert (isinstance(seqr, uvm_sequencer)), \
                 "Tried to start a sequence with a non-sequencer"
         self.sequencer = seqr
+        if call_pre_post:
+            await self.pre_body()
         await self.body()
+        if call_pre_post:
+            await self.post_body()
 
     async def start_item(self, item):
         """

--- a/pyuvm/s14_15_python_sequences.py
+++ b/pyuvm/s14_15_python_sequences.py
@@ -408,7 +408,7 @@ class uvm_sequence(uvm_object):
         You generally override it.
         """
 
-    async def start(self, seqr=None, call_pre_post = True):
+    async def start(self, seqr=None, call_pre_post=True):
         """
         Launch this sequence on the sequencer. Seqr cannot be None.
 

--- a/pyuvm/s14_15_python_sequences.py
+++ b/pyuvm/s14_15_python_sequences.py
@@ -388,13 +388,17 @@ class uvm_sequence(uvm_object):
 
     async def pre_body(self):
         """
-        This function gets launced BEFORE the function body() is started following a start() call.
+        This function gets launced BEFORE the function body() is started
+        following a start() call.
+
         This method should not be called directly by the user.
         """
 
     async def post_body(self):
         """
-        This function gets launced AFTER the function body() is started following a start() call.
+        This function gets launced AFTER the function body() is started
+        following a start() call.
+
         This method should not be called directly by the user.
         """
 
@@ -409,8 +413,8 @@ class uvm_sequence(uvm_object):
         Launch this sequence on the sequencer. Seqr cannot be None.
 
         :param seqr: The sequencer to launch this sequence on.
-        :param call_pre_post: If set to true (default), then the pre_body and post_body
-        tasks will be called before and after the sequence body is called.
+        :param call_pre_post: If set to true (default), then pre_body and
+        post_body are called before and after the sequence body is called.
         :raise AssertionError: If seqr is None
 
         """


### PR DESCRIPTION
An improvement of the uvm_sequences by adding the `pre_body()` and `post_body()` functions, the implementation is based on the implementation in UVM.  As I have found that I'm missing the functionality given by the pre and post body of the sequences. Especially, when creating larger testbenches and multiple sequences to reduce the amount of repeated code across sequences. 

# Implementation
The implementation will automatically invoke the `pre_body()` before the `body()` and the `post_body()` after it. The implementation does not affect the behavior of sequences as is unless they are extended by the user.  The implementation has been done as close to the original UVM implementation as possible, see code below. 

The original UVM implementation :
```
if (call_pre_post == 1) begin
    m_sequence_state = UVM_PRE_BODY;
    #0;
    pre_body();
end

[...] body(); [...]

if (call_pre_post == 1) begin
    m_sequence_state = UVM_POST_BODY;
    #0;
    post_body();
end
```

The adapted pyuvm implementation:
```
        if call_pre_post:
            await self.pre_body()
        await self.body()
        if call_pre_post:
            await self.post_body()
```

Furthermore, I have created a test testing the implementation in `test_14_15_python_sequences.py`