### PR TITLE
Improvement of get_by_name methods in uvm_reg_block

### DIFF
--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -243,16 +243,8 @@ class uvm_reg_block(uvm_object):
     # get_field_by_name
     # 18.1.3.15
     def get_field_by_name(self, namei: str) -> uvm_reg_field:
-        for r in self._regs:
-            for f in r.get_fields():
-                if f.get_name() == namei:
-                    return f
-        for b in self.child_blk:
-            for r in b.get_registers():
-                for f in r.get_fields():
-                    if f.get_name() == namei:
-                        return f
-        return None
+        field_list = list(filter(lambda l: l.get_name() == namei, self.get_fields()))
+        return field_list[0] if field_list else None
 
     # set_coverage
     def set_coverage(self, is_on: bool):

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -1,5 +1,6 @@
 from pyuvm import uvm_object
 from pyuvm.s20_uvm_reg import uvm_reg
+from pyuvm.s19_uvm_reg_field import uvm_reg_field
 from pyuvm.s21_uvm_reg_map import uvm_reg_map
 from pyuvm.s24_uvm_reg_includes import uvm_fatal, uvm_not_implemeneted
 from pyuvm.s17_uvm_reg_enumerations import uvm_hier_e
@@ -240,6 +241,20 @@ class uvm_reg_block(uvm_object):
             # TODO: search into child_blk maps
         else:
             return None
+
+    # get_field_by_name
+    # 18.1.3.15
+    def get_field_by_name(self, namei: str) -> uvm_reg_field:
+        for r in self._regs:
+            for f in r.get_fields():
+                if f.get_name() == namei:
+                    return f
+        for b in self.child_blk:
+            for r in b.get_registers():
+                for f in r.get_fields():
+                    if f.get_name() == namei:
+                        return f
+        return None
 
     # set_coverage
     def set_coverage(self, is_on: bool):

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -237,13 +237,15 @@ class uvm_reg_block(uvm_object):
     # get_reg_by_name
     # 18.1.3.14
     def get_reg_by_name(self, namei: str) -> uvm_reg:
-        reg_list = list(filter(lambda r: r.get_name() == namei, self.get_registers()))
+        reg_list = list(filter(lambda reg: reg.get_name() == namei,
+                               self.get_registers()))
         return reg_list[0] if reg_list else None
 
     # get_field_by_name
     # 18.1.3.15
     def get_field_by_name(self, namei: str) -> uvm_reg_field:
-        field_list = list(filter(lambda l: l.get_name() == namei, self.get_fields()))
+        field_list = list(filter(lambda field: field.get_name() == namei,
+                                 self.get_fields()))
         return field_list[0] if field_list else None
 
     # set_coverage

--- a/pyuvm/s18_uvm_reg_block.py
+++ b/pyuvm/s18_uvm_reg_block.py
@@ -235,12 +235,10 @@ class uvm_reg_block(uvm_object):
             return None
 
     # get_reg_by_name
-    def get_reg_by_name(self, namei: str):
-        if self.reg_mapping[namei] == 1:
-            return [r for r in self._regs if (r.get_name() == namei)]
-            # TODO: search into child_blk maps
-        else:
-            return None
+    # 18.1.3.14
+    def get_reg_by_name(self, namei: str) -> uvm_reg:
+        reg_list = list(filter(lambda r: r.get_name() == namei, self.get_registers()))
+        return reg_list[0] if reg_list else None
 
     # get_field_by_name
     # 18.1.3.15

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -296,7 +296,83 @@ def test_reg_map_with_multiple_regs():
     assert reg_map.get_reg_by_offset("0xf") == reg0
     assert reg_map.get_reg_by_offset("0xff") == reg1
 
