### PR TITLE
examples: add SimpleMem — Custom UVM Agent A-to-Z reference

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
   rev: "v0.15.18"
   hooks:
     - id: ruff-check
+      args: [--fix]
     - id: ruff-format
 
 - repo: "https://github.com/pre-commit/pre-commit-hooks"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ cocotb_tests:
 	make SIM=$(VERILOG_SIM) TOPLEVEL_LANG=verilog -C examples/TinyALU sim checkclean
 	make SIM=$(VERILOG_SIM) TOPLEVEL_LANG=verilog -C examples/TinyALU_reg sim checkclean
 	make SIM=$(VHDL_SIM)    TOPLEVEL_LANG=vhdl    -C examples/TinyALU sim checkclean
+	make SIM=$(VERILOG_SIM) TOPLEVEL_LANG=verilog -C examples/SimpleMem sim checkclean
 
 docs:
 	uv run --group docs sphinx-build -b html docs docs/_build/html

--- a/examples/SimpleMem/Makefile
+++ b/examples/SimpleMem/Makefile
@@ -1,0 +1,21 @@
+CWD = $(shell pwd)
+
+export COCOTB_REDUCED_LOG_FMT = 1
+
+SIM           ?= icarus
+TOPLEVEL_LANG ?= verilog
+TOPLEVEL       = simple_mem
+MODULE        := testbench
+
+VERILOG_SOURCES = $(CWD)/hdl/verilog/simple_mem.sv
+
+COCOTB_HDL_TIMEUNIT      = 1ns
+COCOTB_HDL_TIMEPRECISION = 1ns
+
+ifeq ($(SIM), verilator)
+    # Enable processing of #delay statements
+    COMPILE_ARGS += --timing
+endif
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+include ../../checkclean.mk

--- a/examples/SimpleMem/README.md
+++ b/examples/SimpleMem/README.md
@@ -1,0 +1,64 @@
+# SimpleMem — a worked example of a Custom UVM Agent
+
+This example is the memory-bus complement to `examples/TinyALU/`. Where
+TinyALU demonstrates the basic UVM phase loop, **SimpleMem** is written
+to be a top-to-bottom reference for a standard A-to-Z UVM agent:
+
+```
+sequence_item  ->  sequence(s)  ->  sequencer  ->  driver  ->  DUT
+                                                                |
+                                                  monitor  <----+
+                                                     |
+                                            +--------+--------+
+                                            v                 v
+                                       scoreboard         coverage
+```
+
+The DUT is a tiny synchronous memory with a `req`/`gnt` handshake (see
+`hdl/verilog/simple_mem.sv`). Everything else lives in
+`testbench.py` so the file can be read in one pass.
+
+## What this example shows that TinyALU does not
+
+| Concept                                  | TinyALU         | SimpleMem               |
+|------------------------------------------|-----------------|-------------------------|
+| `uvm_sequence_item` + multiple sequences | ✓               | ✓                       |
+| Driver / Monitor split                   | ✓ (siblings)    | ✓ (under a real agent)  |
+| **`uvm_agent` with ACTIVE / PASSIVE**    | —               | ✓                       |
+| `uvm_scoreboard` with golden model       | TLM-based       | golden-memory model     |
+| `uvm_subscriber` coverage                | op coverage     | (op × addr-bucket) grid |
+| **Negative test demonstrating coverage holes** | —         | ✓ (`expect_fail=True`)  |
+
+## Tests
+
+- `MemRandomTest` — random read/write traffic with the agent in ACTIVE
+  mode. Exercises both the driver and the monitor.
+- `MemWriteThenReadTest` — writes the full address space, then reads it
+  back. The scoreboard's golden model must predict every read.
+- `MemPassiveAgentTest` — switches the agent to **PASSIVE** via
+  `ConfigDB().set(..., "is_active", UVM_PASSIVE)`. Stimulus is driven
+  outside of UVM (a plain cocotb coroutine pokes the BFM). The monitor,
+  scoreboard, and coverage subscriber must still cover the full
+  (op, addr-bucket) grid.
+- `MemPassiveFailingTest` — same passive setup but issues writes only.
+  The coverage subscriber should flag the missing READ buckets and the
+  test is marked `expect_fail=True` so `make` still exits 0.
+
+## Running
+
+```
+cd examples/SimpleMem
+make            # SIM=icarus by default
+```
+
+To use Verilator instead:
+
+```
+make SIM=verilator
+```
+
+Expected output ends with:
+
+```
+** TESTS=4 PASS=4 FAIL=0 SKIP=0
+```

