### PR TITLE
fix: default uvm_component/uvm_sequencer parent to None to match IEEE 1800.2

### DIFF
--- a/pyuvm/_s13_uvm_component.py
+++ b/pyuvm/_s13_uvm_component.py
@@ -43,13 +43,15 @@ class uvm_component(uvm_report_object):
     def clear_components(cls):
         cls.component_dict = {}
 
-    def __init__(self, name, parent):
+    def __init__(self, name, parent=None):
         """
         13.1.2.1---This is new() in the IEEE-UVM, but we mean
         the same thing with __init__()
 
         :param name: The name of the component. Used in the UVM hierarchy
-        :param parent: The parent component.  If None, the parent is uvm_root
+        :param parent: The parent component.  If None (default), the
+            parent is ``uvm_root``. Matches IEEE 1800.2 ``new(name,
+            parent=null)``.
         """
 
         self._children = {}

--- a/pyuvm/_s14_15_python_sequences.py
+++ b/pyuvm/_s14_15_python_sequences.py
@@ -350,7 +350,7 @@ class uvm_sequencer(uvm_component):
     items with the sequencer.
     """
 
-    def __init__(self, name, parent):
+    def __init__(self, name, parent=None):
         super().__init__(name, parent)
         self.seq_item_export = uvm_seq_item_export("seq_item_export", self)
         self.seq_q = UVMQueue(0)

--- a/tests/pytests/test_05_base_classes.py
+++ b/tests/pytests/test_05_base_classes.py
@@ -285,3 +285,18 @@ def test_clone():
     clone = orig.clone()
     assert id(orig) != id(clone)
     assert orig.val == clone.val
+
+
+def test_uvm_component_parent_default(initialize_pyuvm):
+    # IEEE 1800.2 declares ``new(name, parent=null)``; uvm_component should
+    # match that signature and resolve a missing parent to uvm_root.
+    uc = uvm_component("c_default")
+    assert uc.parent is uvm_root()
+
+
+def test_uvm_sequencer_parent_default(initialize_pyuvm):
+    # The constructor of uvm_sequencer was missing the default parent
+    # argument expected by the IEEE 1800.2 signature
+    # ``new(name, parent=null)``. See pyuvm issue #299.
+    seq = uvm_sequencer("seqr_default")
+    assert seq.parent is uvm_root()


### PR DESCRIPTION
## Summary

`uvm_component.__init__` already handles a `None` parent — line 56
explicitly substitutes `uvm_root()` when the user passes `None`, and
the docstring documents this behaviour. However the constructor
signature itself was `(self, name, parent)` with no default, so callers
had to pass `None` explicitly: `uvm_component("c", None)`.

The IEEE 1800.2 SystemVerilog UVM signature is:

```systemverilog
extern function new (string name, uvm_component parent = null);
```

`uvm_sequencer` inherits from `uvm_component` and has the same gap
reported in #299.

## Change

`pyuvm/_s13_uvm_component.py` — `uvm_component.__init__`:

```diff
-    def __init__(self, name, parent):
+    def __init__(self, name, parent=None):
```

`pyuvm/_s14_15_python_sequences.py` — `uvm_sequencer.__init__`:

```diff
-    def __init__(self, name, parent):
+    def __init__(self, name, parent=None):
```

Plus a small docstring update on `uvm_component.__init__` so the
default behaviour and the IEEE 1800.2 reference are visible in the API
docs.

## Test

Adds two pytest cases to `tests/pytests/test_05_base_classes.py`:

```python
def test_uvm_component_parent_default(initialize_pyuvm):
    uc = uvm_component("c_default")
    assert uc.parent is uvm_root()

def test_uvm_sequencer_parent_default(initialize_pyuvm):
    seq = uvm_sequencer("seqr_default")
    assert seq.parent is uvm_root()
```

`pytest tests/pytests/test_05_base_classes.py` runs 19 tests cleanly
with the change applied (17 pre-existing + the two new ones).

## Scope note

Several other `uvm_component`-derived classes still have the older
`(self, name, parent)` signature, including the TLM interface classes
in `_s12_uvm_tlm_interfaces.py` and the predefined component classes
in `_s13_predefined_component_classes.py`. They are intentionally not
touched here — this PR is scoped to closing #299 (uvm_sequencer) plus
the underlying base class. Happy to follow up with a sweep for the
remaining classes if maintainers prefer it as a separate PR.

Closes #299
