### PR TITLE
Updated to latest versions of python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,32 +13,11 @@ on:
 
 jobs:
 
-# I've moved flake into tox, so it should not be needed here.
-# I'll delete this code in a later version.
-
-#  lint-flake8:
-#    runs-on: ubuntu-latest
-#    name: flake8
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python-version: [3.8]
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Set up Python ${{matrix.python-version}}
-#      uses: actions/setup-python@v2
-#      with:
-#        python-version: ${{matrix.python-version}}
-#    - name: flake8
-#      continue-on-error: false
-#      run: |
-#        pip install flake8
-#        flake8 pyuvm
 
   tests:
 
     name: Python ${{matrix.python-version}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ results.xml
 sim_build
 docs/_build/*
 docs/generated/*
+examples/TinyALU/e~tinyalu.o
+examples/TinyALU/tinyalu

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,22 @@ lint:
 	@pylint pyuvm
 
 .PHONY: test
-test:
+pytests:
 	pytest tests/pytests
+
+cocotb_tests:
+	make -C tests/cocotb_tests/queue sim checkclean
+	make -C tests/cocotb_tests/run_phase sim checkclean
+	make -C tests/cocotb_tests/decorator sim checkclean
+	make -C tests/cocotb_tests/t05_base_classes sim checkclean
+	make -C tests/cocotb_tests/t08_factories sim checkclean
+	make -C tests/cocotb_tests/t09_phasing sim checkclean
+	make -C tests/cocotb_tests/t12_tlm sim checkclean
+	make -C tests/cocotb_tests/t13_components sim checkclean
+	make -C tests/cocotb_tests/config_db sim checkclean
+	make -C tests/cocotb_tests/t14_15_sequences sim checkclean
+	make -C tests/cocotb_tests/ext_classes sim checkclean
+	make -C examples/TinyALU sim checkclean
+	make -C examples/TinyALU_reg sim checkclean
+	make SIM=ghdl TOPLEVEL_LANG=vhdl -C examples/TinyALU sim checkclean
+

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -65,7 +65,7 @@ class uvm_reg_block(uvm_object):
 
     # gen_message
     def gen_message(self, txt="") -> str:
-        return f"{self.header,txt}"
+        return f"{self.header, txt}"
 
     # clear_hdl_path
     def clear_hdl_path(self, kind="RTL"):
@@ -271,16 +271,16 @@ class uvm_reg_block(uvm_object):
     # similar to convert2string
     def __str__(self) -> str:
         return f"   {self.gen_message} \
-                    self._regs          : {self._regs      } \
-                    self.def_map        : {self.def_map    } \
-                    self._is_locked     : {self._is_locked } \
-                    self.hdl_paths      : {self.hdl_paths  } \
-                    self.fields         : {self.fields     } \
-                    self.root_path      : {self.root_path  } \
-                    self.child_blk      : {self.child_blk  } \
-                    self.maps           : {self.maps       } \
-                    self.parent_blk     : {self.parent_blk } \
-                    self.blk_maping     : {self.blk_maping } \
+                    self._regs          : {self._regs} \
+                    self.def_map        : {self.def_map} \
+                    self._is_locked     : {self._is_locked} \
+                    self.hdl_paths      : {self.hdl_paths} \
+                    self.fields         : {self.fields} \
+                    self.root_path      : {self.root_path} \
+                    self.child_blk      : {self.child_blk} \
+                    self.maps           : {self.maps} \
+                    self.parent_blk     : {self.parent_blk} \
+                    self.blk_maping     : {self.blk_maping} \
                     self.map_mapping    : {self.map_mapping} \
                     self.reg_mapping    : {self.reg_mapping} \
-                    self.blk_name       : {self.blk_name   }"
+                    self.blk_name       : {self.blk_name}"

--- a/pyuvm/s19_uvm_reg_field.py
+++ b/pyuvm/s19_uvm_reg_field.py
@@ -82,7 +82,7 @@ class uvm_reg_field(uvm_object):
             uvm_error(self._header, f"Reset value for REG \
                       feild : {self.get_name()} is [{self._reset}] \
                       is beyond the MAX valoue given \
-                      by the size [{((2**self._size)-1)}]")
+                      by the size [{((2**self._size) - 1)}]")
         # Add field
         parent._add_field(self)
 

--- a/pyuvm/s20_uvm_reg.py
+++ b/pyuvm/s20_uvm_reg.py
@@ -146,7 +146,7 @@ class uvm_reg(uvm_object):
                 error_out(self._header, f"_add_field: \
                 Fields {field.get_name()} overlap \
                 with field \
-                {self._fields[self._fields.index(field)-1].get_name()}")
+                {self._fields[self._fields.index(field) - 1].get_name()}")
                 self._add_error(
                     uvm_reg_error_decoder.FIELD_OVERLAPPING_ERROR.name)
 

--- a/pyuvm/s24_uvm_reg_includes.py
+++ b/pyuvm/s24_uvm_reg_includes.py
@@ -129,7 +129,7 @@ def uvm_error(header="", message=""):
     '''
     Used to error out based on header and message
     '''
-    raise UVMError(f"{header+message}")
+    raise UVMError(f"{header + message}")
 
 
 #
@@ -138,7 +138,7 @@ def uvm_fatal(header="", message=""):
     Used to fatal out based on header and message
     '''
     if (disable_code_interruption_fatal is False):
-        raise UVMFatalError(f"{header+message}")
+        raise UVMFatalError(f"{header + message}")
 
 
 #
@@ -147,7 +147,7 @@ def uvm_not_implemeneted(header="", message=""):
     Used to fatal out based on header and message
     '''
     if (disable_code_interruption_fatal is False):
-        raise UVMNotImplemented(f"{header+message}")
+        raise UVMNotImplemented(f"{header + message}")
 
 
 #

--- a/tox.ini
+++ b/tox.ini
@@ -59,20 +59,6 @@ commands =
     flake8 pyuvm
     make pytests
     make cocotb_tests
-#    make -C tests/cocotb_tests/queue sim checkclean
-#    make -C tests/cocotb_tests/run_phase sim checkclean
-#    make -C tests/cocotb_tests/decorator sim checkclean
-#    make -C tests/cocotb_tests/t05_base_classes sim checkclean
-#    make -C tests/cocotb_tests/t08_factories sim checkclean
-#    make -C tests/cocotb_tests/t09_phasing sim checkclean
-#    make -C tests/cocotb_tests/t12_tlm sim checkclean
-#    make -C tests/cocotb_tests/t13_components sim checkclean
-#    make -C tests/cocotb_tests/config_db sim checkclean
-#    make -C tests/cocotb_tests/t14_15_sequences sim checkclean
-#    make -C tests/cocotb_tests/ext_classes sim checkclean
-#    make -C examples/TinyALU sim checkclean
-#    make -C examples/TinyALU_reg sim checkclean
-#    make SIM=ghdl TOPLEVEL_LANG=vhdl -C examples/TinyALU sim checkclean
 
 tox_fail_on_error = true
 # needed for coverage to work

--- a/tox.ini
+++ b/tox.ini
@@ -57,21 +57,22 @@ install_command =
 
 commands =
     flake8 pyuvm
-    make test
-    make -C tests/cocotb_tests/queue sim checkclean
-    make -C tests/cocotb_tests/run_phase sim checkclean
-    make -C tests/cocotb_tests/decorator sim checkclean
-    make -C tests/cocotb_tests/t05_base_classes sim checkclean
-    make -C tests/cocotb_tests/t08_factories sim checkclean
-    make -C tests/cocotb_tests/t09_phasing sim checkclean
-    make -C tests/cocotb_tests/t12_tlm sim checkclean
-    make -C tests/cocotb_tests/t13_components sim checkclean
-    make -C tests/cocotb_tests/config_db sim checkclean
-    make -C tests/cocotb_tests/t14_15_sequences sim checkclean
-    make -C tests/cocotb_tests/ext_classes sim checkclean
-    make -C examples/TinyALU sim checkclean
-    make -C examples/TinyALU_reg sim checkclean
-    make SIM=ghdl TOPLEVEL_LANG=vhdl -C examples/TinyALU sim checkclean
+    make pytests
+    make cocotb_tests
+#    make -C tests/cocotb_tests/queue sim checkclean
+#    make -C tests/cocotb_tests/run_phase sim checkclean
+#    make -C tests/cocotb_tests/decorator sim checkclean
+#    make -C tests/cocotb_tests/t05_base_classes sim checkclean
+#    make -C tests/cocotb_tests/t08_factories sim checkclean
+#    make -C tests/cocotb_tests/t09_phasing sim checkclean
+#    make -C tests/cocotb_tests/t12_tlm sim checkclean
+#    make -C tests/cocotb_tests/t13_components sim checkclean
+#    make -C tests/cocotb_tests/config_db sim checkclean
+#    make -C tests/cocotb_tests/t14_15_sequences sim checkclean
+#    make -C tests/cocotb_tests/ext_classes sim checkclean
+#    make -C examples/TinyALU sim checkclean
+#    make -C examples/TinyALU_reg sim checkclean
+#    make SIM=ghdl TOPLEVEL_LANG=vhdl -C examples/TinyALU sim checkclean
 
 tox_fail_on_error = true
 # needed for coverage to work


### PR DESCRIPTION
The latest version of python 3.13 had upgrades that caused flake8 errors. We were creating python code in fstrings that was not flake8 compliant. These were ignored in the past, but flake8 catches them when running with the latest versions of python.

Also, for some reason, I was not using ubuntu-latest. That is fixed now.