### PR TITLE
Remove broad exception fallback in `uvm_factory()` and type-check test_name in `run_test`

### DIFF
--- a/pyuvm/_s08_factory_classes.py
+++ b/pyuvm/_s08_factory_classes.py
@@ -238,10 +238,17 @@ class uvm_factory(metaclass=Singleton):
 
         Create an object using a string to define its uvm_object type.
         """
+        if name is None or name is "":
+            raise UVMFactoryError(
+                "Parameter name must be specified in create_object_by_name"
+            )
+
         try:
             requested_type = FactoryData().classes[requested_type_name]  # noqa
         except KeyError:
-            requested_type = requested_type_name
+            raise UVMFactoryError(
+                f"Requested type {requested_type_name} not in uvm_factory()"
+            )
 
         new_obj = self.create_object_by_type(requested_type, parent_inst_path, name)
         return new_obj
@@ -289,7 +296,7 @@ class uvm_factory(metaclass=Singleton):
         :raises: UVMFactoryError if the type is not in the factory
         :return: A uvm_object with the name given
         """
-        if name is None:
+        if name is None or name is "":
             raise UVMFactoryError(
                 "Parameter name must be specified in create_component_by_name"
             )
@@ -297,7 +304,9 @@ class uvm_factory(metaclass=Singleton):
         try:
             requested_type = FactoryData().classes[requested_type_name]  # noqa
         except KeyError:
