### PR TITLE
Remove support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,6 @@ jobs:
       matrix:
         include:
           # Test all Python versions with latest cocotb
-          - python-version: "3.7"
-            cocotb-version: "2.0"
-            vhdl-sim: "nvc"
-          - python-version: "3.8"
-            cocotb-version: "2.0"
-            vhdl-sim: "nvc"
           - python-version: "3.9"
             cocotb-version: "2.0"
             vhdl-sim: "nvc"
@@ -45,40 +39,26 @@ jobs:
             vhdl-sim: "nvc"
           # Test other cocotb versions
           # Must use GHDL as VHDL simulator as NVC is only supported in cocotb 1.9+
-          - python-version: "3.8"
+          - python-version: "3.9"
             cocotb-version: "1.6"
             vhdl-sim: "ghdl"
-          - python-version: "3.8"
+          - python-version: "3.9"
             cocotb-version: "1.7"
             vhdl-sim: "ghdl"
-          - python-version: "3.8"
+          - python-version: "3.9"
             cocotb-version: "1.8"
             vhdl-sim: "ghdl"
-          - python-version: "3.8"
+          - python-version: "3.9"
             cocotb-version: "1.9"
             vhdl-sim: "nvc"
 
     steps:
     - uses: actions/checkout@v6
 
-    - name: Set up Python ${{matrix.python-version}} (setup-python)
-      if: matrix.python-version != 3.7
+    - name: Set up Python ${{matrix.python-version}}
       uses: actions/setup-python@v6
       with:
         python-version: ${{matrix.python-version}}
-
-    - name: Set up Python ${{matrix.python-version}} (pyenv pt.1)
-      if: matrix.python-version == 3.7
-      uses: gabrielfalcao/pyenv-action@a1fc55906be92612782934c70e3985b940bd0165  # v18
-      with:
-        default: ${{matrix.python-version}}
-        command: pip install -U pip  # upgrade pip after installing python
-
-    - name: Set up Python ${{matrix.python-version}} (pyenv pt.2)
-      if: matrix.python-version == 3.7
-      run: |
-        pyenv install ${{matrix.python-version}}
-        pyenv global ${{matrix.python-version}}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyuvm"
 version = "4.0.1"
 description = "A Python implementation of the UVM using cocotb"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
     {name = "Ray Salemi", email = "ray@raysalemi.com"}
 ]
@@ -51,7 +51,7 @@ docs = [
 docs = {requires-python = ">=3.11"}
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py39"
 
 [tool.ruff.lint]
 extend-select = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 skip_missing_interpreters=true
 envlist =
-    py{37,38,39,310,311,312,313}-cocotb20-{linux,macos,windows}
-    py{37,38,39,310,311,312,313}-cocotb19-{linux,windows}
-    py{37,38,39,310,311,312}-cocotb18-{linux,windows}
-    py{37,38,39,310,311}-cocotb17-{linux,windows}
-    py{37,38,39,310}-cocotb16-{linux,windows}
+    py{39,310,311,312,313}-cocotb20-{linux,macos,windows}
+    py{39,310,311,312,313}-cocotb19-{linux,windows}
+    py{39,310,311,312}-cocotb18-{linux,windows}
+    py{39,310,311}-cocotb17-{linux,windows}
+    py{39,310}-cocotb16-{linux,windows}
 
 # for the requires key
 minversion = 3.2.0
@@ -60,8 +60,6 @@ tox_fail_on_error = true
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
These have been EOL for over a year, cocotb has already dropped support for these, and supporting 3.7 in particular is a pain.