### PR TITLE
Fix of Override's __str__() method

### DIFF
--- a/pyuvm/utility_classes.py
+++ b/pyuvm/utility_classes.py
@@ -79,16 +79,12 @@ class Override:
         else:
             to = "Type Override: None"
         ss = f"{to:25}" + " || "
-        if self.inst_overrides is not None:
-            ss += "Instance Overrides: "
-            first = True
-            for inst in self.inst_overrides:
-                if not first:
-                    ss += " | "
-                first = False
-                if len(inst) > 29:
-                    inst = inst[:29]
-                ss += inst + f" => {self.inst_overrides[inst].__name__}"
+        io = " | ".join([
+            (f"{inst_path[:29] if len(inst_path) > 29 else inst_path}"
+             f" => {inst_override.__name__}")
+            for inst_path, inst_override in self.inst_overrides.items()
+        ])
+        ss += f"Instance Overrides: {io}" if io else ""
 
         return ss
 

--- a/tests/cocotb_tests/t08_factories/factory_tests.py
+++ b/tests/cocotb_tests/t08_factories/factory_tests.py
@@ -378,6 +378,23 @@ class s08_factory_classes_TestCase():
         # other tests being run. This catches the basic functionality.
         assert len(ss2) > len(ss1) > len(ss0)
 
+    def test_factory_str_long_pathes(self):
+        """Test, whether an overrides with a long instance paths produce correct output"""
+        self.factory.set_inst_override_by_name("original_comp", "comp_2", "top.sib.orig.some_really_long_named_instance")
+        self.factory.set_inst_override_by_name("original_comp", "comp_3", "top.mid.orig.another_really_long_named_instance")
+        self.factory.debug_level = 0
+        ss0 = self.factory.__str__()
+        assert ss0.find("top.sib.orig.some_really")
+        assert ss0.find("top.sib.orig.another_rea")
+        self.factory.debug_level = 1
+        ss1 = self.factory.__str__()
+        assert ss1.find("top.sib.orig.some_really")
+        assert ss1.find("top.sib.orig.another_rea")
+        self.factory.debug_level = 2
+        ss2 = self.factory.__str__()
+        assert ss2.find("top.sib.orig.some_really")
+        assert ss2.find("top.sib.orig.another_rea")
+
     def test_object_creation(self):
         new_obj = uvm_object.create("claribel")
         assert isinstance(new_obj, uvm_object)


### PR DESCRIPTION
This PR is a fix of #264.

- New test of `str(uvm_factory)` method was added, which aim is to test correct logging of instance overrides with long paths (it is assumed, that at least first 24 characters of the path should be printed, which is true for the previous logic, but is up to discussion).
- Fixed incorrect logic for `Override.__str__` method in these cases.