### PR TITLE
uvm_reg_field methods refactoring

### DIFF
--- a/pyuvm/s19_uvm_reg_field.py
+++ b/pyuvm/s19_uvm_reg_field.py
@@ -327,64 +327,34 @@ class uvm_reg_field(uvm_object):
         # Define an all 1 values
         _mask = int("".join(["1"] * self._size), 2)
         # Return value based on the access type
-        if self.get_access() == "RO":
+        field_access = self.get_access()
+        if field_access in ("RO", "NOACCESS"):
             self._field_mirrored = self._reset
-        if self.get_access() == "RW":
+        elif field_access in ("RW", "WRC", "WRS", "WO"):
             self._field_mirrored = wr_val
-        if self.get_access() == "RC":
+        elif field_access in ("RC", "RS"):
             self._field_mirrored = self._field_mirrored
-        if self.get_access() == "RS":
-            self._field_mirrored = self._field_mirrored
-        if self.get_access() == "WC":
+        elif field_access in ("WC", "WCRS", "WOC"):
             self._field_mirrored = 0
-        if self.get_access() == "WS":
+        elif field_access in ("WS", "WSRC", "WOS"):
             self._field_mirrored = _mask
-        if self.get_access() == "WRC":
-            self._field_mirrored = wr_val
-        if self.get_access() == "WRS":
-            self._field_mirrored = wr_val
-        if self.get_access() == "WSRC":
-            self._field_mirrored = _mask
-        if self.get_access() == "WCRS":
-            self._field_mirrored = 0
-        if self.get_access() == "W1C":
+        elif field_access in ("W1C", "W1CRS"):
             self._field_mirrored = self._field_mirrored & (~wr_val)
-        if self.get_access() == "W1S":
+        elif field_access in ("W1S", "W1SRC"):
             self._field_mirrored = self._field_mirrored | wr_val
-        if self.get_access() == "W1T":
+        elif field_access == "W1T":
             self._field_mirrored = self._field_mirrored ^ wr_val
-        if self.get_access() == "W0C":
+        elif field_access in ("W0C", "W0CRS"):
             self._field_mirrored = self._field_mirrored & wr_val
-        if self.get_access() == "W0S":
+        elif field_access in ("W0S", "W0SRC"):
             self._field_mirrored = self._field_mirrored | (~wr_val & _mask)
-        if self.get_access() == "W0T":
+        elif field_access == "W0T":
             self._field_mirrored = self._field_mirrored ^ (~wr_val & _mask)
-        if self.get_access() == "W1SRC":
-            self._field_mirrored = self._field_mirrored | wr_val
-        if self.get_access() == "W1CRS":
-            self._field_mirrored = self._field_mirrored & (~wr_val)
-        if self.get_access() == "W0SRC":
-            self._field_mirrored = self._field_mirrored | (~wr_val & _mask)
-        if self.get_access() == "W0CRS":
-            self._field_mirrored = self._field_mirrored & wr_val
-        if self.get_access() == "WO":
-            self._field_mirrored = wr_val
-        if self.get_access() == "WOC":
-            self._field_mirrored = 0
-        if self.get_access() == "WOS":
-            self._field_mirrored = _mask
-        if self.get_access() == "W1":
+        elif field_access in ("W1", "WO1"):
             if self._has_been_writ is True:
                 self._field_mirrored = self._field_mirrored
             else:
                 self._field_mirrored = wr_val
-        if self.get_access() == "WO1":
-            if self._has_been_writ is True:
-                self._field_mirrored = self._field_mirrored
-            else:
-                self._field_mirrored = wr_val
-        if self.get_access() == "NOACCESS":
-            self._field_mirrored = self._reset
 
     # atomic predict value based on the operation (READ)
     # Where error is mentioned it depends on _error_on_read flag, no effect

--- a/pyuvm/s19_uvm_reg_field.py
+++ b/pyuvm/s19_uvm_reg_field.py
@@ -264,61 +264,33 @@ class uvm_reg_field(uvm_object):
         #
         #
 