+@pytest.mark.reg_block_get_reg_by_name
+def test_reg_block_get_reg_by_name():
+    # FIRST REGISTER
+    class temp_reg_1(uvm_reg):
+        def __init__(self, name="temp_reg_1", reg_width=32):
+            super().__init__(name, reg_width)
 
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # SECOND REGISTER
+    class temp_reg_2(uvm_reg):
+        def __init__(self, name="temp_reg_2", reg_width=32):
+            super().__init__(name, reg_width)
+
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # THIRD REGISTER
+    class temp_reg_3(uvm_reg):
+        def __init__(self, name="temp_reg_3", reg_width=32):
+            super().__init__(name, reg_width)
+
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # FOUTH REGISTER
+    class temp_reg_4(uvm_reg):
+        def __init__(self, name="temp_reg_4", reg_width=32):
+            super().__init__(name, reg_width)
+
+        def build(self):
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # FIRST SUB REG BLOCK
+    class temp_blk_1(uvm_reg_block):
+        def __init__(self, name="temp_blk_1"):
+            super().__init__(name)
+            self.def_map = uvm_reg_map("blk_1_map")
+            self.def_map.configure(self, 0)
+
+            self.reg0 = temp_reg_2()
+            self.reg0.configure(self, "0x8", "")
+            self.reg1 = temp_reg_3()
+            self.reg1.configure(self, "0xC", "")
+            self.def_map.add_reg(self.reg0, "0x0", 'RW')
+            self.def_map.add_reg(self.reg1, "0x0", 'RW')
+    # SECOND SUB REG BLOCK
+    class temp_blk_2(uvm_reg_block):
+        def __init__(self, name="temp_blk_2"):
+            super().__init__(name)
+            self.def_map = uvm_reg_map("blk_2_map")
+            self.def_map.configure(self, 0)
+
+            self.reg0 = temp_reg_4()
+            self.reg0.configure(self, "0x10", "")
+            self.def_map.add_reg(self.reg0, "0x0", 'RW')
+
+            self.blk1 = temp_blk_1()
+            self.blk1.set_lock()
+            self.add_block(self.blk1)
+    block = uvm_reg_block()
+    reg0 = temp_reg_1()
+    reg0.configure(block, "0x4", "")
+    blk0 = temp_blk_2()
+    blk0.set_lock()
+    block.add_block(blk0)
+    block.set_lock()
+
+    print(type(block.get_reg_by_name("temp_reg_1")))
+    assert block.get_reg_by_name("temp_reg_1") == reg0
+    assert block.get_reg_by_name("temp_reg_2") == blk0.blk1.reg0
+    assert block.get_reg_by_name("temp_reg_3") == blk0.blk1.reg1
+    assert block.get_reg_by_name("temp_reg_4") == blk0.reg0
+    assert block.get_reg_by_name("temp_reg_X") == None
+
+@pytest.mark.reg_block_get_field_by_name
 def test_reg_block_get_field_by_name():
     # FIRST REGISTER
     class temp_reg_1(uvm_reg):

--- a/tests/pytests/test_uvm_reg_block.py
+++ b/tests/pytests/test_uvm_reg_block.py
@@ -296,6 +296,99 @@ def test_reg_map_with_multiple_regs():
     assert reg_map.get_reg_by_offset("0xf") == reg0
     assert reg_map.get_reg_by_offset("0xff") == reg1
 
