### PR TITLE
feat(pytest): pytest + cocotb + pyuvm ❤️

### DIFF
--- a/docs/docsources/pytest.rst
+++ b/docs/docsources/pytest.rst
@@ -1,0 +1,230 @@
+.. _pytest-support:
+
+**************
+Pytest Support
+**************
+
+The :mod:`cocotb_tools.pytest.plugin` with the :mod:`pyuvm_tools.pytest.plugin` provides full `pytest`_ integration with cocotb and PyUVM.
+
+For more details please visit the official Cocotb documentation about `Pytest Support`_.
+
+
+.. _pytest-plugin-enable:
+
+Enabling the Plugin
+===================
+
+:py:mod:`pyuvm_tools.pytest.plugin` can be enabled in various ways.
+
+In a Python project
+-------------------
+
+When using the `pyproject.toml`_ file (recommended way):
+
+.. code:: toml
+
+    [project.entry-points.pytest11]
+    cocotb = "cocotb_tools.pytest.plugin"
+    pyuvm = "pyuvm_tools.pytest.plugin"
+
+When using the ``pytest.ini`` file:
+
+.. code:: ini
+
+    [pytest]
+    addopts = -p cocotb_tools.pytest.plugin -p pyuvm_tools.pytest.plugin
+
+When using the ``setup.cfg`` file:
+
+.. code:: ini
+
+    [options.entry_points]
+    pytest11 =
+      cocotb = cocotb_tools.pytest.plugin
+      cocotb = pyuvm_tools.pytest.plugin
+
+When using the ``setup.py`` file:
+
+.. code:: python
+
+    from setuptools import setup
+
+    setup(
+        # ...,
+        entry_points={
+            "pytest11": [
+                "cocotb = cocotb_tools.pytest.plugin",
+                "pyuvm = pyuvm_tools.pytest.plugin",
+            ],
+        },
+    )
+
+In a non-Python project
+-----------------------
+
+By defining the global variable ``pytest_plugins`` when using a ``conftest.py`` file
+(which must be located in the root of the project):
+
+.. code:: python
+
+    pytest_plugins = ("cocotb_tools.pytest.plugin", "pyuvm_tools.pytest.plugin")
+
+By defining the ``PYTEST_PLUGINS`` environment variable:
+
+.. code:: shell
+
+    export PYTEST_PLUGINS="cocotb_tools.pytest.plugin,pyuvm_tools.pytest.plugin"
+
+By using the ``-p <plugin>`` option when invoking the `pytest`_ command line interface:
+
+.. code:: shell
+
+    pytest -p cocotb_tools.pytest.plugin -p pyuvm_tools.pytest.plugin ...
+
+
+.. _pytest-plugin-fixtures:
+
+Fixtures
+========
+
+The :deco:`!pytest.mark.pyuvm_fixtures` can be used to request `pytest`_ fixtures by PyUVM test:
+
+.. code:: python
+
+    # test_*.py
+
+    from typing import Any
+    from pathlib import Path
+
+    import pytest
+    from pytest import LogCaptureFixture
+    from pyuvm import uvm_test
+
+
+    @pytest.mark.pyuvm_fixtures("tmp_path", "caplog", "dut")
+    class TestDUTFeature(uvm_test):
+        """Test DUT feature with requested pytest fixtures."""
+
+        dut: Any
+        tmp_path: Path
+        caplog: LogCaptureFixture
+
+        def build_phase(self) -> None:
+            """Build UVM components."""
+            assert self.dut is not None
+            assert self.tmp_path
+            assert self.caplog
+
+
+Parametrize
+===========
+
+The :deco:`pytest.mark.parametrize` fixture can be used to parametrize PyUVM test:
+
+.. code:: python
+
+    # test_*.py
+
+    import pytest
+    from pyuvm import uvm_test
+
+
+    @pytest.mark.parametrize("x", (1, 2))
+    @pytest.mark.parametrize("y", (3, 4, 5))
+    class TestDUTFeature(uvm_test):
+        """Test DUT feature with different parameters."""
+
+        x: int = 0
+        y: int = 0
+
+        def build_phase(self) -> None:
+            """Build UVM components."""
+            assert self.x in (1, 2)
+            assert self.y in (3, 4, 5)
+
+
+.. _pytest-plugin-examples:
+
+Examples
+========
+
+Define a new HDL design by using the :class:`cocotb_tools.pytest.hdl.HDL` fixture in the ``tests/conftest.py`` file:
+
+.. code:: python
+
+    # tests/conftest.py
+
+    """Common fixtures and configurations used by all tests ``test_*.py`` defined in this directory."""
+
+    from pathlib import Path
+
+    import pytest
+    from cocotb_tools.pytest.hdl import HDL
+
+    # The root of the project (repository), assuming the "tests" directory
+    PROJECT_ROOT: Path = Path(__file__).parent.parent.resolve()
+
+
+    @pytest.fixture
+    def sample_module(hdl: HDL) -> HDL:
+        """Define HDL design by adding HDL source files to it.
+
+        Args:
+            hdl: Fixture created by the cocotb pytest plugin, representing a HDL design.
+
+        Returns:
+            Representation of HDL design with added HDL source files.
+        """
+        hdl.sources = (
+            # List HDL source files,
+            PROJECT_ROOT / "hdl" / "sample_module.sv",
+        )
+
+        return hdl
+
+
+Define a cocotb runner with PyUVM tests in ``tests/test_*.py`` file:
+
+.. code:: python
+
+    # tests/test_sample_module.py
+
+    from cocotb_tools.pytest.hdl import HDL
+    from pyuvm import uvm_test
+
+
+    def test_sample_module(sample_module: HDL) -> None:
+        """Build and test HDL module with pyuvm tests."""
+        sample_module.test()
+
+
+    class TestSampleModuleFeature1(uvm_test):
+        """Test feature 1."""
+
+
+    class TestSampleModuleFeature2(uvm_test):
+        """Test feature 2."""
+
+
+To list all available tests:
+
+.. code:: shell
+
+    pytest -v --collect-only
+
+To run all tests:
+
+.. code:: shell
+
+    pytest
+
+To run specific test:
+
+.. code:: shell
+
+    pytest -k TestSampleModuleFeature2
+
+
+.. _pytest: https://docs.pytest.org/en/stable/contents.html
+.. _pyproject.toml: https://packaging.python.org/en/latest/specifications/pyproject-toml/
+.. _Pytest Support: https://docs.cocotb.org/en/development/pytest.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,4 +6,5 @@ pyuvm
 
    docsources/README.md
    docsources/UVM_and_Python
