### PR TITLE
Fix deprecations warnings from 2.0

### DIFF
--- a/examples/TinyALU_reg/testbench.py
+++ b/examples/TinyALU_reg/testbench.py
@@ -592,7 +592,7 @@ class AluTestBase(uvm_test):
 
         if LANGUAGE == "verilog":
             # Start clock
-            clock = Clock(cocotb.top.clk, 1, units="ns")
+            clock = Clock(cocotb.top.clk, 1, "ns")
             cocotb.start_soon(clock.start())
 
         await self.test_all.start()

--- a/examples/TinyALU_reg/tinyalu_utils.py
+++ b/examples/TinyALU_reg/tinyalu_utils.py
@@ -60,7 +60,7 @@ class TinyAluBfm(metaclass=utility_classes.Singleton):
         self.dut.addr.value = sw_addr
         await FallingEdge(self.dut.clk)
         self.dut.valid.value = 0
-        return self.dut.rdata.value.integer
+        return int(self.dut.rdata.value)
 
     async def SW_WRITE(self, sw_addr: int, sw_data: int):
         await FallingEdge(self.dut.clk)
@@ -90,19 +90,19 @@ class TinyAluBfm(metaclass=utility_classes.Singleton):
         return hex(self.dut.addr.value)
 
     def get_src0(self):
-        return self.dut.regblock.SRC_data0_q.value.integer
+        return int(self.dut.regblock.SRC_data0_q.value)
 
     def get_src1(self):
-        return self.dut.regblock.SRC_data1_q.value.integer
+        return int(self.dut.regblock.SRC_data1_q.value)
 
     def get_op(self):
         if (self.dut.regblock.CMD_op_q.value != 0):
-            return Ops(self.dut.regblock.CMD_op_q.value.integer)
+            return Ops(int(self.dut.regblock.CMD_op_q.value))
         else:
             return 0
 
     def get_result(self):
-        return self.dut.result.value.integer
+        return int(self.dut.result.value)
 
     def get_reset(self):
         return self.dut.reset_n.value

--- a/pyuvm/s14_15_python_sequences.py
+++ b/pyuvm/s14_15_python_sequences.py
@@ -101,7 +101,7 @@ class ResponseQueue(UVMQueue):
 
     def __init__(self, maxsize: int = 0):
         super().__init__(maxsize=maxsize)
-        self.put_event = CocotbEvent("put event")
+        self.put_event = CocotbEvent()
 
     def put_nowait(self, item):
         """

--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -225,7 +225,7 @@ class ObjectionHandler(metaclass=Singleton):
 
     def __init__(self):
         self.__objections = {}
-        self._objection_event = Event("objection changed")
+        self._objection_event = Event()
         self.objection_raised = False
         self.run_phase_done_flag = None  # used in test suites
         self.printed_warning = False
@@ -293,7 +293,7 @@ class UVMQueue(cocotb.queue.Queue):
         If the queue is empty, wait until an item is available.
         """
         while self.empty():
-            event = Event('{} peek'.format(type(self).__name__))
+            event = Event()
             self._getters.append((event, current_task()))
             await event.wait()
         return self.peek_nowait()

--- a/scratch/dut_cocotb.py
+++ b/scratch/dut_cocotb.py
@@ -48,7 +48,7 @@ def run_test(test):
 
 @cocotb.test()
 async def test_alu(dut):
-    clock = Clock(dut.clk, 2, units="us")
+    clock = Clock(dut.clk, 2, "us")
     cocotb.start_soon(clock.start())
     bfm = CocoTBBFM(dut)
     stim = test_sw.Stim(5,dut, bfm)

--- a/tests/cocotb_tests/config_db/test.py
+++ b/tests/cocotb_tests/config_db/test.py
@@ -37,7 +37,7 @@ async def run_tests(dut):
 @cocotb.test()  # pylint: disable=no-value-for-parameter
 async def test_12_tlm(dut):
     """Tests the TLM FIFOS"""
-    clock = Clock(dut.clk, 2, units="us")
+    clock = Clock(dut.clk, 2, "us")
     cocotb.start_soon(clock.start())
     await run_tests(dut)
 

--- a/tests/cocotb_tests/ext_classes/test_ext_classes.py
+++ b/tests/cocotb_tests/ext_classes/test_ext_classes.py
@@ -5,7 +5,7 @@ from cocotb.triggers import Timer
 
 
 async def waitabit(abit=5):