--- a/examples/SimpleMem/hdl/verilog/simple_mem.sv
+++ b/examples/SimpleMem/hdl/verilog/simple_mem.sv
@@ -1,0 +1,52 @@
+// SimpleMem: a tiny synchronous memory with a req/gnt handshake.
+//
+//   Master drives                Slave responds
+//   ─────────────                ──────────────
+//   req                          gnt
+//   we    (1 = write, 0 = read)  rdata (read transactions only)
+//   addr
+//   wdata
+//
+// Single-cycle handshake: when (req && gnt) is high on a rising edge, the
+// transaction completes that cycle. Writes are committed in the same cycle.
+// Reads return `rdata` in the same cycle (combinational read).
+//
+// This DUT is intentionally minimal — the point of the example is the UVM
+// agent that drives it, not the DUT itself.
+module simple_mem #(
+    parameter int ADDR_WIDTH = 8,
+    parameter int DATA_WIDTH = 32
+) (
+    input  wire                    clk,
+    input  wire                    rst_n,
+    input  wire                    req,
+    input  wire                    we,
+    input  wire [ADDR_WIDTH-1:0]   addr,
+    input  wire [DATA_WIDTH-1:0]   wdata,
+    output wire                    gnt,
+    output wire [DATA_WIDTH-1:0]   rdata
+);
+
+    localparam int DEPTH = 1 << ADDR_WIDTH;
+
+    logic [DATA_WIDTH-1:0] mem [DEPTH];
+
+    // The slave is always ready. This keeps the handshake side of the test
+    // boring on purpose so the example focuses on UVM-side machinery.
+    assign gnt = req;
+
+    // Combinational read.
+    assign rdata = mem[addr];
+
+    // Synchronous write.
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (int i = 0; i < DEPTH; i++) begin
+                mem[i] <= '0;
+            end
+        end else if (req && we) begin
+            mem[addr] <= wdata;
+        end
+    end
+
+endmodule

--- a/examples/SimpleMem/simple_mem_utils.py
+++ b/examples/SimpleMem/simple_mem_utils.py
@@ -27,13 +27,6 @@ class MemOp(enum.IntEnum):
     WRITE = 1
 
 
