### PR TITLE
uvm_reg_block methods fix

### DIFF
--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -167,8 +167,9 @@ class uvm_reg_block(uvm_object):
                                        be locked"))
         return local_reg_collector
 
-    # blk_get_fields
-    def blk_get_fields(self) -> list:
+    # get_fields
+    # 18.1.3.8
+    def get_fields(self) -> list:
         local_field_collector = []
         for r in self.get_registers():
             local_field_collector.append(r.get_fields())

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -151,8 +151,9 @@ class uvm_reg_block(uvm_object):
         else:
             self.parent_blk + "." + self.blk_name
 
-    # blk_get_registers
-    def _get_registers(self) -> list:
+    # get_registers
+    # 18.1.3.7
+    def get_registers(self) -> list:
         local_reg_collector = []
         if self.is_locked() is True:
             for r in self._regs:
@@ -160,16 +161,16 @@ class uvm_reg_block(uvm_object):
                     local_reg_collector.append(r)
             if len(self.child_blk) != 0:
                 for b in self.child_blk:
-                    local_reg_collector.append(b.blk_get_registers())
+                    local_reg_collector.append(b.get_registers())
         else:
-            uvm_fatal(self.gen_message("_get_registers -- register block must \
+            uvm_fatal(self.gen_message("get_registers -- register block must \
                                        be locked"))
         return local_reg_collector
 
     # blk_get_fields
     def blk_get_fields(self) -> list:
         local_field_collector = []
-        for r in self.blk_get_registers():
+        for r in self.get_registers():
             local_field_collector.append(r.get_fields())
         return local_field_collector
 

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -154,15 +154,16 @@ class uvm_reg_block(uvm_object):
 
     # get_registers
     # 18.1.3.7
-    def get_registers(self) -> list:
+    def get_registers(self, hier = uvm_hier_e.UVM_HIER) -> list:
         local_reg_collector = []
         if self.is_locked() is True:
             for r in self._regs:
                 if self.blk_is_reg_mapped(r) is True:
                     local_reg_collector.append(r)
-            if len(self.child_blk) != 0:
+            if (hier == uvm_hier_e.UVM_HIER) and (len(self.child_blk) != 0):
                 for b in self.child_blk:
-                    local_reg_collector.append(b.get_registers())
+                    for r in b.get_registers(hier):
+                        local_reg_collector.append(r)
         else:
             uvm_fatal(self.gen_message("get_registers -- register block must \
                                        be locked"))
@@ -172,12 +173,12 @@ class uvm_reg_block(uvm_object):
     # 18.1.3.8
     def get_fields(self, hier = uvm_hier_e.UVM_HIER) -> list:
         local_field_collector = []
-        for r in self.get_registers():
+        for r in self.get_registers(hier):
             for f in r.get_fields():
                 local_field_collector.append(f)
         if hier == uvm_hier_e.UVM_HIER:
             for blk in self.get_all_child_blk():
-                for f in blk.get_fields():
+                for f in blk.get_fields(hier):
                     local_field_collector.append(f)
         return local_field_collector
 

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -154,7 +154,7 @@ class uvm_reg_block(uvm_object):
 
     # get_registers
     # 18.1.3.7
-    def get_registers(self, hier = uvm_hier_e.UVM_HIER) -> list:
+    def get_registers(self, hier=uvm_hier_e.UVM_HIER) -> list:
         local_reg_collector = []
         if self.is_locked() is True:
             for r in self._regs:
@@ -171,7 +171,7 @@ class uvm_reg_block(uvm_object):
 
     # get_fields
     # 18.1.3.8
-    def get_fields(self, hier = uvm_hier_e.UVM_HIER) -> list:
+    def get_fields(self, hier=uvm_hier_e.UVM_HIER) -> list:
         local_field_collector = []
         for r in self.get_registers(hier):
             for f in r.get_fields():
@@ -186,7 +186,7 @@ class uvm_reg_block(uvm_object):
     def get_all_child_blk(self) -> list:
         local_blk_collector = []
         for b in self.child_blk:
-            if (self.blk_is_child_mapped(b) is True):
+            if self.blk_is_child_mapped(b) is True:
                 local_blk_collector.append(b)
                 local_blk_collector.append(b.get_all_child_blk())
         return local_blk_collector

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -172,7 +172,8 @@ class uvm_reg_block(uvm_object):
     def get_fields(self) -> list:
         local_field_collector = []
         for r in self.get_registers():
-            local_field_collector.append(r.get_fields())
+            for f in r.get_fields():
+                local_field_collector.append(f)
         return local_field_collector
 
     # get_all_child_blk

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -2,6 +2,7 @@ from pyuvm import uvm_object
 from pyuvm.s20_uvm_reg import uvm_reg
 from pyuvm.s21_uvm_reg_map import uvm_reg_map
 from pyuvm.s24_uvm_reg_includes import uvm_fatal, uvm_not_implemeneted
+from pyuvm.s17_uvm_reg_enumerations import uvm_hier_e
 
 '''
     TODO: the following must be completed
@@ -169,11 +170,15 @@ class uvm_reg_block(uvm_object):
 
     # get_fields
     # 18.1.3.8
-    def get_fields(self) -> list:
+    def get_fields(self, hier = uvm_hier_e.UVM_HIER) -> list:
         local_field_collector = []
         for r in self.get_registers():
             for f in r.get_fields():
                 local_field_collector.append(f)
+        if hier == uvm_hier_e.UVM_HIER:
+            for blk in self.get_all_child_blk():
+                for f in blk.get_fields():
+                    local_field_collector.append(f)
         return local_field_collector
 
     # get_all_child_blk

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -109,7 +109,7 @@ def test_reg_block_with_sub_blocks():
             self.def_map = uvm_reg_map("blk_1_map")
             self.def_map.configure(self, 0)
 
-            self.reg0 = temp_reg_3("TEST_REG_1")
+            self.reg0 = temp_reg_3("test_reg_3")
             self.reg0.configure(self, "0xC", "")
             self.def_map.add_reg(self.reg0, "0x0", 'RW')
     # START
@@ -148,10 +148,10 @@ def test_reg_block_get_field_single_reg():
     class temp_reg(uvm_reg):
         def __init__(self, name="temp_reg", reg_width=32):
             super().__init__(name, reg_width)
-            self.TEST_FIELD_1 = uvm_reg_field("TEST_FIELD_1")
+            self.test_field_1 = uvm_reg_field("test_field_1")
 
         def build(self):
-            self.TEST_FIELD_1.configure(self, 8, 0, 'RW', 0, 0)
+            self.test_field_1.configure(self, 8, 0, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
     # START
@@ -159,7 +159,7 @@ def test_reg_block_get_field_single_reg():
     reg0 = temp_reg()
     reg0.configure(block, "0x4", "")
     block.set_lock()
-    assert block.get_fields() == [reg0.TEST_FIELD_1]
+    assert block.get_fields() == [reg0.test_field_1]
 
 
 @pytest.mark.reg_block_get_field_multiple_regs
@@ -168,26 +168,26 @@ def test_reg_block_get_field_multiple_regs():
     class temp_reg_1(uvm_reg):
         def __init__(self, name="temp_reg_1", reg_width=32):
             super().__init__(name, reg_width)
-            self.TEST_FIELD_1 = uvm_reg_field("TEST_FIELD_1")
-            self.TEST_FIELD_2 = uvm_reg_field("TEST_FIELD_2")
+            self.test_field_1 = uvm_reg_field("test_field_1")
+            self.test_field_2 = uvm_reg_field("test_field_2")
 
         def build(self):
-            self.TEST_FIELD_1.configure(self, 8, 0, 'RW', 0, 0)
-            self.TEST_FIELD_2.configure(self, 16, 8, 'RW', 0, 0)
+            self.test_field_1.configure(self, 8, 0, 'RW', 0, 0)
+            self.test_field_2.configure(self, 16, 8, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
     # SECOND REGISTER
     class temp_reg_2(uvm_reg):
         def __init__(self, name="temp_reg_2", reg_width=32):
             super().__init__(name, reg_width)
-            self.TEST_FIELD_3 = uvm_reg_field("TEST_FIELD_3")
-            self.TEST_FIELD_4 = uvm_reg_field("TEST_FIELD_4")
-            self.TEST_FIELD_5 = uvm_reg_field("TEST_FIELD_5")
+            self.test_field_3 = uvm_reg_field("test_field_3")
+            self.test_field_4 = uvm_reg_field("test_field_4")
+            self.test_field_5 = uvm_reg_field("test_field_5")
 
         def build(self):
-            self.TEST_FIELD_3.configure(self, 8, 0, 'RW', 0, 0)
-            self.TEST_FIELD_4.configure(self, 8, 8, 'RW', 0, 0)
-            self.TEST_FIELD_5.configure(self, 8, 16, 'RW', 0, 0)
+            self.test_field_3.configure(self, 8, 0, 'RW', 0, 0)
+            self.test_field_4.configure(self, 8, 8, 'RW', 0, 0)
+            self.test_field_5.configure(self, 8, 16, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
     # START
@@ -197,7 +197,7 @@ def test_reg_block_get_field_multiple_regs():
     reg1 = temp_reg_2()
     reg1.configure(block, "0x8", "")
     block.set_lock()
-    assert block.get_fields() == [reg0.TEST_FIELD_1, reg0.TEST_FIELD_2, reg1.TEST_FIELD_3, reg1.TEST_FIELD_4, reg1.TEST_FIELD_5]
+    assert block.get_fields() == [reg0.test_field_1, reg0.test_field_2, reg1.test_field_3, reg1.test_field_4, reg1.test_field_5]
 
 
 @pytest.mark.reg_block_get_field_sub_reg_block
@@ -206,38 +206,38 @@ def test_reg_block_get_field_sub_reg_block():
     class temp_reg_1(uvm_reg):
         def __init__(self, name="temp_reg_1", reg_width=32):
             super().__init__(name, reg_width)
-            self.TEST_FIELD_1 = uvm_reg_field("TEST_FIELD_1")
-            self.TEST_FIELD_2 = uvm_reg_field("TEST_FIELD_2")
+            self.test_field_1 = uvm_reg_field("test_field_1")
+            self.test_field_2 = uvm_reg_field("test_field_2")
 
         def build(self):
-            self.TEST_FIELD_1.configure(self, 8, 0, 'RW', 0, 0)
-            self.TEST_FIELD_2.configure(self, 16, 8, 'RW', 0, 0)
+            self.test_field_1.configure(self, 8, 0, 'RW', 0, 0)
+            self.test_field_2.configure(self, 16, 8, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
     # SECOND REGISTER
     class temp_reg_2(uvm_reg):
         def __init__(self, name="temp_reg_2", reg_width=32):
             super().__init__(name, reg_width)
-            self.TEST_FIELD_3 = uvm_reg_field("TEST_FIELD_3")
-            self.TEST_FIELD_4 = uvm_reg_field("TEST_FIELD_4")
-            self.TEST_FIELD_5 = uvm_reg_field("TEST_FIELD_5")
+            self.test_field_3 = uvm_reg_field("test_field_3")
+            self.test_field_4 = uvm_reg_field("test_field_4")
+            self.test_field_5 = uvm_reg_field("test_field_5")
 
         def build(self):
-            self.TEST_FIELD_3.configure(self, 8, 0, 'RW', 0, 0)
-            self.TEST_FIELD_4.configure(self, 8, 8, 'RW', 0, 0)
-            self.TEST_FIELD_5.configure(self, 8, 16, 'RW', 0, 0)
+            self.test_field_3.configure(self, 8, 0, 'RW', 0, 0)
+            self.test_field_4.configure(self, 8, 8, 'RW', 0, 0)
+            self.test_field_5.configure(self, 8, 16, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
     # THIRD REGISTER
     class temp_reg_3(uvm_reg):
         def __init__(self, name="temp_reg_3", reg_width=32):
             super().__init__(name, reg_width)
-            self.TEST_FIELD_6 = uvm_reg_field("TEST_FIELD_6")
-            self.TEST_FIELD_7 = uvm_reg_field("TEST_FIELD_7")
+            self.test_field_6 = uvm_reg_field("test_field_6")
+            self.test_field_7 = uvm_reg_field("test_field_7")
 
         def build(self):
-            self.TEST_FIELD_6.configure(self, 8, 0, 'RW', 0, 0)
-            self.TEST_FIELD_7.configure(self, 8, 8, 'RW', 0, 0)
+            self.test_field_6.configure(self, 8, 0, 'RW', 0, 0)
+            self.test_field_7.configure(self, 8, 8, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
     # SUB REG BLOCK
@@ -247,9 +247,9 @@ def test_reg_block_get_field_sub_reg_block():
             self.def_map = uvm_reg_map("blk_1_map")
             self.def_map.configure(self, 0)
 
-            self.TEST_REG_1 = temp_reg_3("TEST_REG_1")
-            self.TEST_REG_1.configure(self, "0xC", "")
-            self.def_map.add_reg(self.TEST_REG_1, "0x0", 'RW')
+            self.test_reg_1 = temp_reg_3("test_reg_3")
+            self.test_reg_1.configure(self, "0xC", "")
+            self.def_map.add_reg(self.test_reg_1, "0x0", 'RW')
     # START
     block = uvm_reg_block()
     reg0 = temp_reg_1()
@@ -260,8 +260,8 @@ def test_reg_block_get_field_sub_reg_block():
     blk0.set_lock()
     block.add_block(blk0)
     block.set_lock()
-    assert block.get_fields() == [reg0.TEST_FIELD_1, reg0.TEST_FIELD_2, reg1.TEST_FIELD_3, reg1.TEST_FIELD_4, reg1.TEST_FIELD_5, blk0.TEST_REG_1.TEST_FIELD_6, blk0.TEST_REG_1.TEST_FIELD_7]
-    assert block.get_fields(hier=uvm_hier_e.UVM_NO_HIER) == [reg0.TEST_FIELD_1, reg0.TEST_FIELD_2, reg1.TEST_FIELD_3, reg1.TEST_FIELD_4, reg1.TEST_FIELD_5]
+    assert block.get_fields() == [reg0.test_field_1, reg0.test_field_2, reg1.test_field_3, reg1.test_field_4, reg1.test_field_5, blk0.test_reg_1.test_field_6, blk0.test_reg_1.test_field_7]
+    assert block.get_fields(hier=uvm_hier_e.UVM_NO_HIER) == [reg0.test_field_1, reg0.test_field_2, reg1.test_field_3, reg1.test_field_4, reg1.test_field_5]
 
 
 def test_reg_map_get_name():

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -56,7 +56,6 @@ def test_reg_block_with_single_reg():
     assert block.get_registers() == [reg]
 
 
-
 @pytest.mark.reg_block_with_multiple_regs
 def test_reg_block_with_multiple_regs():
     class temp_reg(uvm_reg):
@@ -76,8 +75,8 @@ def test_reg_block_with_multiple_regs():
     assert block.get_registers() == [reg0, reg1]
 
 
-@pytest.mark.reg_block_get_field_name_empty_reg
-def test_reg_block_get_field_name_empty_reg():
+@pytest.mark.reg_block_get_field_empty_reg
+def test_reg_block_get_field_empty_reg():
     class temp_reg(uvm_reg):
         def __init__(self, name="temp_reg", reg_width=32):
             super().__init__(name, reg_width)
@@ -93,8 +92,8 @@ def test_reg_block_get_field_name_empty_reg():
     assert block.get_fields() == []
 
 
-@pytest.mark.reg_block_get_field_name_single_reg
-def test_reg_block_get_field_name_single_reg():
+@pytest.mark.reg_block_get_field_single_reg
+def test_reg_block_get_field_single_reg():
     class temp_reg(uvm_reg):
         def __init__(self, name="temp_reg", reg_width=32):
             super().__init__(name, reg_width)
@@ -112,8 +111,8 @@ def test_reg_block_get_field_name_single_reg():
     assert block.get_fields() == [reg0.TEST_FIELD_1]
 
 
-@pytest.mark.reg_block_get_field_name_multiple_regs
-def test_reg_block_get_field_name_multiple_regs():
+@pytest.mark.reg_block_get_field_multiple_regs
+def test_reg_block_get_field_multiple_regs():
     # FIRST REGISTER
     class temp_reg_1(uvm_reg):
         def __init__(self, name="temp_reg_1", reg_width=32):

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -102,7 +102,7 @@ def test_reg_block_with_sub_blocks():
         def build(self):
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
-    # BLOCK
+    # SUB REG BLOCK
     class temp_blk_1(uvm_reg_block):
         def __init__(self, name="temp_blk_1"):
             super().__init__(name)
@@ -228,6 +228,7 @@ def test_reg_block_get_field_sub_reg_block():
             self.TEST_FIELD_5.configure(self, 8, 16, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
+    # THIRD REGISTER
     class temp_reg_3(uvm_reg):
         def __init__(self, name="temp_reg_3", reg_width=32):
             super().__init__(name, reg_width)
@@ -239,7 +240,7 @@ def test_reg_block_get_field_sub_reg_block():
             self.TEST_FIELD_7.configure(self, 8, 8, 'RW', 0, 0)
             self._set_lock()
             self.set_prediction(predict_t.PREDICT_DIRECT)
-    # BLOCK
+    # SUB REG BLOCK
     class temp_blk_1(uvm_reg_block):
         def __init__(self, name="temp_blk_1"):
             super().__init__(name)

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -76,6 +76,80 @@ def test_reg_block_with_multiple_regs():
     assert block.get_registers() == [reg0, reg1]
 
 
+@pytest.mark.reg_block_get_field_name_empty_reg
+def test_reg_block_get_field_name_empty_reg():
+    class temp_reg(uvm_reg):
+        def __init__(self, name="temp_reg", reg_width=32):
+            super().__init__(name, reg_width)
+
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # START
+    block = uvm_reg_block()
+    reg0 = temp_reg()
+    reg0.configure(block, "0x4", "")
+    block.set_lock()
+    assert block.get_fields() == []
+
+
+@pytest.mark.reg_block_get_field_name_single_reg
+def test_reg_block_get_field_name_single_reg():
+    class temp_reg(uvm_reg):
+        def __init__(self, name="temp_reg", reg_width=32):
+            super().__init__(name, reg_width)
+            self.TEST_FIELD_1 = uvm_reg_field("TEST_FIELD_1")
+
+        def build(self):
+            self.TEST_FIELD_1.configure(self, 8, 0, 'RW', 0, 0)
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # START
+    block = uvm_reg_block()
+    reg0 = temp_reg()
+    reg0.configure(block, "0x4", "")
+    block.set_lock()
+    assert block.get_fields() == [reg0.TEST_FIELD_1]
+
+
+@pytest.mark.reg_block_get_field_name_multiple_regs
+def test_reg_block_get_field_name_multiple_regs():
+    # FIRST REGISTER
+    class temp_reg_1(uvm_reg):
+        def __init__(self, name="temp_reg_1", reg_width=32):
+            super().__init__(name, reg_width)
+            self.TEST_FIELD_1 = uvm_reg_field("TEST_FIELD_1")
+            self.TEST_FIELD_2 = uvm_reg_field("TEST_FIELD_2")
+
+        def build(self):
+            self.TEST_FIELD_1.configure(self, 8, 0, 'RW', 0, 0)
+            self.TEST_FIELD_2.configure(self, 16, 8, 'RW', 0, 0)
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # SECOND REGISTER
+    class temp_reg_2(uvm_reg):
+        def __init__(self, name="temp_reg_2", reg_width=32):
+            super().__init__(name, reg_width)
+            self.TEST_FIELD_3 = uvm_reg_field("TEST_FIELD_3")
+            self.TEST_FIELD_4 = uvm_reg_field("TEST_FIELD_4")
+            self.TEST_FIELD_5 = uvm_reg_field("TEST_FIELD_5")
+
+        def build(self):
+            self.TEST_FIELD_3.configure(self, 8, 0, 'RW', 0, 0)
+            self.TEST_FIELD_4.configure(self, 8, 8, 'RW', 0, 0)
+            self.TEST_FIELD_5.configure(self, 8, 16, 'RW', 0, 0)
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # START
+    block = uvm_reg_block()
+    reg0 = temp_reg_1()
+    reg0.configure(block, "0x4", "")
+    reg1 = temp_reg_2()
+    reg1.configure(block, "0x8", "")
+    block.set_lock()
+    assert block.get_fields() == [reg0.TEST_FIELD_1, reg0.TEST_FIELD_2, reg1.TEST_FIELD_3, reg1.TEST_FIELD_4, reg1.TEST_FIELD_5]
+
+
 def test_reg_map_get_name():
     map_with_explicit_name = uvm_reg_map('some_map')
     assert map_with_explicit_name.get_name() == 'some_map'

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -76,6 +76,56 @@ def test_reg_block_with_multiple_regs():
     assert block.get_registers() == [reg0, reg1]
 
 
+@pytest.mark.reg_block_with_sub_blocks
+def test_reg_block_with_sub_blocks():
+    # FIRST REGISTER
+    class temp_reg_1(uvm_reg):
+        def __init__(self, name="temp_reg_1", reg_width=32):
+            super().__init__(name, reg_width)
+
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # SECOND REGISTER
+    class temp_reg_2(uvm_reg):
+        def __init__(self, name="temp_reg_2", reg_width=32):
+            super().__init__(name, reg_width)
+
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # THIRD REGISTER
+    class temp_reg_3(uvm_reg):
+        def __init__(self, name="temp_reg_3", reg_width=32):
+            super().__init__(name, reg_width)
+
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # BLOCK
+    class temp_blk_1(uvm_reg_block):
+        def __init__(self, name="temp_blk_1"):
+            super().__init__(name)
+            self.def_map = uvm_reg_map("blk_1_map")
+            self.def_map.configure(self, 0)
+
+            self.reg0 = temp_reg_3("TEST_REG_1")
+            self.reg0.configure(self, "0xC", "")
+            self.def_map.add_reg(self.reg0, "0x0", 'RW')
+    # START
+    block = uvm_reg_block()
+    reg0 = temp_reg_1()
+    reg0.configure(block, "0x4", "")
+    reg1 = temp_reg_2()
+    reg1.configure(block, "0x8", "")
+    blk0 = temp_blk_1()
+    blk0.set_lock()
+    block.add_block(blk0)
+    block.set_lock()
+    assert block.get_registers() == [reg0, reg1, blk0.reg0]
+    assert block.get_registers(hier=uvm_hier_e.UVM_NO_HIER) == [reg0, reg1]
+
+
 @pytest.mark.reg_block_get_field_empty_reg
 def test_reg_block_get_field_empty_reg():
     class temp_reg(uvm_reg):

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -53,7 +53,8 @@ def test_reg_block_with_single_reg():
     reg = temp_reg()
     reg.configure(block, "0x4", "")
     block.set_lock()
-    assert block._get_registers() == [reg]
+    assert block.get_registers() == [reg]
+
 
 
 @pytest.mark.reg_block_with_multiple_regs
@@ -72,7 +73,7 @@ def test_reg_block_with_multiple_regs():
     reg1 = temp_reg()
     reg1.configure(block, "0x8", "")
     block.set_lock()
-    assert block._get_registers() == [reg0, reg1]
+    assert block.get_registers() == [reg0, reg1]
 
 
 def test_reg_map_get_name():

--- a/tests/pytests/test_uvm_reg_map.py
+++ b/tests/pytests/test_uvm_reg_map.py
@@ -53,7 +53,7 @@ def test_reg_block_with_single_reg():
     reg = temp_reg()
     reg.configure(block, "0x4", "")
     block.set_lock()
-    assert block._get_registers() == [reg]
+    assert block.get_registers() == [reg]
 
 
 @pytest.mark.test_reg_block_with_multiple_regs
@@ -72,7 +72,7 @@ def test_reg_block_with_multiple_regs():
     reg1 = temp_reg()
     reg1.configure(block, "0x8", "")
     block.set_lock()
-    assert block._get_registers() == [reg0, reg1]
+    assert block.get_registers() == [reg0, reg1]
 
 
 @pytest.mark.test_reg_map_get_name


### PR DESCRIPTION
Changes:
- The method `_get_registers()` has been renamed to `get_registers()`, as it is named in the specification "IEEE Standard for Universal Verification Methodology Language Reference Manual (Revision of IEEE Std 1800.2-2017)". A comment with the section number for this method has been added. All usages of that method were fixed. It seems that `_get_registers()` was previously called `blk_get_registers()`, so it was also renamed to `get_registers()`.

- The method `_blk_get_fields()` has been renamed to `get_fields()`, as it is named in the UVM Specification. A comment with the section number for this method has been added.

- Previously, the methods `get_fields()` and `get_registers()` returned a nested list. This has been fixed, and now the methods return flat lists, as specified in UVM.

- Added the `hier` argument to both methods and rewrote some logic for it, since it exists in the UVM Specification method definitions (sections 18.1.3.7 and 18.1.3.8).

- Added tests for `get_fields()` and `get_registers()`:
   - `test_reg_block_with_sub_blocks()` - tests `get_field()` in a reg block with sub reg block (checks that the hier argument works).
   - `test_reg_block_get_field_empty_reg()` - tests `get_field()` when the reg block is empty.
   - `test_reg_block_get_field_single_reg()` - tests `get_field()` with the reg block contains one register.
   - `test_reg_block_get_field_multiple_regs()` - tests `get_field()` with the reg block contains more than one register.
   - `test_reg_block_get_field_sub_reg_block()` - tests `get_field()` with the reg block contains a sub reg block (checks that the hier argument works).