### PR TITLE
Fix tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 skip_missing_interpreters=true
 envlist =
-    py{36,37,38,39,310,311,312,313}-cocotb{19,20}-{linux,macos,windows}
-    py{36,37,38,39,310,311,312}-cocotb18-{linux,macos,windows}
-    py{36,37,38,39,310,311}-cocotb17-{linux,macos,windows}
-    py{36,37,38,39,310}-cocotb16-{linux,macos,windows}
+    py{36,37,38,39,310,311,312,313}-cocotb20-{linux,macos,windows}
+    py{36,37,38,39,310,311,312,313}-cocotb19-{linux,windows}
+    py{36,37,38,39,310,311,312}-cocotb18-{linux,windows}
+    py{36,37,38,39,310,311}-cocotb17-{linux,windows}
+    py{36,37,38,39,310}-cocotb16-{linux,windows}
 
 # for the requires key
 minversion = 3.2.0


### PR DESCRIPTION
Letting tox splat everything isn't great as old versions of cocotb didn't support unreleased versions of Python. Whoops. We are already doing the right thing in CI, but when people run `tox` locally it runs all combinations including invalid ones.