+        field_access = self.get_access()
         # Return value based on the access
-        if self.get_access() == "RO":
+        if field_access in ("RO", "RC", "RS", "NOACCESS"):
             self._desired = self._desired  # Leave the desired value stable
-        if self.get_access() == "RW":
+        elif field_access in ("RW", "WRC", "WRS", "WO"):
             self._desired = value
-        if self.get_access() == "RC":
-            self._desired = self._desired  # Leave the desired value stable
-        if self.get_access() == "RS":
-            self._desired = self._desired  # Leave the desired value stable
-        if self.get_access() == "WC":
+        elif field_access in ("WC", "WCRS", "WOC"):
             self._desired = 0
-        if self.get_access() == "WS":
+        elif field_access in ("WS", "WSRC", "WOS"):
             self._desired = _mask
-        if self.get_access() == "WRC":
-            self._desired = value
-        if self.get_access() == "WRS":
-            self._desired = value
-        if self.get_access() == "WSRC":
-            self._desired = _mask
-        if self.get_access() == "WCRS":
-            self._desired = 0
-        if self.get_access() == "W1C":
+        elif field_access in ("W1C", "W1CRS"):
             self._desired = self._desired & (~value)
-        if self.get_access() == "W1S":
+        elif field_access in ("W1S", "W1SRC"):
             self._desired = self._desired | value
-        if self.get_access() == "W1T":
+        elif field_access == "W1T":
             self._desired = self._desired ^ value
-        if self.get_access() == "W0C":
+        elif field_access in ("W0C", "W0CRS"):
             self._desired = self._desired & value
-        if self.get_access() == "W0S":
+        elif field_access in ("W0S", "W0SRC"):
             self._desired = self._desired | (~value & _mask)
-        if self.get_access() == "W0T":
+        elif field_access == "W0T":
             self._desired = self._desired ^ (~value & _mask)
-        if self.get_access() == "W1SRC":
-            self._desired = self._desired | value
-        if self.get_access() == "W1CRS":
-            self._desired = self._desired & (~value)
-        if self.get_access() == "W0SRC":
-            self._desired = self._desired | (~value & _mask)
-        if self.get_access() == "W0CRS":
-            self._desired = self._desired & value
-        if self.get_access() == "WO":
+        elif field_access in ("W1", "WO1"):
+            if self._has_been_writ is False:
+                self._desired = value
+        else:
             self._desired = value
-        if self.get_access() == "WOC":
-            self._desired = 0
-        if self.get_access() == "WOS":
-            self._desired = _mask
-        if self.get_access() == "W1":
-            if self._has_been_writ is False:
-                self._desired = value
-        if self.get_access() == "WO1":
-            if self._has_been_writ is False:
-                self._desired = value
-        if self.get_access() == "NOACCESS":
-            self._desired = self._desired  # Leave the desired value stable
 
     # Since there is no Switch case in python we use a simple switch case
     # Where error is mentioned it depends on _error_on_write flag, no effect

--- a/pyuvm/s19_uvm_reg_field.py
+++ b/pyuvm/s19_uvm_reg_field.py
@@ -37,7 +37,7 @@ class uvm_reg_field(uvm_object):
         self._value = 0
         # Keep desired value as 0
         # TODO: add eventually support for PYVSC for randomization
-        self._desidered = 0
+        self._desired = 0
         self._config_done = False
         self._has_been_writ = False
         self._prediction = predict_t
@@ -63,7 +63,7 @@ class uvm_reg_field(uvm_object):
         # Ignore randomization if the field is known not to be writeable
         # i.e. not "RW", "WRC", "WRS", "WO", "W1", "WO1"
         # TODO: add eventually support for PYVSC for randomization
