### PR TITLE
docs: note that examples/ require an editable install of the cloned source (closes #363)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ This section demonstrates running an example simulation and then shows how the e
 
 ## Running the simulation
 
+> **Note** &mdash; The example files in `examples/` are kept in lockstep with the
+> latest pyuvm source on `master` and may rely on API additions that have not
+> yet been published to PyPI. Install pyuvm in editable mode from your cloned
+> repository (see [Running from a cloned repository](#running-from-a-cloned-repository)
+> above) before running the example, otherwise the imports resolve to the
+> older PyPI release and you may hit errors such as
+> `TypeError: uvm_component.raise_objection() takes 1 positional argument but 2 were given`
+> (see #363).
+
 The TinyALU is, as its name implies, a tiny ALU. It has four operations: ADD, AND, NOT, and MUL. This example shows us running the Verilog version of the design, but there is also a VHDL version.
 
 **cocotb** uses a Makefile to run its simulation. We see it in `examples/TinyALU`:


### PR DESCRIPTION
## Summary

A user who follows the README top-down hits

\`\`\`
TypeError: uvm_component.raise_objection() takes 1 positional argument but 2 were given
\`\`\`

when they:

1. \`pip install pyuvm\` (Installation section)
2. \`git clone pyuvm\` (implied by the example path in the \"Running the simulation\" section)
3. \`cd examples/TinyALU && make sim\`

…because the cloned \`examples/testbench.py\` already uses the new
\`raise_objection(description)\` signature added in commit d28405a,
while the pinned PyPI release predates that change and still exposes
\`raise_objection(self)\` only. Imports resolve to the PyPI copy, so
the example breaks.

The \"Running from a cloned repository\" section already documents the
correct setup (\`pip install -e .\` in the cloned tree), but the
TinyALU run-through doesn't reference it, so new users land in the
broken combination by default.

Closes #363.

## Change

Single-block note at the top of the \"Running the simulation\" section:

> The example files in \`examples/\` are kept in lockstep with the latest
> pyuvm source on \`master\` and may rely on API additions that have not
> yet been published to PyPI. Install pyuvm in editable mode from your
> cloned repository (see [Running from a cloned repository] above)
> before running the example, otherwise the imports resolve to the
> older PyPI release and you may hit errors such as
> \`TypeError: uvm_component.raise_objection() takes 1 positional
> argument but 2 were given\` (see #363).

## Scope

Documentation only. Single file change (+9 lines in \`README.md\`), no
code or test changes. The reporter (@JohnTheo01) suggested this same
fix in the issue.