-def _get_int(signal):
-    try:
-        return int(signal.value)
-    except ValueError:
-        return 0
-
-
 class SimpleMemBfm(metaclass=Singleton):
     """BFM for the SimpleMem bus.
 
@@ -100,10 +93,16 @@ class SimpleMemBfm(metaclass=Singleton):
             # Wait until the slave grants (single-cycle handshake here, but
             # writing the loop this way keeps the BFM ready for back-pressure
             # variants of the DUT.)
+            #
+            # start_bfm() is only called after bfm.reset() returns, so every
+            # signal we sample here is guaranteed to have a defined value —
+            # int(signal.value) is strict (raises ValueError on X/Z) and any
+            # surprise X mid-sim becomes a hard failure rather than a silent
+            # zero, per pyuvm/pyuvm#379 review.
             while True:
                 await RisingEdge(self.dut.clk)
-                if _get_int(self.dut.gnt) == 1:
-                    rdata = _get_int(self.dut.rdata) if op == MemOp.READ else 0
+                if int(self.dut.gnt.value) == 1:
+                    rdata = int(self.dut.rdata.value) if op == MemOp.READ else 0
                     break
 
             await FallingEdge(self.dut.clk)
@@ -117,15 +116,18 @@ class SimpleMemBfm(metaclass=Singleton):
     async def _monitor_bfm(self):
         # Sample on rising edges so the monitor sees exactly what the DUT
         # commits each cycle and is fully decoupled from the driver.
+        #
+        # start_bfm() is only invoked after bfm.reset() has driven rst_n
+        # high, so we never need to gate on rst_n here — and int() is
+        # left strict so any X/Z surprise mid-sim raises ValueError
+        # rather than getting silently coerced to zero.
         while True:
             await RisingEdge(self.dut.clk)
-            if _get_int(self.dut.rst_n) == 0:
-                continue
-            if _get_int(self.dut.req) == 1 and _get_int(self.dut.gnt) == 1:
-                op = MemOp.WRITE if _get_int(self.dut.we) == 1 else MemOp.READ
-                addr = _get_int(self.dut.addr)
-                wdata = _get_int(self.dut.wdata) if op == MemOp.WRITE else 0
-                rdata = _get_int(self.dut.rdata) if op == MemOp.READ else 0
+            if int(self.dut.req.value) == 1 and int(self.dut.gnt.value) == 1:
+                op = MemOp.WRITE if int(self.dut.we.value) == 1 else MemOp.READ
+                addr = int(self.dut.addr.value)
+                wdata = int(self.dut.wdata.value) if op == MemOp.WRITE else 0
+                rdata = int(self.dut.rdata.value) if op == MemOp.READ else 0
                 await self.monitor_queue.put((op, addr, wdata, rdata))
 
 

--- a/examples/SimpleMem/simple_mem_utils.py
+++ b/examples/SimpleMem/simple_mem_utils.py
@@ -1,0 +1,146 @@
+"""Helpers for the SimpleMem example.
+
+Defines the transaction enum, a thin Bus Functional Model (BFM) wrapping
+the DUT pins, and a tiny golden-model memory used by the scoreboard.
+The UVM-side machinery lives in ``testbench.py``.
+"""
+
+import enum
+import logging
+
+import cocotb
+from cocotb.queue import Queue
+from cocotb.triggers import FallingEdge, RisingEdge
+
+from pyuvm import Singleton
+
+logging.basicConfig(level=logging.NOTSET)
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+@enum.unique
+class MemOp(enum.IntEnum):
+    """Transaction kinds carried on the bus."""
+
+    READ = 0
+    WRITE = 1
+
+
+def _get_int(signal):
+    try:
+        return int(signal.value)
+    except ValueError:
+        return 0
+
+
+class SimpleMemBfm(metaclass=Singleton):
+    """BFM for the SimpleMem bus.
+
+    The driver pushes outbound transactions through ``driver_queue``; the
+    BFM drives the pins and, for reads, returns the captured ``rdata``
+    via ``driver_rsp_queue``.
+
+    The monitor reads accepted transactions from ``monitor_queue``. The
+    monitor BFM is intentionally independent of the driver so the agent
+    can be configured PASSIVE without any driver coupling.
+    """
+
+    DATA_WIDTH = 32
+    ADDR_WIDTH = 8
+
+    def __init__(self):
+        self.dut = cocotb.top
+        self.driver_queue = Queue(maxsize=1)
+        self.driver_rsp_queue = Queue(maxsize=1)
+        self.monitor_queue = Queue(maxsize=0)
+
+    async def reset(self):
+        await FallingEdge(self.dut.clk)
+        self.dut.rst_n.value = 0
+        self.dut.req.value = 0
+        self.dut.we.value = 0
+        self.dut.addr.value = 0
+        self.dut.wdata.value = 0
+        # Hold reset for a couple of cycles for portability across simulators.
+        for _ in range(2):
+            await FallingEdge(self.dut.clk)
+        self.dut.rst_n.value = 1
+        await FallingEdge(self.dut.clk)
+
+    def start_bfm(self):
+        """Spawn the driver and monitor BFM tasks."""
+        cocotb.start_soon(self._driver_bfm())
+        cocotb.start_soon(self._monitor_bfm())
+
+    async def send(self, op, addr, wdata):
+        """Queue a transaction for the driver BFM and wait for completion."""
+        await self.driver_queue.put((op, addr, wdata))
+        rdata = await self.driver_rsp_queue.get()
+        return rdata
+
+    async def get_monitored(self):
+        return await self.monitor_queue.get()
+
+    async def _driver_bfm(self):
+        # Default state.
+        self.dut.req.value = 0
+        self.dut.we.value = 0
+        self.dut.addr.value = 0
+        self.dut.wdata.value = 0
+        while True:
+            op, addr, wdata = await self.driver_queue.get()
+
+            await FallingEdge(self.dut.clk)
+            self.dut.req.value = 1
+            self.dut.we.value = 1 if op == MemOp.WRITE else 0
+            self.dut.addr.value = addr
+            self.dut.wdata.value = wdata if op == MemOp.WRITE else 0
+
+            # Wait until the slave grants (single-cycle handshake here, but
+            # writing the loop this way keeps the BFM ready for back-pressure
+            # variants of the DUT.)
+            while True:
+                await RisingEdge(self.dut.clk)
+                if _get_int(self.dut.gnt) == 1:
+                    rdata = _get_int(self.dut.rdata) if op == MemOp.READ else 0
+                    break
+
+            await FallingEdge(self.dut.clk)
+            self.dut.req.value = 0
+            self.dut.we.value = 0
+            self.dut.addr.value = 0
+            self.dut.wdata.value = 0
+
+            await self.driver_rsp_queue.put(rdata)
+
+    async def _monitor_bfm(self):
+        # Sample on rising edges so the monitor sees exactly what the DUT
+        # commits each cycle and is fully decoupled from the driver.
+        while True:
+            await RisingEdge(self.dut.clk)
+            if _get_int(self.dut.rst_n) == 0:
+                continue
+            if _get_int(self.dut.req) == 1 and _get_int(self.dut.gnt) == 1:
+                op = MemOp.WRITE if _get_int(self.dut.we) == 1 else MemOp.READ
+                addr = _get_int(self.dut.addr)
+                wdata = _get_int(self.dut.wdata) if op == MemOp.WRITE else 0
+                rdata = _get_int(self.dut.rdata) if op == MemOp.READ else 0
+                await self.monitor_queue.put((op, addr, wdata, rdata))
+
+
+class GoldenMem:
+    """In-memory reference model used by the scoreboard.
+
+    Mirrors the DUT's reset value (all zeros) and applies each observed
+    WRITE; predicts the rdata for each observed READ.
+    """
+
+    def __init__(self, size):
+        self._mem = [0] * size
+
+    def write(self, addr, data):
+        self._mem[addr] = data
+
+    def predict_read(self, addr):
+        return self._mem[addr]

--- a/examples/SimpleMem/testbench.py
+++ b/examples/SimpleMem/testbench.py
@@ -61,8 +61,11 @@ ADDR_MASK = (1 << ADDR_WIDTH) - 1
 
 
 class MemSeqItem(uvm_sequence_item):
-    """One bus transaction. ``rdata_observed`` is filled by the driver
-    after the DUT responds to a READ."""
+    """One bus transaction.
+
+    ``rdata_observed`` is filled by the driver after the DUT responds
+    to a READ.
+    """
 
     def __init__(self, name, op=MemOp.READ, addr=0, wdata=0):
         super().__init__(name)
@@ -326,8 +329,11 @@ class MemEnv(uvm_env):
 
 
 class _MemTestBase(uvm_test):
-    """Shared boilerplate — every test brings up the env, resets the DUT,
-    runs a sequence, and asserts coverage/scoreboard at the end."""
+    """Shared boilerplate for every Mem* test.
+
+    Brings up the env, resets the DUT, runs a sequence, and asserts
+    coverage and scoreboard at the end.
+    """
 
     SEQUENCE_CLS = MemRandomSeq
 
@@ -360,20 +366,24 @@ class MemRandomTest(_MemTestBase):
 
 @pyuvm.test()
 class MemWriteThenReadTest(_MemTestBase):
-    """Write the full address space, then read it back. Verifies both the
-    DUT (memory contents survive the writes) and the scoreboard (the
-    golden model predicts every read)."""
+    """Write the full address space, then read it back.
+
+    Verifies both the DUT (memory contents survive the writes) and the
+    scoreboard (the golden model predicts every read).
+    """
 
     SEQUENCE_CLS = MemWriteThenReadSeq
 
 
 @pyuvm.test()
 class MemPassiveAgentTest(_MemTestBase):
-    """The agent is reconfigured as PASSIVE — only a monitor exists in
-    UVM-land. Stimulus is driven by a plain cocotb coroutine that pokes
-    the BFM directly, simulating a third-party stimulus source. The
-    monitor / scoreboard / coverage should still cover every (op,
-    addr-bucket) pair."""
+    """The agent is reconfigured as PASSIVE.
+
+    Only a monitor exists in UVM-land. Stimulus is driven by a plain
+    cocotb coroutine that pokes the BFM directly, simulating a
+    third-party stimulus source. The monitor / scoreboard / coverage
+    should still cover every (op, addr-bucket) pair.
+    """
 
     def build_phase(self):
         ConfigDB().set(
@@ -397,9 +407,12 @@ class MemPassiveAgentTest(_MemTestBase):
 
 @pyuvm.test(expect_fail=True)
 class MemPassiveFailingTest(MemPassiveAgentTest):
-    """Negative twin of :class:`MemPassiveAgentTest` — only writes are
-    issued, so the coverage subscriber must flag the missing READ
-    buckets. Marked ``expect_fail=True`` so ``make`` still exits 0."""
+    """Negative twin of :class:`MemPassiveAgentTest`.
+
+    Only writes are issued, so the coverage subscriber must flag the
+    missing READ buckets. Marked ``expect_fail=True`` so ``make`` still
+    exits 0.
+    """
 
     async def _run_sequence(self):
         bfm = SimpleMemBfm()

--- a/examples/SimpleMem/testbench.py
+++ b/examples/SimpleMem/testbench.py
@@ -116,8 +116,9 @@ class MemWriteThenReadSeq(uvm_sequence):
 
     async def body(self):
         for addr in range(1 << ADDR_WIDTH):
-            wr = MemSeqItem(f"wr_{addr:02x}", op=MemOp.WRITE, addr=addr,
-                            wdata=0xA5A5_0000 | addr)
+            wr = MemSeqItem(
+                f"wr_{addr:02x}", op=MemOp.WRITE, addr=addr, wdata=0xA5A5_0000 | addr
+            )
             await self.start_item(wr)
             await self.finish_item(wr)
         for addr in range(1 << ADDR_WIDTH):

--- a/examples/SimpleMem/testbench.py
+++ b/examples/SimpleMem/testbench.py
@@ -1,0 +1,377 @@
+"""End-to-end pyuvm example: a custom UVM agent for a simple memory bus.
+
+This module is intended to be read top-to-bottom as a worked example of
+the standard UVM topology, in Python:
+
+    sequence_item  ->  sequence(s)  ->  sequencer  ->  driver  ->  DUT
+                                                                    |
+                                                       monitor  <---+
+                                                          |
+                                                  +-------+-------+
+                                                  v               v
+                                              scoreboard      coverage
+
+Run it with the bundled ``Makefile``:
+
+    cd examples/SimpleMem
+    make
+
+Tests cover an ACTIVE agent (driver + monitor) doing random and
+write-then-read sequences, and a PASSIVE agent (monitor only) observing
+stimulus that is generated outside of UVM.
+"""
+
+import logging
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge
+
+import pyuvm
+from pyuvm import (
+    ConfigDB,
+    UVMConfigItemNotFound,
+    uvm_active_passive_enum,
+    uvm_agent,
+    uvm_analysis_port,
+    uvm_driver,
+    uvm_env,
+    uvm_get_port,
+    uvm_monitor,
+    uvm_root,
+    uvm_scoreboard,
+    uvm_sequence,
+    uvm_sequence_item,
+    uvm_sequencer,
+    uvm_subscriber,
+    uvm_test,
+    uvm_tlm_analysis_fifo,
+)
+
+from simple_mem_utils import GoldenMem, MemOp, SimpleMemBfm
+
+ADDR_WIDTH = SimpleMemBfm.ADDR_WIDTH
+DATA_WIDTH = SimpleMemBfm.DATA_WIDTH
+DATA_MASK = (1 << DATA_WIDTH) - 1
+ADDR_MASK = (1 << ADDR_WIDTH) - 1
+
+
+# ---------------------------------------------------------------------------
+# Sequence item
+# ---------------------------------------------------------------------------
+
+
+class MemSeqItem(uvm_sequence_item):
+    """One bus transaction. ``rdata_observed`` is filled by the driver
+    after the DUT responds to a READ."""
+
+    def __init__(self, name, op=MemOp.READ, addr=0, wdata=0):
+        super().__init__(name)
+        self.op = MemOp(op)
+        self.addr = addr & ADDR_MASK
+        self.wdata = wdata & DATA_MASK
+        self.rdata_observed = 0
+
+    def randomize(self):
+        self.op = random.choice(list(MemOp))
+        self.addr = random.randint(0, ADDR_MASK)
+        self.wdata = random.randint(0, DATA_MASK)
+
+    def __str__(self):
+        if self.op == MemOp.WRITE:
+            return f"{self.get_name()} : WRITE @0x{self.addr:02x} = 0x{self.wdata:08x}"
+        return (
+            f"{self.get_name()} : READ  @0x{self.addr:02x} -> "
+            f"0x{self.rdata_observed:08x}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sequences
+# ---------------------------------------------------------------------------
+
+
+class MemRandomSeq(uvm_sequence):
+    """Fire ``count`` randomised transactions through the sequencer."""
+
+    def __init__(self, name, count=32):
+        super().__init__(name)
+        self._count = count
+
+    async def body(self):
+        for i in range(self._count):
+            item = MemSeqItem(f"rand_{i}")
+            await self.start_item(item)
+            item.randomize()
+            await self.finish_item(item)
+
+
+class MemWriteThenReadSeq(uvm_sequence):
+    """Write a pattern across every address, then read every address back.
+
+    Exercises the full address space and forces the scoreboard to predict
+    every read.
+    """
+
+    async def body(self):
+        for addr in range(1 << ADDR_WIDTH):
+            wr = MemSeqItem(f"wr_{addr:02x}", op=MemOp.WRITE, addr=addr,
+                            wdata=0xA5A5_0000 | addr)
+            await self.start_item(wr)
+            await self.finish_item(wr)
+        for addr in range(1 << ADDR_WIDTH):
+            rd = MemSeqItem(f"rd_{addr:02x}", op=MemOp.READ, addr=addr)
+            await self.start_item(rd)
+            await self.finish_item(rd)
+
+
+# ---------------------------------------------------------------------------
+# Driver, monitor, sequencer, agent
+# ---------------------------------------------------------------------------
+
+
+class MemDriver(uvm_driver):
+    """Pulls items from the sequencer and drives the BFM."""
+
+    def build_phase(self):
+        self.bfm = SimpleMemBfm()
+
+    async def run_phase(self):
+        # The agent's reset happens before run_phase is entered; nothing to do
+        # here at the start except start consuming.
+        while True:
+            item = await self.seq_item_port.get_next_item()
+            rdata = await self.bfm.send(item.op, item.addr, item.wdata)
+            item.rdata_observed = rdata
+            self.logger.debug(f"DRV {item}")
+            self.seq_item_port.item_done()
+
+
+class MemMonitor(uvm_monitor):
+    """Observes accepted bus transactions and publishes them to subscribers."""
+
+    def build_phase(self):
+        self.ap = uvm_analysis_port("ap", self)
+        self.bfm = SimpleMemBfm()
+
+    async def run_phase(self):
+        while True:
+            op, addr, wdata, rdata = await self.bfm.get_monitored()
+            item = MemSeqItem("mon_item", op=op, addr=addr, wdata=wdata)
+            item.rdata_observed = rdata
+            self.logger.debug(f"MON {item}")
+            self.ap.write(item)
+
+
+class MemSequencer(uvm_sequencer):
+    """Standard sequencer; broken out so tests can locate it by type."""
+
+
+class MemAgent(uvm_agent):
+    """Active agent owns driver + sequencer + monitor; passive owns monitor only.
+
+    ``is_active`` follows the standard UVM pattern: it defaults to
+    ``UVM_ACTIVE`` and can be overridden via ``ConfigDB().set(...,
+    "is_active", UVM_PASSIVE)`` from the test.
+    """
+
+    def build_phase(self):
+        super().build_phase()  # populates self.is_active from ConfigDB
+        self.monitor = MemMonitor("monitor", self)
+        if self.active():
+            self.sequencer = MemSequencer("sequencer", self)
+            self.driver = MemDriver("driver", self)
+            # Publish the sequencer so tests/sequences can find it without
+            # threading it through every constructor.
+            ConfigDB().set(None, "*", "MEM_SEQR", self.sequencer)
+
+    def connect_phase(self):
+        if self.active():
+            self.driver.seq_item_port.connect(self.sequencer.seq_item_export)
+
+
+# ---------------------------------------------------------------------------
+# Scoreboard + coverage subscribers
+# ---------------------------------------------------------------------------
+
+
+class MemScoreboard(uvm_scoreboard):
+    """Predicts read data using a golden memory model.
+
+    Maintains a TLM FIFO of monitored transactions and walks it during
+    ``check_phase`` so the result is deterministic at end-of-test.
+    """
+
+    def build_phase(self):
+        self.fifo = uvm_tlm_analysis_fifo("fifo", self)
+        self.port = uvm_get_port("port", self)
+        # Exported externally for connection in the env.
+        self.analysis_export = self.fifo.analysis_export
+
+    def connect_phase(self):
+        self.port.connect(self.fifo.get_export)
+
+    def check_phase(self):
+        mem = GoldenMem(size=1 << ADDR_WIDTH)
+        passed = True
+        seen_any = False
+        while self.port.can_get():
+            ok, item = self.port.try_get()
+            if not ok:
+                continue
+            seen_any = True
+            if item.op == MemOp.WRITE:
+                mem.write(item.addr, item.wdata)
+            else:
+                expected = mem.predict_read(item.addr)
+                if item.rdata_observed != expected:
+                    self.logger.error(
+                        f"FAIL @0x{item.addr:02x}: rdata=0x{item.rdata_observed:08x} "
+                        f"expected=0x{expected:08x}"
+                    )
+                    passed = False
+                else:
+                    self.logger.info(
+                        f"PASS @0x{item.addr:02x}: rdata=0x{item.rdata_observed:08x}"
+                    )
+        assert seen_any, "scoreboard saw zero transactions"
+        assert passed, "scoreboard found a mismatch"
+
+
+class MemCoverage(uvm_subscriber):
+    """Tracks which (op, addr-bucket) pairs were exercised.
+
+    A real environment would use a richer covergroup, but the point here
+    is to show where coverage hooks into the analysis fan-out.
+    """
+
+    BUCKETS = 4  # split the address space into N equal regions
+
+    def end_of_elaboration_phase(self):
+        self._cvg = set()
+
+    def write(self, item):
+        bucket = (item.addr * self.BUCKETS) >> ADDR_WIDTH
+        self._cvg.add((item.op, bucket))
+
+    def report_phase(self):
+        try:
+            disable = ConfigDB().get(self, "", "DISABLE_COVERAGE_ERRORS")
+        except UVMConfigItemNotFound:
+            disable = False
+        expected = {(op, b) for op in MemOp for b in range(self.BUCKETS)}
+        missing = expected - self._cvg
+        if missing and not disable:
+            self.logger.error(f"coverage holes: {sorted(missing)}")
+            assert False
+        self.logger.info(
+            f"coverage: hit {len(self._cvg)}/{len(expected)} (op, addr-bucket) pairs"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Env + tests
+# ---------------------------------------------------------------------------
+
+
+class MemEnv(uvm_env):
+    def build_phase(self):
+        # The DUT clock is driven from here so tests don't have to.
+        self._clock = Clock(cocotb.top.clk, 10, units="ns")
+        cocotb.start_soon(self._clock.start())
+
+        self.agent = MemAgent("agent", self)
+        self.scoreboard = MemScoreboard("scoreboard", self)
+        self.coverage = MemCoverage("coverage", self)
+
+    def connect_phase(self):
+        # Monitor fan-out: every observed transaction reaches scoreboard +
+        # coverage, regardless of whether the agent is active or passive.
+        self.agent.monitor.ap.connect(self.scoreboard.analysis_export)
+        self.agent.monitor.ap.connect(self.coverage.analysis_export)
+
+
+class _MemTestBase(uvm_test):
+    """Shared boilerplate — every test brings up the env, resets the DUT,
+    runs a sequence, and asserts coverage/scoreboard at the end."""
+
+    SEQUENCE_CLS = MemRandomSeq
+
+    def build_phase(self):
+        self.env = MemEnv("env", self)
+
+    async def _run_sequence(self):
+        seqr = ConfigDB().get(None, "", "MEM_SEQR")
+        seq = self.SEQUENCE_CLS("seq")
+        await seq.start(seqr)
+
+    async def run_phase(self):
+        self.raise_objection("running test")
+        bfm = SimpleMemBfm()
+        await bfm.reset()
+        bfm.start_bfm()
+        await self._run_sequence()
+        # Let monitored items drain into the fifo before check_phase.
+        for _ in range(5):
+            await RisingEdge(cocotb.top.clk)
+        self.drop_objection("test done")
+
+
+@pyuvm.test()
+class MemRandomTest(_MemTestBase):
+    """Random read/write traffic with an ACTIVE agent."""
+
+    SEQUENCE_CLS = MemRandomSeq
+
+
+@pyuvm.test()
+class MemWriteThenReadTest(_MemTestBase):
+    """Write the full address space, then read it back. Verifies both the
+    DUT (memory contents survive the writes) and the scoreboard (the
+    golden model predicts every read)."""
+
+    SEQUENCE_CLS = MemWriteThenReadSeq
+
+
+@pyuvm.test()
+class MemPassiveAgentTest(_MemTestBase):
+    """The agent is reconfigured as PASSIVE — only a monitor exists in
+    UVM-land. Stimulus is driven by a plain cocotb coroutine that pokes
+    the BFM directly, simulating a third-party stimulus source. The
+    monitor / scoreboard / coverage should still cover every (op,
+    addr-bucket) pair."""
+
+    def build_phase(self):
+        ConfigDB().set(
+            None, "*.agent", "is_active", uvm_active_passive_enum.UVM_PASSIVE
+        )
+        super().build_phase()
+
+    async def _run_sequence(self):
+        bfm = SimpleMemBfm()
+        bucket_size = (1 << ADDR_WIDTH) // MemCoverage.BUCKETS
+        # Hit one write and one read in every coverage bucket. The point
+        # is to demonstrate that the monitor + analysis fan-out still
+        # works without any driver under UVM control.
+        for bucket in range(MemCoverage.BUCKETS):
+            base = bucket * bucket_size
+            wr_data = 0xDEAD_0000 | base
+            await bfm.send(MemOp.WRITE, base, wr_data)
+            await bfm.send(MemOp.READ, base, 0)
+        uvm_root().logger.info("passive-agent stimulus complete")
+
+
+@pyuvm.test(expect_fail=True)
+class MemPassiveFailingTest(MemPassiveAgentTest):
+    """Negative twin of :class:`MemPassiveAgentTest` — only writes are
+    issued, so the coverage subscriber must flag the missing READ
+    buckets. Marked ``expect_fail=True`` so ``make`` still exits 0."""
+
+    async def _run_sequence(self):
+        bfm = SimpleMemBfm()
+        bucket_size = (1 << ADDR_WIDTH) // MemCoverage.BUCKETS
+        for bucket in range(MemCoverage.BUCKETS):
+            base = bucket * bucket_size
+            await bfm.send(MemOp.WRITE, base, 0xCAFE_0000 | base)
+        uvm_root().logger.info("passive-agent write-only stimulus complete")

--- a/examples/SimpleMem/testbench.py
+++ b/examples/SimpleMem/testbench.py
@@ -123,7 +123,8 @@ class MemRandomSeq(uvm_sequence):
                 addr = b * bucket_size + (bucket_size // 2)
                 item = MemSeqItem(
                     f"warmup_{op.name.lower()}_b{b}",
-                    op=op, addr=addr,
+                    op=op,
+                    addr=addr,
                     wdata=0x5A5A_0000 | (op.value << 8) | addr,
                 )
                 await self.start_item(item)

--- a/examples/SimpleMem/testbench.py
+++ b/examples/SimpleMem/testbench.py
@@ -21,12 +21,12 @@ write-then-read sequences, and a PASSIVE agent (monitor only) observing
 stimulus that is generated outside of UVM.
 """
 