-            requested_type = requested_type_name
+            raise UVMFactoryError(
+                f"Requested type {requested_type_name} not uvm_factory()"
+            )
 
         new_obj = self.create_component_by_type(
             requested_type, parent_inst_path, name, parent

--- a/pyuvm/_s08_factory_classes.py
+++ b/pyuvm/_s08_factory_classes.py
@@ -253,7 +253,7 @@ class uvm_factory(metaclass=Singleton):
             else:
                 raise UVMFactoryError(
                     f"Requested type {requested_type_name} not in "
-                     "uvm_factory()  or overrides"
+                    "uvm_factory()  or overrides"
                 )
 
         new_obj = self.create_object_by_type(requested_type, parent_inst_path, name)
@@ -310,7 +310,7 @@ class uvm_factory(metaclass=Singleton):
             else:
                 raise UVMFactoryError(
                     f"Requested type {requested_type_name} not in "
-                     "uvm_factory()  or overrides"
+                    "uvm_factory()  or overrides"
                 )
 
         new_obj = self.create_component_by_type(

--- a/pyuvm/_s08_factory_classes.py
+++ b/pyuvm/_s08_factory_classes.py
@@ -243,12 +243,18 @@ class uvm_factory(metaclass=Singleton):
                 "Parameter name must be specified in create_object_by_name"
             )
 
+        # Find the requested_type_name in registered classes or overrides if
+        # the string has been registered with an override.
         try:
             requested_type = FactoryData().classes[requested_type_name]  # noqa
         except KeyError:
-            raise UVMFactoryError(
-                f"Requested type {requested_type_name} not in uvm_factory()"
-            )
+            if requested_type_name in self.fd.overrides:
+                requested_type = requested_type_name
+            else:
+                raise UVMFactoryError(
+                    f"Requested type {requested_type_name} not in "
+                     "uvm_factory()  or overrides"
+                )
 
         new_obj = self.create_object_by_type(requested_type, parent_inst_path, name)
         return new_obj
@@ -296,17 +302,16 @@ class uvm_factory(metaclass=Singleton):
         :raises: UVMFactoryError if the type is not in the factory
         :return: A uvm_object with the name given
         """
-        if name is None or name == "":
-            raise UVMFactoryError(
-                "Parameter name must be specified in create_component_by_name"
-            )
-
         try:
             requested_type = FactoryData().classes[requested_type_name]  # noqa
         except KeyError:
-            raise UVMFactoryError(
-                f"Requested type {requested_type_name} not uvm_factory()"
-            )
+            if requested_type_name in self.fd.overrides:
+                requested_type = requested_type_name
+            else:
+                raise UVMFactoryError(
+                    f"Requested type {requested_type_name} not in "
+                     "uvm_factory()  or overrides"
+                )
 
         new_obj = self.create_component_by_type(
             requested_type, parent_inst_path, name, parent

--- a/pyuvm/_s08_factory_classes.py
+++ b/pyuvm/_s08_factory_classes.py
@@ -238,7 +238,7 @@ class uvm_factory(metaclass=Singleton):
 
         Create an object using a string to define its uvm_object type.
         """
-        if name is None or name is "":
+        if name is None or name == "":
             raise UVMFactoryError(
                 "Parameter name must be specified in create_object_by_name"
             )
@@ -296,7 +296,7 @@ class uvm_factory(metaclass=Singleton):
         :raises: UVMFactoryError if the type is not in the factory
         :return: A uvm_object with the name given
         """
-        if name is None or name is "":
+        if name is None or name == "":
             raise UVMFactoryError(
                 "Parameter name must be specified in create_component_by_name"
             )

--- a/pyuvm/_s13_uvm_component.py
+++ b/pyuvm/_s13_uvm_component.py
@@ -497,9 +497,15 @@ class uvm_root(uvm_component, metaclass=UVM_ROOT_Singleton):
             factory.clear_overrides()
         self.clear_children()
         ObjectionHandler().clear()
-        self.uvm_test_top = factory.create_component_by_name(
-            test_name, "", "uvm_test_top", self
-        )
+        if type(test_name) is str:
+            self.uvm_test_top = factory.create_component_by_name(
+                test_name, "", "uvm_test_top", self
+            )
+        else:
+            self.uvm_test_top = factory.create_component_by_type(
+                test_name, "", "uvm_test_top", self
+            )
+
         for self.running_phase in uvm_common_phases:
             self.logger.log(PYUVM_DEBUG, str(self.running_phase))
             self.running_phase.traverse(self.uvm_test_top)

--- a/pyuvm/_s13_uvm_component.py
+++ b/pyuvm/_s13_uvm_component.py
@@ -497,7 +497,7 @@ class uvm_root(uvm_component, metaclass=UVM_ROOT_Singleton):
             factory.clear_overrides()
         self.clear_children()
         ObjectionHandler().clear()
-        if type(test_name) is str:
+        if isinstance(test_name, str):
             self.uvm_test_top = factory.create_component_by_name(
                 test_name, "", "uvm_test_top", self
             )

--- a/pyuvm/_s13_uvm_component.py
+++ b/pyuvm/_s13_uvm_component.py
@@ -497,7 +497,11 @@ class uvm_root(uvm_component, metaclass=UVM_ROOT_Singleton):
             factory.clear_overrides()
         self.clear_children()
         ObjectionHandler().clear()
+<<<<<<< HEAD
         if isinstance(test_name, str):
+=======
+        if type(test_name) is str:
+>>>>>>> 3667de5 (Remove broad exception fallback in `uvm_factory()` and type-check test_name in `run_test`)
             self.uvm_test_top = factory.create_component_by_name(
                 test_name, "", "uvm_test_top", self
             )

--- a/pyuvm/_s13_uvm_component.py
+++ b/pyuvm/_s13_uvm_component.py
@@ -497,11 +497,7 @@ class uvm_root(uvm_component, metaclass=UVM_ROOT_Singleton):
             factory.clear_overrides()
         self.clear_children()
         ObjectionHandler().clear()
-<<<<<<< HEAD
         if isinstance(test_name, str):
-=======
-        if type(test_name) is str:
->>>>>>> 3667de5 (Remove broad exception fallback in `uvm_factory()` and type-check test_name in `run_test`)
             self.uvm_test_top = factory.create_component_by_name(
                 test_name, "", "uvm_test_top", self
             )


### PR DESCRIPTION
Both `create_component_by_name` and `create_object_by_name` had a exception fallback to use the `requested_type_name` as the `requested_type` if the lookup in the factory classes failed.
This is not in line with the UVM standard, as is states 
>  If the factory does not recognize the requested_type_name, an error shall be generated and a null handle returned[^1]

Additionally is creates confusion as the methods essentially function as create by name or type.
Therefore is is removed and an exception is thrown instead.

The check for `requested_type_name` is extended to also catch empty strings, as the default value is an empty string.

The `run_test` function is extended to correctly call `request_component_by_type`/`request_component_by_name` depending on if a string is passed.

[^1]: IEEE Std 1800.2-2020 p. 78