### PR TITLE
Add docstrings to uvm classes and methods

### DIFF
--- a/pyuvm/s13_predefined_component_classes.py
+++ b/pyuvm/s13_predefined_component_classes.py
@@ -122,6 +122,15 @@ class uvm_monitor(uvm_component):
 
 # 13.6
 class uvm_scoreboard(uvm_component):
+    """
+    This class should be used as the base class for user-defined scoreboards.
+
+    Deriving from :class:`!uvm_scoreboard` will allow you to distinguish
+    scoreboards from other component types inheriting directly from
+    :class:`~uvm_component`. Such scoreboards will automatically inherit and
+    benefit from features that may be added to :class:`!uvm_scoreboard` in the
+    future.
+    """
     ...
 
 

--- a/pyuvm/s13_predefined_component_classes.py
+++ b/pyuvm/s13_predefined_component_classes.py
@@ -45,7 +45,10 @@ class uvm_test(uvm_component):
 # 13.3
 class uvm_env(uvm_component):
     """
-    A container for agents and what-not
+    The base class for hierarchical containers of other components that
+    together comprise a complete environment. The environment may
+    initially consist of the entire testbench. Later, it can be reused as
+    a sub-environment in even larger system-level environments.
     """
 
 

--- a/pyuvm/s13_predefined_component_classes.py
+++ b/pyuvm/s13_predefined_component_classes.py
@@ -171,6 +171,16 @@ class uvm_driver(uvm_component):
 
 # 13.9
 class uvm_subscriber(uvm_component):
+    """
+    This class provides an analysis export for receiving transactions from a
+    connected analysis export. Making such a connection "subscribes" this
+    component to any transactions emitted by the connected analysis port.
+
+    Subtypes of this class must define the write method to process the
+    incoming transactions. This class is particularly useful when designing a
+    coverage collector that attaches to a monitor.
+    """
+
     class uvm_AnalysisImp(uvm_analysis_export):
         def __init__(self, name, parent, write_fn):
             super().__init__(name, parent)
@@ -194,7 +204,8 @@ class uvm_subscriber(uvm_component):
 
     def write(self, tt):
         """
-        Force the user to implement the write method.
+        Method that must be defined in each subclass. Access to this method by
+        outside components should be done via the :any:`analysis_export`.
         """
         raise error_classes.UVMFatalError(
             "You must override the write() method in"

--- a/pyuvm/s13_predefined_component_classes.py
+++ b/pyuvm/s13_predefined_component_classes.py
@@ -109,6 +109,14 @@ class uvm_agent(uvm_component):
 
 # 13.5
 class uvm_monitor(uvm_component):
+    """
+    This class should be used as the base class for user-defined monitors.
+
+    Deriving from :class:`!uvm_monitor` allows you to distinguish monitors
+    from generic component types inheriting from :class:`~uvm_component`. Such
+    monitors will automatically inherit features that may be added to
+    :class:`!uvm_monitor` in the future.
+    """
     ...
 
 

--- a/pyuvm/s13_predefined_component_classes.py
+++ b/pyuvm/s13_predefined_component_classes.py
@@ -136,8 +136,30 @@ class uvm_scoreboard(uvm_component):
 
 # 13.7
 class uvm_driver(uvm_component):
+    """
+    The base class for drivers that initiate requests for new transactions via
+    a :class:`~uvm_seq_item_pull_port`. The ports are typically connected to
+    the exports of an appropriate sequencer component.
+
+    This driver operates in pull mode. Its ports are typically connected to
+    the corresponding exports in a pull sequencer as follows:
+
+    .. code-block:: python
+
+        driver.seq_item_port.connect(sequencer.seq_item_export)
+        driver.rsp_port.connect(sequencer.rsp_export)
+
+    The ``rsp_port`` needs connecting only if the driver will use it to write
+    responses to the analysis export in the sequencer.
+    """
 
     def __init__(self, name, parent):
+        """
+        Creates and initializes an instance of this class using the normal
+        constructor arguments for :class:`~uvm_component`: *name* is the name
+        of the instance, and *parent* is the handle to the hierarchical
+        parent, if any.
+        """
         super().__init__(name, parent)
         self.seq_item_port = uvm_seq_item_port("seq_item_port", self)
 

--- a/pyuvm/s13_predefined_component_classes.py
+++ b/pyuvm/s13_predefined_component_classes.py
@@ -55,7 +55,17 @@ class uvm_env(uvm_component):
 # 13.4
 class uvm_agent(uvm_component):
     """
-    Contains controls for individual agents
+    The :class:`!uvm_agent` virtual class should be used as the base class for
+    the user-defined agents. Deriving from :class:`!uvm_agent` will allow you
+    to distinguish agents from other component types also using its
+    inheritance. Such agents will automatically inherit features that may be
+    added to :class:`!uvm_agent` in the future.
+
+    While an agent's build function, inherited from :class:`~uvm_component`,
+    can be implemented to define any agent topology, an agent typically
+    contains three subcomponents: a driver, sequencer, and monitor. If the
+    agent is active, subtypes should contain all three subcomponents. If the
+    agent is passive, subtypes should contain only the monitor.
     """
 
     def build_phase(self):
@@ -82,6 +92,15 @@ class uvm_agent(uvm_component):
             self.is_active = uvm_active_passive_enum.UVM_ACTIVE
 
     def get_is_active(self):
+        """
+        Returns :data:`~uvm_active_passive_enum.UVM_ACTIVE` if the agent is
+        acting as an active agent and
+        :data:`~uvm_active_passive_enum.UVM_PASSIVE` if it is acting as a
+        passive agent. The default implementation is to just return the
+        ``is_active`` flag, but the component developer may override this
+        behavior if a more complex algorithm is needed to determine the
+        active/passive nature of the agent.
+        """
         return self.is_active
 
     def active(self):


### PR DESCRIPTION
Convert the comments from the SystemVerilog source code into a Python docstring format.