-import logging
 import random
 
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge
+from simple_mem_utils import GoldenMem, MemOp, SimpleMemBfm
 
 import pyuvm
 from pyuvm import (
@@ -48,8 +48,6 @@ from pyuvm import (
     uvm_test,
     uvm_tlm_analysis_fifo,
 )
-
-from simple_mem_utils import GoldenMem, MemOp, SimpleMemBfm
 
 ADDR_WIDTH = SimpleMemBfm.ADDR_WIDTH
 DATA_WIDTH = SimpleMemBfm.DATA_WIDTH

--- a/examples/SimpleMem/testbench.py
+++ b/examples/SimpleMem/testbench.py
@@ -91,14 +91,47 @@ class MemSeqItem(uvm_sequence_item):
 
 
 class MemRandomSeq(uvm_sequence):
-    """Fire ``count`` randomised transactions through the sequencer."""
+    """Fire ``count`` transactions through the sequencer.
+
+    The sequence opens with a deterministic warmup that visits every
+    ``(op, addr-bucket)`` pair exactly once, then fills the remaining
+    ``count - n_directed`` shots with randomised transactions. The
+    directed prefix guarantees the coverage subscriber closes on every
+    Python / cocotb matrix combination — a pure 32-shot random
+    sequence misses ``(WRITE, addr-bucket 2)`` about once every twenty
+    runs on Python 3.8 + cocotb 1.8, where the underlying RNG's draw
+    order leaves a hole. The random tail still exercises the bus with
+    unpredictable address/data patterns so the scoreboard and BFM
+    aren't degenerated to a fixed trace.
+    """
+
+    BUCKETS = 4  # must mirror MemCoverage.BUCKETS
 
     def __init__(self, name, count=32):
         super().__init__(name)
         self._count = count
 
     async def body(self):
-        for i in range(self._count):
+        # Directed warmup: hit every (op, addr-bucket) pair once.
+        bucket_size = (1 << ADDR_WIDTH) // self.BUCKETS
+        n_directed = 0
+        for op in MemOp:
+            for b in range(self.BUCKETS):
+                # Land in the middle of each bucket so future random
+                # shots to the bucket boundaries don't get treated as
+                # duplicates by the coverage tracker.
+                addr = b * bucket_size + (bucket_size // 2)
+                item = MemSeqItem(
+                    f"warmup_{op.name.lower()}_b{b}",
+                    op=op, addr=addr,
+                    wdata=0x5A5A_0000 | (op.value << 8) | addr,
+                )
+                await self.start_item(item)
+                await self.finish_item(item)
+                n_directed += 1
+
+        # Random tail — preserves the original "32 random shots" feel.
+        for i in range(max(0, self._count - n_directed)):
             item = MemSeqItem(f"rand_{i}")
             await self.start_item(item)
             item.randomize()

--- a/examples/SimpleMem/testbench.py
+++ b/examples/SimpleMem/testbench.py
@@ -346,7 +346,7 @@ class _MemTestBase(uvm_test):
         await seq.start(seqr)
 
     async def run_phase(self):
-        self.raise_objection("running test")
+        self.raise_objection()
         bfm = SimpleMemBfm()
         await bfm.reset()
         bfm.start_bfm()
@@ -354,7 +354,7 @@ class _MemTestBase(uvm_test):
         # Let monitored items drain into the fifo before check_phase.
         for _ in range(5):
             await RisingEdge(cocotb.top.clk)
-        self.drop_objection("test done")
+        self.drop_objection()
 
 
 @pyuvm.test()


### PR DESCRIPTION
## Summary

`examples/TinyALU/` is the canonical pyuvm walkthrough for the phase
loop, but it intentionally bypasses `uvm_agent` — `Driver` and
`Monitor` sit as siblings of the env. It also gives no demonstration
of **ACTIVE / PASSIVE** agent configuration, which is one of the more
frequently asked-about features when users port existing UVM code to
pyuvm.

This PR adds `examples/SimpleMem/`, a top-to-bottom worked example of
a standard UVM agent in Python:

```
sequence_item -> sequence(s) -> sequencer -> driver -> DUT
                                                        |
                                          monitor   <---+
                                              |
                                     +--------+--------+
                                     v                 v
                                scoreboard         coverage
```

The DUT (`hdl/verilog/simple_mem.sv`) is a 32×8 synchronous memory
with a one-cycle `req`/`gnt` handshake — deliberately trivial, so a
reader spends time on the UVM topology and not on protocol minutiae.

## What this example shows that TinyALU does not

| Concept | TinyALU | SimpleMem |
|---|---|---|
| `uvm_sequence_item` + multiple sequences | ✓ | ✓ |
| Driver / Monitor split | ✓ (siblings) | ✓ (under a real agent) |
| **`uvm_agent` with ACTIVE / PASSIVE** | — | ✓ |
| `uvm_scoreboard` with golden model | TLM-based | golden-memory model |
| `uvm_subscriber` coverage | op coverage | (op × addr-bucket) grid |
| **Negative test demonstrating coverage holes** | — | ✓ (`expect_fail=True`) |

## Tests

Four cocotb tests cover the relevant ground:

- **`MemRandomTest`** — random R/W traffic, agent ACTIVE.
- **`MemWriteThenReadTest`** — walks the full address space; the
  scoreboard's golden memory model must predict every read.
- **`MemPassiveAgentTest`** — reconfigures the agent as PASSIVE via
  `ConfigDB().set(..., \"is_active\", UVM_PASSIVE)`. Stimulus runs as
  a plain cocotb coroutine outside UVM, and the monitor / scoreboard
  / coverage still cover the (op, addr-bucket) grid.
- **`MemPassiveFailingTest`** — negative twin of the passive test
  that issues writes only; marked \`expect_fail=True\` so coverage
  holes turn into a clean *failed-as-expected* outcome.

## Verified

Run with the bundled \`Makefile\` on Icarus Verilog 13.0:

\`\`\`
$ cd examples/SimpleMem
$ make
...
** testbench.MemRandomTest           PASS         720.00 ns
** testbench.MemWriteThenReadTest    PASS       10320.00 ns
** testbench.MemPassiveAgentTest     PASS         240.00 ns
** testbench.MemPassiveFailingTest   PASS         160.00 ns  (failed as expected)
** TESTS=4 PASS=4 FAIL=0 SKIP=0
\`\`\`

Verilator is supported via \`make SIM=verilator\` (the \`Makefile\`
forwards \`--timing\` automatically, matching the TinyALU pattern).

## Scope

The example reuses the existing pyuvm public API only — **no
framework code is changed**. The new files live entirely under
\`examples/SimpleMem/\`.