+   docsources/pytest
    apidocs/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ Homepage = "https://github.com/pyuvm/pyuvm"
 [tool.setuptools]
 packages = [
     "pyuvm",
+    "pyuvm_tools",
 ]
 
 [dependency-groups]

--- a/pyuvm/_extension_classes.py
+++ b/pyuvm/_extension_classes.py
@@ -38,7 +38,11 @@ def test(
         # create cocotb.test object to be picked up RegressionManager
         @cocotb.test(**test_dec_args)
         @functools.wraps(cls)
-        async def test_obj(_):
+        async def test_obj(*args: object, **kwargs: object) -> None:
+            # Assign pytest fixtures to object class
+            for name, value in kwargs.items():
+                setattr(cls, name, value)
+
             await uvm_root().run_test(
                 cls, keep_singletons=keep_singletons, keep_set=keep_set
             )

--- a/pyuvm_tools/pytest/plugin.py
+++ b/pyuvm_tools/pytest/plugin.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pytest plugin that allows to collect and run pyuvm tests by cocotb pytest plugin."""
+
+from collections.abc import Generator, Iterable
+from functools import wraps
+from inspect import Parameter, signature
+
+from pytest import (
+    Class,
+    Collector,
+    Config,
+    Function,
+    Item,
+    Mark,
+    Module,
+    hookimpl,
+    mark,
+)
+
+from pyuvm import uvm_root, uvm_test
+
+
+@hookimpl(tryfirst=True)
+def pytest_configure(config: Config) -> None:
+    """Set plugin options and configure it."""
+    config.addinivalue_line("markers", "pyuvm_test: Mark class as PyUVM test")
+    config.addinivalue_line(
+        "markers", "pyuvm_fixtures: Request fixtures for PyUVM test"
+    )
+
+    # Register internal plugin for pre and post processing actions for pytest hooks
+    config.pluginmanager.register(_HookWrappers(), "pyuvm_hook_wrappers")
+
+
+@hookimpl(tryfirst=True)
+def pytest_pycollect_makeitem(
+    collector: Module | Class, name: str, obj: object
+) -> Item | Collector | list[Item | Collector] | None:
+    """Pytest hook called on every collected object from Python module or class.
+
+    Args:
+        collector: Instance that is collecting objects from Python module or class.
+        name: Name of collected object in Python module or class.
+        obj: Collected object from Python module or class.
+
+    Returns:
+        Created pytest item (test) or collector (Python module -> Python class).
+    """
+    # Must be a class inherit from the uvm_test class
+    if not isinstance(obj, type) or not issubclass(obj, uvm_test):
+        # If not, delegate handling collected object to other plugins
+        return None  # delegate to other plugins
+
+    # Pytest treads classes as nested scoped namespaces for tests
+    # We need to create a test function that will not override pyuvm test object class
+    test_obj_name: str = f"__{name}"  # compatible with the @cocotb.test decorator
+
+    # If test function was already defined or this is not an UVM test, do nothing
+    # It will be or it was already created by other iteration of the pytest_pycollect_makeitem hook
+    if hasattr(collector.obj, test_obj_name) or not _is_uvm_test(collector, name, obj):
+        return []  # do nothing
+
+    # Retrieve pytest markers from collected object
+    markers: list[Mark] = list(getattr(obj, "pytestmark", ()))
+
+    # Named argument "dut" is a pytest fixture defined in cocotb pytest plugin and it is required
+    @wraps(obj)
+    async def test_obj(*args: object, **kwargs: object) -> None:
+        # Assign pytest fixtures to object class
+        for key, value in kwargs.items():
+            setattr(obj, key, value)
+
+        await uvm_root().run_test(obj)
+
+    if not any(marker.name == "cocotb_test" for marker in markers):
+        markers.append(mark.cocotb_test().mark)
+
+    # Add pytest markers test function
+    setattr(test_obj, "pytestmark", markers)
+
+    # Store created test function in Python module or class
+    # Needed by the pytest code introspection mechanism that will retrieve parameter types, signature, file and line location
+    setattr(collector.obj, test_obj_name, test_obj)
+
+    # Delegate creating a pytest item (test) from collected object to other plugins (cocotb pytest plugin)
+    return collector.ihook.pytest_pycollect_makeitem(
+        collector=collector,
+        name=test_obj_name,
+        obj=test_obj,
+    )
+
+
+class _HookWrappers:
+    """Hook wrappers for pytest hooks."""
+
+    @hookimpl(trylast=True, wrapper=True)
+    def pytest_pycollect_makeitem(
+        self, collector: Module | Class, name: str, obj: object
+    ) -> Generator[
+        None,
+        Item | Collector | list[Item | Collector] | None,
+        list[Item | Collector] | None,
+    ]:
+        """Pre and post processing actions for the :func:`!pytest_pycollect_makeitem` hook.
+
+        Args:
+            collector: Instance that is collecting objects from Python module or class.
+            name: Name of collected object in Python module or class.
+            obj: Collected object from Python module or class.
+
+        Returns:
+            Created pytest item (test) or collector (Python module -> Python class).
+        """
+        # Add pytest fixtures to pyuvm test
+        _update_test_signature(collector, name, obj)
+
+        result: Item | Collector | list[Item | Collector] | None = yield
+
+        if result is None:
+            return None
+
+        items: list[Item | Collector] = result if isinstance(result, list) else [result]
+
+        for item in items:
+            # Remove the "__" prefix from name of test function
+            if isinstance(item, Function) and item.name.startswith("__"):
+                item.name = item.name.removeprefix("__")
+                item._nodeid = item.nodeid.replace("::__", "::")
+                item.extra_keyword_matches.add(item.name)
+
+        return items
+
+
+def _is_uvm_test(collector: Module | Class, name: str, obj: object) -> bool:
+    """Check if collected object from Python module or class is UVM test.
+
+    Args:
+        collector: Instance that is collecting objects from Python module or class.
+        name: Name of collected object in Python module or class.
+        obj: Collected object from Python module or class.
+
+    Returns:
+        :data:`True` if collected object is UVM test. Otherwise :data:`False`.
+    """
+    if collector.istestclass(obj, name):
+        # It is following the pytest name convention for tests that must start with the Test prefix
+        return True
+
+    # Test was marked with the @pytest.mark.pyuvm_test marker
+    markers: Iterable[Mark] | None = getattr(obj, "pytestmark", None)
+
+    return any(marker.name == "pyuvm_test" for marker in markers or ())
+
+
+def _update_test_signature(collector: Module | Class, name: str, obj: object) -> None:
+    """Update test signature of collected object from Python module.
+
+    Args:
+        collector: Instance that is collecting objects from Python module or class.
+        name: Name of collected object in Python module or class.
+        obj: Collected object from Python module or class.
+    """
+    # pyuvm test as cocotb test starts from the "__" name prefix
+    if not name.startswith("__"):
+        return
+
+    # pyuvm test (class type) is stored in the same Python module like cocotb test
+    cls = getattr(collector.obj, name[2:], None)
+
+    # Get test function (optionally it can be wrapped)
+    func = getattr(obj, "__func__", obj)
+
+    # Object class type MUST be uvm_test and collected object MUST be callable
+    if (
+        cls is None
+        or not isinstance(cls, type)
+        or not issubclass(cls, uvm_test)
+        or not callable(func)
+    ):
+        return
+
+    # ``@functools.wraps(uvm_test)`` will wrap function but use signature from the ``uvm_test.__init__(name, parent)``
+    # The pytest introspection mechanism will treat all function arguments as fixtures
+    # For "name" and "parent" will raise an error about not defined fixtures. We need to override these arguments
+    sig = signature(func)
+
+    # Requested pytest fixtures
+    args: set[str] = set()
+
+    # Get @pytest.mark.* markers from test function
+    markers: Iterable[Mark] | None = getattr(obj, "pytestmark", None)
+
+    for marker in markers or ():
+        # @pytest.mark.parametrize("x,y", ((1, 2), (3, 4)))
+        if marker.name == "parametrize" and marker.args:
+            args.update(marker.args[0].split(","))
+
+        # @pytest.mark.pyuvm_fixtures("caplog", "tmp_path")
+        elif marker.name == "pyuvm_fixtures":
+            args.update(marker.args)
+
+    # Compose new arguments for test function
+    parameters: list[Parameter] = [
+        Parameter(name=arg, kind=Parameter.POSITIONAL_OR_KEYWORD) for arg in args
+    ]
+
+    # Override signature of test function with new arguments to make pytest happy
+    setattr(func, "__signature__", sig.replace(parameters=parameters))

--- a/tests/pytest_plugin/conftest.py
+++ b/tests/pytest_plugin/conftest.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common fixtures and configurations used by all tests ``test_*.py`` defined in this directory."""
+
+from pathlib import Path
+
+from cocotb_tools.pytest.hdl import HDL
+from pytest import Parser, PytestPluginManager, fixture, hookimpl
+
+# The root of the pyuvm project (repository)
+PROJECT_ROOT: Path = Path(__file__).parent.parent.parent.resolve()
+
+# List of pytest plugins to enable
+PLUGINS: tuple[str, ...] = (
+    "cocotb_tools.pytest.plugin",
+    "pyuvm_tools.pytest.plugin",
+)
+
+
+@hookimpl(tryfirst=True)
+def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> None:
+    """Load pytest cocotb/pyuvm plugin in early stage of pytest when adding options to pytest.
+
+    This will allow to automatically load plugin when invoking ``pytest`` with ``tests/pytest_plugin`` argument
+    without need of providing additional ``-p cocotb_tools.pytest.plugin -p pyuvm_tools.pytest.plugin`` arguments.
+
+    Most users in their projects will load plugin by defining an entry point in ``pyproject.toml`` file:
+
+    .. code:: toml
+
+        [project.entry-points.pytest11]
+        cocotb = "cocotb_tools.pytest.plugin"
+        pyuvm = "pyuvm_tools.pytest.plugin"
+
+    Args:
+        parser: Instance of command line arguments parser used by pytest.
+        pluginmanager: Instance of pytest plugin manager.
+    """
+    for plugin in PLUGINS:
+        if not pluginmanager.has_plugin(plugin):
+            pluginmanager.import_plugin(plugin)  # import and register plugin
+
+
+# The "hdl" fixture is defined in the cocotb pytest plugin and it is used to define HDL design
+# that will be built and tested. Created "tinyalu" fixture can be used in cocotb runner test functions
+# to invoke the tinyalu.test() method that will run HDL simulator with cocotb tests for this HDL design.
+@fixture
+def tinyalu(hdl: HDL) -> HDL:
+    """Define HDL design for the ``TinyALU`` module."""
+    src: Path = PROJECT_ROOT / "examples" / "TinyALU" / "hdl"
+
+    # TODO: This can be removed after merging https://github.com/cocotb/cocotb/pull/5243
+    # Setting explicitly name of toplevel will be optional in cocotb pytest plugin
+    # Default value will be implicitly based on the last added HDL source file
+    hdl.toplevel = "tinyalu"
+
+    # The "toplevel_lang" attribute, if not specified via the --cocotb-toplevel-lang=<vhdl|verilog> option,
+    # is set to "vhdl" for NVC and GHDL simulators, to "verilog" for Verilator and Icarus simulators, set empty for others
+    if hdl.toplevel_lang == "vhdl":
+        hdl.sources = [
+            src / "vhdl" / "single_cycle_add_and_xor.vhd",
+            src / "vhdl" / "three_cycle_mult.vhd",
+            src / "vhdl" / "tinyalu.vhd",
+        ]
+    else:
+        hdl.sources = [
+            src / "verilog" / "tinyalu.sv",
+        ]
+
+    # TODO: This can be removed after merging https://github.com/cocotb/cocotb/pull/5243
+    # The hdl.build() method will be implicitly invoked by the hdl.test() method if it was not called explicitly
+    hdl.build()
+
+    # Return defined HDL design that will be tested
+    return hdl

--- a/tests/pytest_plugin/test_tinyalu.py
+++ b/tests/pytest_plugin/test_tinyalu.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Testing the pyuvm pytest plugin by using the ``TinyALU`` module as reference."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cocotb_tools.pytest.hdl import HDL
+from pytest import LogCaptureFixture
+
+import pyuvm
+from pyuvm import uvm_test
+
+
+# NOTE: @pytest.mark.cocotb_runner can be removed after merging https://github.com/cocotb/cocotb/pull/5260
+@pytest.mark.cocotb_runner
+def test_tinyalu(tinyalu: HDL) -> None:
+    """Build and test the ``TinyALU`` module with cocotb/pyuvm tests defined in this file."""
+    tinyalu.test()
+
+
+async def test_tinyalu_with_cocotb(dut) -> None:
+    """Direct testing by using the ``cocotb`` directly."""
+
+
+class TestBase(uvm_test):
+    """test base for all tests."""
+
+    async def run_phase(self) -> None:
+        self.raise_objection()
+        print(f"{self.__class__!r}: Hello from run phase!")
+        self.drop_objection()
+
+
+# With the pyuvm pytest plugin, decorators are not needed. Requirements:
+# - Name for test MUST start with the "Test" prefix
+# - It MUST be a class inherit from the :class:`pyuvm.uvm_test` class (directly or indirectly)
+class TestTinyALUWithoutDecorators(TestBase):
+    """pyuvm test without need of using :deco:`pyuvm.test` or :deco:`!pytest.mark.pyuvm_test` decorators."""
+
+
+# Pytest marker provided by the pyuvm pytest plugin
+# It allows to use any name for test. No need for the "Test" prefix
+@pytest.mark.pyuvm_test
+class TinyALUWithPytestMarker(TestBase):
+    """pyuvm test marked with the :deco:`!pytest.mark.pyuvm_test` decorator."""
+
+
+@pyuvm.test()
+class TinyALUWithPyUVMDecorator(TestBase):
+    """pyuvm test marked with the :deco:`pyuvm.test` decorator (old-way)."""
+
+
+@pyuvm.test()
+@pytest.mark.parametrize("x", (1, 2))
+@pytest.mark.parametrize("y", (3, 4))
+@pytest.mark.pyuvm_fixtures("tmp_path", "caplog", "dut")
+class TinyALUParametrizeWithPyUVMDecorator(TestBase):
+    """pyuvm test marked with the :deco:`pyuvm.test` decorator (old-way)."""
+
+    dut: Any
+    tmp_path: Path
+    caplog: LogCaptureFixture
+    x: int = 0
+    y: int = 0
+
+    def build_phase(self) -> None:
+        assert self.dut is not None
+        assert self.tmp_path
+        assert self.caplog
+        assert self.x in (1, 2)
+        assert self.y in (3, 4)
+
+
+@pytest.mark.parametrize("a", (True, False))
+@pytest.mark.parametrize("b", ("x", "y"))
+@pytest.mark.pyuvm_fixtures("dut", "caplog")
+class TestTinyALUParametrizeWithoutDecorators(TestBase):
+    """pyuvm test without need of using :deco:`pyuvm.test` or :deco:`!pytest.mark.pyuvm_test` decorators."""
+
+    dut: Any
+    caplog: LogCaptureFixture
+    a: bool = False
+    b: str = ""
+
+    def build_phase(self) -> None:
+        assert self.dut is not None
+        assert self.caplog
+        assert self.a in (True, False)
+        assert self.b in ("x", "y")


### PR DESCRIPTION
- Added pytest plugin `pyuvm_tools.pytest.plugin` that allows to run pyuvm tests via `pytest` with [cocotb pytest plugin](https://docs.cocotb.org/en/development/pytest.html)
- Added documentation about pytest support
- Added silly unit tests
- Added examples

Ready to use with the cocotb 2.1 that will add full pytest support. For more details, please read the official Cocotb documentation about [Pytest Support](https://docs.cocotb.org/en/development/pytest.html) (from development release).

## Local Testing

Create Python virtual environment:

```plaintext
uv venv
```

Activate created Python virtual environment:

```plaintext
. .venv/bin/activate
```

Install Cocotb from https://github.com/cocotb/cocotb/pull/5260:

```plaintext
uv pip install 'git+https://github.com/tymonx/cocotb@chore/pytest-plugin-makeitem'
```

Install PyUVM from this PR: 

```plaintext
uv pip install 'git+https://github.com/tymonx/pyuvm@feature/cocotb-pytest-plugin-support'
```

Install `pytest`:

```plaintext
uv pip install pytest
```

List all available pyuvm tests from the `tests/pytest_plugin/` directory:

```plaintext
pytest -v ./tests/pytest_plugin/ --collect-only
```

Output:

```plaintext
<Dir pyuvm>
  <Dir tests>
    <Dir pytest_plugin>
      <Module test_tinyalu.py>
        <Runner test_tinyalu>
          <Testbench test_tinyalu>
            <Function test_tinyalu_with_cocotb>
            <Function TinyALUWithPyUVMDecorator>
            <Function TestTinyALUWithoutDecorators>
            <Function TinyALUWithPytestMarker>
```

Run all pyuvm tests:

```plaintext
pytest -v -s ./tests/pytest_plugin/ 
```

Run specific pyuvm test(s):

```plaintext
pytest -v -s ./tests/pytest_plugin/ -k TestTinyALUWithoutDecorators 
```

Closes #156
Closes #228 
Closes #327 