-        self._desidered = 0
+        self._desired = 0
         # Check if size is 0
         if (self._size == 0):
             uvm_fatal(self._header, "Size of a filed \
@@ -210,7 +210,7 @@ class uvm_reg_field(uvm_object):
 
     # atomic get value
     def get(self):
-        return self._desidered
+        return self._desired
 
     # atomic reset value
     def reset(self):
@@ -266,59 +266,59 @@ class uvm_reg_field(uvm_object):
 
         # Return value based on the access
         if self.get_access() == "RO":
-            self._desidered = self._desidered  # Leave the desired value stable
+            self._desired = self._desired  # Leave the desired value stable
         if self.get_access() == "RW":
-            self._desidered = value
+            self._desired = value
         if self.get_access() == "RC":
-            self._desidered = self._desidered  # Leave the desired value stable
+            self._desired = self._desired  # Leave the desired value stable
         if self.get_access() == "RS":
-            self._desidered = self._desidered  # Leave the desired value stable
+            self._desired = self._desired  # Leave the desired value stable
         if self.get_access() == "WC":
-            self._desidered = 0
+            self._desired = 0
         if self.get_access() == "WS":
-            self._desidered = _mask
+            self._desired = _mask
         if self.get_access() == "WRC":
-            self._desidered = value
+            self._desired = value
         if self.get_access() == "WRS":
-            self._desidered = value
+            self._desired = value
         if self.get_access() == "WSRC":
-            self._desidered = _mask
+            self._desired = _mask
         if self.get_access() == "WCRS":
-            self._desidered = 0
+            self._desired = 0
         if self.get_access() == "W1C":
-            self._desidered = self._desidered & (~value)
+            self._desired = self._desired & (~value)
         if self.get_access() == "W1S":
-            self._desidered = self._desidered | value
+            self._desired = self._desired | value
         if self.get_access() == "W1T":
-            self._desidered = self._desidered ^ value
+            self._desired = self._desired ^ value
         if self.get_access() == "W0C":
-            self._desidered = self._desidered & value
+            self._desired = self._desired & value
         if self.get_access() == "W0S":
-            self._desidered = self._desidered | (~value & _mask)
+            self._desired = self._desired | (~value & _mask)
         if self.get_access() == "W0T":
-            self._desidered = self._desidered ^ (~value & _mask)
+            self._desired = self._desired ^ (~value & _mask)
         if self.get_access() == "W1SRC":
-            self._desidered = self._desidered | value
+            self._desired = self._desired | value
         if self.get_access() == "W1CRS":
-            self._desidered = self._desidered & (~value)
+            self._desired = self._desired & (~value)
         if self.get_access() == "W0SRC":
-            self._desidered = self._desidered | (~value & _mask)
+            self._desired = self._desired | (~value & _mask)
         if self.get_access() == "W0CRS":
-            self._desidered = self._desidered & value
+            self._desired = self._desired & value
         if self.get_access() == "WO":
-            self._desidered = value
+            self._desired = value
         if self.get_access() == "WOC":
-            self._desidered = 0
+            self._desired = 0
         if self.get_access() == "WOS":
-            self._desidered = _mask
+            self._desired = _mask
         if self.get_access() == "W1":
             if self._has_been_writ is False:
-                self._desidered = value
+                self._desired = value
         if self.get_access() == "WO1":
             if self._has_been_writ is False:
-                self._desidered = value
+                self._desired = value
         if self.get_access() == "NOACCESS":
-            self._desidered = self._desidered  # Leave the desired value stable
+            self._desired = self._desired  # Leave the desired value stable
 
     # Since there is no Switch case in python we use a simple switch case
     # Where error is mentioned it depends on _error_on_write flag, no effect


### PR DESCRIPTION
Changes:
- Fixed typo: `_desidered` was replaced with `_desired`, according to the original UVM naming convention (https://github.com/nitronis/UVM/blob/main/1800.2-2020/src/reg/uvm_reg_field.svh#L49)
- The field_set method was refactored: used if-elif cascading to remove odd checks, added an else statement according to original SV UVM default case (https://github.com/nitronis/UVM/blob/main/1800.2-2020/src/reg/uvm_reg_field.svh#L929)
- Refactored the predict_based_on_write method in the same way