### PR TITLE
Prevent pytest from picking up `pyuvm.test` as a test

### DIFF
--- a/pyuvm/_extension_classes.py
+++ b/pyuvm/_extension_classes.py
@@ -58,3 +58,7 @@ def test(
         return cls
 
     return decorator
+
+
+# Ensure pytest doesn't collect this as a test.
+test.__test__ = False


### PR DESCRIPTION
Depends on #318. 