-    await Timer(1, units="us")
+    await Timer(1, "us")
 class s12_uvm_tlm_interfaces_TestCase(uvm_unittest.uvm_TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -597,7 +597,7 @@ class s12_uvm_tlm_interfaces_TestCase(uvm_unittest.uvm_TestCase):
         self.assertFalse(success)
         self.assertIsNone(data)
         cocotb.start_soon(self.do_nonblocking_put(pp, put_data))
-        await Timer(1, units="us")
+        await Timer(1, "us")
         self.assertTrue(pk.can_peek())
         await self.do_nonblocking_peek(gpp, peek_data)
         success, data = peek_data.pop()

--- a/tests/cocotb_tests/queue/test.py
+++ b/tests/cocotb_tests/queue/test.py
@@ -87,7 +87,7 @@ def run_uvm_test(test_name):
 # noinspection PyArgumentList,PyAsyncCall
 # @cocotb.test()
 async def test_alu(dut):
-    clock = Clock(dut.clk, 2, units="us")
+    clock = Clock(dut.clk, 2, "us")
     cocotb.start_soon(clock.start())
     proxy = CocotbProxy(dut, "PROXY")
     await proxy.reset()
@@ -144,7 +144,7 @@ async def delay_peek(qq, delay):
 @cocotb.test()
 async def wait_on_queue(dut):
     """Test put and get with waits"""
-    clock = Clock(dut.clk, 2, units="us") #make the simualtor wait
+    clock = Clock(dut.clk, 2, "us")  # make the simulator wait
     cocotb.start_soon(clock.start())
     qq = utility_classes.UVMQueue(maxsize=1)
     send_data = [

--- a/tests/cocotb_tests/run_phase/test.py
+++ b/tests/cocotb_tests/run_phase/test.py
@@ -24,7 +24,7 @@ class my_no_objection(uvm_test):
 class nested_parent(uvm_test):
     async def run_phase(self):
         self.raise_objection()
-        await Timer(1, units="ms")
+        await Timer(1, "ms")
         self.drop_objection()
 
 
@@ -32,11 +32,11 @@ class nested_objections(nested_parent):
     async def run_phase(self):
         self.raise_objection()
         await super().run_phase()
-        await Timer(10, units="ms")
+        await Timer(10, "ms")
         self.drop_objection()
 
     def check_phase(self):
-        assert get_sim_time(units="ms") > 10
+        assert get_sim_time("ms") > 10
 
 
 class TopTest(uvm_test):
@@ -46,7 +46,7 @@ class TopTest(uvm_test):
 
     async def run_phase(self):
         self.raise_objection()
-        await Timer(10, units="ms")
+        await Timer(10, "ms")
         self.drop_objection()
 
 
@@ -58,12 +58,12 @@ class SubComponent(uvm_component):
         self.raise_objection()
 
         # sub component takes longer than TopTest
-        await Timer(50, units="ms")
+        await Timer(50, "ms")
 
         self.drop_objection()
 
     def check_phase(self):
-        assert get_sim_time(units="ms") >= 50
+        assert get_sim_time("ms") >= 50
 
 
 @cocotb.test()

--- a/tests/cocotb_tests/t12_tlm/test_12_uvm_tlm_interfaces.py
+++ b/tests/cocotb_tests/t12_tlm/test_12_uvm_tlm_interfaces.py
@@ -5,7 +5,7 @@ from cocotb.triggers import Timer
 
 
 async def waitabit(abit=5):
-    await Timer(1, units="us")
+    await Timer(1, "us")
 class s12_uvm_tlm_interfaces_TestCase(uvm_unittest.uvm_TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -597,7 +597,7 @@ class s12_uvm_tlm_interfaces_TestCase(uvm_unittest.uvm_TestCase):
         self.assertFalse(success)
         self.assertIsNone(data)
         cocotb.start_soon(self.do_nonblocking_put(pp, put_data))
-        await Timer(1, units="us")
+        await Timer(1, "us")
         self.assertTrue(pk.can_peek())
         await self.do_nonblocking_peek(gpp, peek_data)
         success, data = peek_data.pop()

--- a/tests/cocotb_tests/t13_components/test.py
+++ b/tests/cocotb_tests/t13_components/test.py
@@ -35,7 +35,7 @@ async def run_tests(dut):
 @cocotb.test() # pylint: disable=no-value-for-parameter
 async def test_12_tlm(dut):
     """Tests the TLM FIFOS"""
-    clock = Clock(dut.clk, 2, units="us")
+    clock = Clock(dut.clk, 2, "us")
     cocotb.start_soon(clock.start())
     await run_tests(dut)
 

--- a/tests/cocotb_tests/t14_15_sequences/test.py
+++ b/tests/cocotb_tests/t14_15_sequences/test.py
@@ -37,6 +37,6 @@ async def run_tests(dut):
 @cocotb.test()  # pylint: disable=no-value-for-parameter
 async def test_14_sequences(dut):
     """Tests the Sequences"""
-    clock = Clock(dut.clk, 2, units="us")
+    clock = Clock(dut.clk, 2, "us")
     cocotb.start_soon(clock.start())
     await run_tests(dut)

--- a/tests/cocotb_tests/t14_15_sequences/test_14_15_python_sequences.py
+++ b/tests/cocotb_tests/t14_15_sequences/test_14_15_python_sequences.py
@@ -487,24 +487,24 @@ class py1415_sequence_TestCase(uvm_unittest.uvm_TestCase):
 
             async def run_phase(self):
                 while True:
-                    await Timer(self.start_delay_ns, units="ns")
+                    await Timer(self.start_delay_ns, "ns")
                     op_item = await self.seq_item_port.get_next_item()
                     op_item.result = op_item.data + 1
-                    await Timer(self.finish_delay_ns, units="ns")
+                    await Timer(self.finish_delay_ns, "ns")
                     self.seq_item_port.item_done()
 
         class Seq(uvm_sequence):
             async def body(self):
                 op = SeqItem("op")
-                DataHolder().start_item_call_time = get_sim_time(units="ns")
+                DataHolder().start_item_call_time = get_sim_time("ns")
                 uvm_root().logger.info("CALLING START_ITEM")
                 await self.start_item(op)
                 uvm_root().logger.info("BACK FROM START_ITEM")
-                DataHolder().start_item_return_time = get_sim_time(units="ns")
+                DataHolder().start_item_return_time = get_sim_time("ns")
                 op.data = 0
-                DataHolder().finish_item_call_time = get_sim_time(units="ns")
+                DataHolder().finish_item_call_time = get_sim_time("ns")
                 await self.finish_item(op)
-                DataHolder().finish_item_return_time = get_sim_time(units="ns")
+                DataHolder().finish_item_return_time = get_sim_time("ns")
                 DataHolder().datum = (op.result == (op.data + 1))
 
         class SeqTest(uvm_test):


### PR DESCRIPTION
This fixes all code causing a DeprecationWarning in 2.0 while still supporting 1.x

* `units` was renamed to `unit`
* `LogicArray.integer` was deprecated
* `Event` doesn't take a name anymore (to match asyncio)