+
+def test_reg_block_get_field_by_name():
+    # FIRST REGISTER
+    class temp_reg_1(uvm_reg):
+        def __init__(self, name="temp_reg_1", reg_width=32):
+            super().__init__(name, reg_width)
+            self.fieldA = uvm_reg_field("fieldA")
+            self.fieldB = uvm_reg_field("fieldB")
+
+        def build(self):
+            self.fieldA.configure(self, 8, 0, 'RW', 0, 0)
+            self.fieldB.configure(self, 16, 8, 'RW', 0, 0)
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # SECOND REGISTER
+    class temp_reg_2(uvm_reg):
+        def __init__(self, name="temp_reg_2", reg_width=32):
+            super().__init__(name, reg_width)
+            self.fieldC = uvm_reg_field("fieldC")
+            self.fieldD = uvm_reg_field("fieldD")
+            self.fieldE = uvm_reg_field("fieldE")
+
+        def build(self):
+            self.fieldC.configure(self, 8, 0, 'RW', 0, 0)
+            self.fieldD.configure(self, 8, 8, 'RW', 0, 0)
+            self.fieldE.configure(self, 8, 16, 'RW', 0, 0)
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # THIRD REGISTER
+    class temp_reg_3(uvm_reg):
+        def __init__(self, name="temp_reg_3", reg_width=32):
+            super().__init__(name, reg_width)
+            self.fieldF = uvm_reg_field("fieldF")
+            self.fieldG = uvm_reg_field("fieldG")
+
+        def build(self):
+            self.fieldF.configure(self, 8, 0, 'RW', 0, 0)
+            self.fieldG.configure(self, 8, 8, 'RW', 0, 0)
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # FOUTH REGISTER
+    class temp_reg_4(uvm_reg):
+        def __init__(self, name="temp_reg_4", reg_width=32):
+            super().__init__(name, reg_width)
+            self.fieldH = uvm_reg_field("fieldH")
+            self.fieldI = uvm_reg_field("fieldI")
+
+        def build(self):
+            self.fieldH.configure(self, 8, 0, 'RW', 0, 0)
+            self.fieldI.configure(self, 8, 8, 'RW', 0, 0)
+            self._set_lock()
+            self.set_prediction(predict_t.PREDICT_DIRECT)
+    # FIRST SUB REG BLOCK
+    class temp_blk_1(uvm_reg_block):
+        def __init__(self, name="temp_blk_1"):
+            super().__init__(name)
+            self.def_map = uvm_reg_map("blk_1_map")
+            self.def_map.configure(self, 0)
+
+            self.reg0 = temp_reg_2("reg2")
+            self.reg0.configure(self, "0x8", "")
+            self.reg1 = temp_reg_3("reg3")
+            self.reg1.configure(self, "0xC", "")
+            self.def_map.add_reg(self.reg0, "0x0", 'RW')
+            self.def_map.add_reg(self.reg1, "0x0", 'RW')
+    # SECOND SUB REG BLOCK
+    class temp_blk_2(uvm_reg_block):
+        def __init__(self, name="temp_blk_2"):
+            super().__init__(name)
+            self.def_map = uvm_reg_map("blk_2_map")
+            self.def_map.configure(self, 0)
+
+            self.reg0 = temp_reg_4("reg4")
+            self.reg0.configure(self, "0x10", "")
+            self.def_map.add_reg(self.reg0, "0x0", 'RW')
+
+            self.blk1 = temp_blk_1()
+            self.blk1.set_lock()
+            self.add_block(self.blk1)
+    # START
+    block = uvm_reg_block()
+    reg0 = temp_reg_1()
+    reg0.configure(block, "0x4", "")
+    blk0 = temp_blk_2()
+    blk0.set_lock()
+    block.add_block(blk0)
+    block.set_lock()
+    assert block.get_field_by_name("fieldB") == reg0.fieldB
+    assert block.get_field_by_name("fieldC") == blk0.blk1.reg0.fieldC
+    assert block.get_field_by_name("fieldF") == blk0.blk1.reg1.fieldF
+    assert block.get_field_by_name("fieldH") == blk0.reg0.fieldH
+    assert block.get_field_by_name("fieldX") == None
+
 ##############################################################################
 # TESTS UVM_REG
 ##############################################################################


### PR DESCRIPTION
Changes:
- Added the method `get_field_by_name()`, based on the specification "IEEE Standard for Universal Verification Methodology Language Reference Manual (Revision of IEEE Std 1800.2-2017)". A comment with the corresponding section number has been added.

- Rewrote the method `get_reg_by_name()` according to the UVM specification. A comment with the corresponding section number has been added.

- Added tests for `get_field_by_name()` and `get_reg_by_name()`:
   - test_reg_block_get_reg_by_name()
   - test_reg_block_get_field_by_name()