### PR TITLE
Implement uvm_mem RAL core support and reg_map memory plumbing

### DIFF
--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -538,7 +538,7 @@ class uvm_mem(uvm_object):
                 await self._do_read_frontdoor(rw, map_info)
             # TODO: post_read callbacks
             # TODO: report
-       finally:
+        finally:
             self._read_in_progress = False
 
     async def _do_read_backdoor(

--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -3,23 +3,23 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, ClassVar
 
+from cocotb.triggers import Lock
+
 from pyuvm._error_classes import UVMFatalError
+from pyuvm._reg.uvm_reg_item import uvm_reg_item
 from pyuvm._reg.uvm_reg_model import (
+    uvm_access_e,
     uvm_coverage_model_e,
     uvm_door_e,
+    uvm_elem_kind_e,
+    uvm_status_e,
 )
 from pyuvm._s05_base_classes import uvm_object
 
 if TYPE_CHECKING:
-    from pyuvm._reg.uvm_mem_mam import (
-        alloc_mode_e,
-        locality_e,
-        uvm_mem_mam,
-        uvm_mem_mam_cfg,
-    )
+    from pyuvm._reg.uvm_mem_mam import uvm_mem_mam
     from pyuvm._reg.uvm_reg_backdoor import uvm_reg_backdoor
     from pyuvm._reg.uvm_reg_block import uvm_reg_block
-    from pyuvm._reg.uvm_reg_item import uvm_reg_item
     from pyuvm._reg.uvm_reg_map import uvm_reg_map, uvm_reg_map_info
     from pyuvm._reg.uvm_reg_model import (
         uvm_hdl_path_concat,
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
         uvm_reg_addr_t,
         uvm_reg_cvr_t,
         uvm_reg_data_t,
-        uvm_status_e,
     )
     from pyuvm._reg.uvm_reg_sequence import uvm_reg_frontdoor
     from pyuvm._reg.uvm_vreg import uvm_vreg
@@ -67,7 +66,7 @@ class uvm_mem(uvm_object):
         self._vregs: list[uvm_vreg] = list()
         # self._hdl_paths_pool: uvm_object_string_pool = None
         self._mam: uvm_mem_mam = None
-        raise NotImplementedError
+        self._atomic = Lock()
 
     def configure(self, parent: uvm_reg_block, hdl_path: str = "") -> None:
         if not parent:
@@ -80,16 +79,10 @@ class uvm_mem(uvm_object):
                 "and 'RO', setting access to 'RW'"
             )
             self._access = "RW"
-            cfg = uvm_mem_mam_cfg()
-            cfg.n_bytes = 0
-            cfg.start_offset = 0
-            cfg.end_offset = self._size - 1
-            cfg.mode = alloc_mode_e.GREEDY
-            cfg.locality = locality_e.BROAD
-            self.mam = uvm_mem_mam(self.get_full_name(), cfg, self)
-            self._parent.add_mem(self)
-            if hdl_path != "":
-                self.add_hdl_path_slice(hdl_path, -1, -1)
+        # TODO: construct self._mam via uvm_mem_mam once implemented (PR2)
+        self._parent._add_memory(self)
+        if hdl_path != "":
+            self.add_hdl_path_slice(hdl_path, -1, -1)
 
     def set_offset(
         self, map: uvm_reg_map, offset: uvm_reg_addr_t, unmapped: bool = False
@@ -111,7 +104,7 @@ class uvm_mem(uvm_object):
         self._maps.append(map)
 
     def _lock_model(self) -> None:
-        self._lock_model = True
+        self._locked = True
 
     def _add_vreg(self, vreg: uvm_vreg) -> None:
         raise NotImplementedError
@@ -221,7 +214,7 @@ class uvm_mem(uvm_object):
         return self._size
 
     def get_n_bytes(self) -> int:
-        return int(self._n_bits - 1 / 8 + 1)
+        return (self._n_bits + 7) // 8
 
     def get_n_bits(self) -> int:
         return self._n_bits
@@ -300,9 +293,62 @@ class uvm_mem(uvm_object):
                 f"Memory '{self.get_name()}' is unmapped in map '{map_name}'"
             )
             return -1, list()
-        stride = map_info.stride
+        stride = map_info.mem_range.stride
         addresses = [a + stride * offset for a in map_info.addr]
         return local_map.get_n_bytes(), addresses
+
+    def _build_write_item(
+        self,
+        offset: uvm_reg_addr_t,
+        value: uvm_reg_data_t,
+        path: uvm_door_e,
+        map: uvm_reg_map,
+        parent: uvm_sequence_base,
+        prior: int,
+        extension: uvm_object,
+        fname: str,
+        lineno: int,
+    ) -> uvm_reg_item:
+        rw = uvm_reg_item("write_item")
+        rw.set_element(self)
+        rw.set_element_kind(uvm_elem_kind_e.UVM_MEM)
+        rw.set_kind(uvm_access_e.UVM_WRITE)
+        rw.set_value(value)
+        rw.set_offset(offset)
+        rw.set_door(path)
+        rw.set_map(map)
+        rw.set_parent_sequence(parent)
+        rw.set_priority(prior)
+        rw.set_extension(extension)
+        rw.set_fname(fname)
+        rw.set_line(lineno)
+        return rw
+
+    def _build_read_item(
+        self,
+        offset: uvm_reg_addr_t,
+        path: uvm_door_e,
+        map: uvm_reg_map,
+        parent: uvm_sequence_base,
+        prior: int,
+        extension: uvm_object,
+        fname: str,
+        lineno: int,
+    ) -> uvm_reg_item:
+        rw = uvm_reg_item("read_item")
+        rw.set_element(self)
+        rw.set_element_kind(uvm_elem_kind_e.UVM_MEM)
+        rw.set_kind(uvm_access_e.UVM_READ)
+        rw.set_value(0)
+        rw.set_offset(offset)
+        rw.set_door(path)
+        rw.set_map(map)
+        rw.set_parent_sequence(parent)
+        rw.set_priority(prior)
+        rw.set_extension(extension)
+        rw.set_fname(fname)
+        rw.set_line(lineno)
+        return rw
 
     async def write(
         self,
@@ -316,7 +362,12 @@ class uvm_mem(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        async with self._atomic:
+            rw = self._build_write_item(
+                offset, value, path, map, parent, prior, extension, fname, lineno
+            )
+            await self.do_write(rw)
+        return rw.get_status()
 
     async def read(
         self,
@@ -329,7 +380,12 @@ class uvm_mem(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        async with self._atomic:
+            rw = self._build_read_item(
+                offset, path, map, parent, prior, extension, fname, lineno
+            )
+            await self.do_read(rw)
+        return rw.get_status(), rw.get_value()
 
     async def burst_write(
         self,
@@ -343,7 +399,16 @@ class uvm_mem(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        status = uvm_status_e.UVM_IS_OK
+        async with self._atomic:
+            for i, val in enumerate(value):
+                rw = self._build_write_item(
+                    offset + i, val, path, map, parent, prior, extension, fname, lineno
+                )
+                await self.do_write(rw)
+                if rw.get_status() != uvm_status_e.UVM_IS_OK:
+                    status = rw.get_status()
+        return status
 
     async def burst_read(
         self,
@@ -357,7 +422,17 @@ class uvm_mem(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        status = uvm_status_e.UVM_IS_OK
+        async with self._atomic:
+            for i in range(len(value)):
+                rw = self._build_read_item(
+                    offset + i, path, map, parent, prior, extension, fname, lineno
+                )
+                await self.do_read(rw)
+                if rw.get_status() != uvm_status_e.UVM_IS_OK:
+                    status = rw.get_status()
+                value[i] = rw.get_value()
+        return status
 
     async def poke(
         self,
@@ -382,14 +457,108 @@ class uvm_mem(uvm_object):
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
         raise NotImplementedError
 
-    def _check_access(self, rw: uvm_reg_item) -> uvm_reg_map_info | None:
-        raise NotImplementedError
+    def _check_access(self, rw: uvm_reg_item) -> tuple[bool, uvm_reg_map_info | None]:
+        map_info = None
+        if rw.get_door() == uvm_door_e.UVM_DEFAULT_DOOR:
+            rw.set_door(self._parent.get_default_door())
+        if rw.get_door() == uvm_door_e.UVM_BACKDOOR:
+            raise NotImplementedError
+        if rw.get_door() != uvm_door_e.UVM_BACKDOOR:
+            tmp_map = rw.get_map()
+            rw.set_local_map(self.get_local_map(tmp_map))
+            if not rw.get_local_map():
+                # TODO: Error message
+                rw.set_status(uvm_status_e.UVM_NOT_OK)
+                return False, None
+            tmp_local_map = rw.get_local_map()
+            map_info = tmp_local_map.get_mem_map_info(self)
+            if not map_info.frontdoor and map_info.unmapped:
+                # TODO: Error message
+                rw.set_status(uvm_status_e.UVM_NOT_OK)
+                return False, None
+            if not tmp_map:
+                rw.set_map(tmp_local_map)
+        return True, map_info
 
     async def do_write(self, rw: uvm_reg_item) -> None:
+        self._fname = rw.get_fname()
+        self._lineno = rw.get_line()
+        rc, map_info = self._check_access(rw)
+        if not rc:
+            return
+        self._write_in_progress = True
+        rw.set_status(uvm_status_e.UVM_IS_OK)
+        # TODO: pre_write callbacks
+        door = rw.get_door()
+        if door == uvm_door_e.UVM_BACKDOOR:
+            await self._do_write_backdoor(rw, map_info)
+        elif door == uvm_door_e.UVM_FRONTDOOR:
+            await self._do_write_frontdoor(rw, map_info)
+        # TODO: post_write callbacks
+        # TODO: report
+        self._write_in_progress = False
+
+    async def _do_write_backdoor(
+        self, rw: uvm_reg_item, map_info: uvm_reg_map_info
+    ) -> None:
         raise NotImplementedError
 
+    async def _do_write_frontdoor(
+        self, rw: uvm_reg_item, map_info: uvm_reg_map_info
+    ) -> None:
+        local_map = rw.get_local_map()
+        system_map = local_map.get_root_map()
+        # INFO: User frontdoor
+        if map_info.frontdoor is not None:
+            frontdoor = map_info.frontdoor
+            frontdoor.atomic_lock()
+            frontdoor.rw_info = rw
+            if frontdoor.sequencer is None:
+                frontdoor.sequencer = system_map.get_sequencer()
+            frontdoor.start(frontdoor.sequencer, rw.get_parent_sequence())
+            frontdoor.atomic_unlock()
+        # INFO: Built in frontdoor
+        else:
+            await local_map.do_write(rw)
+
     async def do_read(self, rw: uvm_reg_item) -> None:
+        self._fname = rw.get_fname()
+        self._lineno = rw.get_line()
+        rc, map_info = self._check_access(rw)
+        if not rc:
+            return
+        self._read_in_progress = True
+        rw.set_status(uvm_status_e.UVM_IS_OK)
+        # TODO: pre_read callbacks
+        door = rw.get_door()
+        if door == uvm_door_e.UVM_BACKDOOR:
+            await self._do_read_backdoor(rw, map_info)
+        elif door == uvm_door_e.UVM_FRONTDOOR:
+            await self._do_read_frontdoor(rw, map_info)
+        # TODO: post_read callbacks
+        # TODO: report
+        self._read_in_progress = False
+
+    async def _do_read_backdoor(
+        self, rw: uvm_reg_item, map_info: uvm_reg_map_info
+    ) -> None:
         raise NotImplementedError
+
+    async def _do_read_frontdoor(
+        self, rw: uvm_reg_item, map_info: uvm_reg_map_info
+    ) -> None:
+        local_map = rw.get_local_map()
+        system_map = local_map.get_root_map()
+        if map_info.frontdoor:
+            frontdoor = map_info.frontdoor
+            frontdoor.atomic_lock()
+            frontdoor.rw_info = rw
+            if not frontdoor.sequencer:
+                frontdoor.sequencer = system_map.get_sequencer()
+            frontdoor.start(frontdoor.sequencer, rw.get_parent_sequence())
+            frontdoor.atomic_unlock()
+        else:  # Built-in frontdoor
+            await local_map.do_read(rw)
 
     def set_frontdoor(
         self,

--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -527,17 +527,19 @@ class uvm_mem(uvm_object):
         rc, map_info = self._check_access(rw)
         if not rc:
             return
-        self._read_in_progress = True
-        rw.set_status(uvm_status_e.UVM_IS_OK)
-        # TODO: pre_read callbacks
-        door = rw.get_door()
-        if door == uvm_door_e.UVM_BACKDOOR:
-            await self._do_read_backdoor(rw, map_info)
-        elif door == uvm_door_e.UVM_FRONTDOOR:
-            await self._do_read_frontdoor(rw, map_info)
-        # TODO: post_read callbacks
-        # TODO: report
-        self._read_in_progress = False
+        try:
+            self._read_in_progress = True
+            rw.set_status(uvm_status_e.UVM_IS_OK)
+            # TODO: pre_read callbacks
+            door = rw.get_door()
+            if door == uvm_door_e.UVM_BACKDOOR:
+                await self._do_read_backdoor(rw, map_info)
+            elif door == uvm_door_e.UVM_FRONTDOOR:
+                await self._do_read_frontdoor(rw, map_info)
+            # TODO: post_read callbacks
+            # TODO: report
+       finally:
+            self._read_in_progress = False
 
     async def _do_read_backdoor(
         self, rw: uvm_reg_item, map_info: uvm_reg_map_info

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -139,6 +139,19 @@ class uvm_reg_block(uvm_object):
             return
         self._regs[uid] = reg
 
+    def _add_memory(self, mem: uvm_mem) -> None:
+        uid = mem.get_inst_id()
+        if self.is_locked():
+            logger.error("Cannot add memory to a locked block model")
+            return
+        if uid in self._mems:
+            logger.error(
+                f"Memory {repr(mem.get_name())} has already been "
+                f"registered with block {self.get_full_name()}"
+            )
+            return
+        self._mems[uid] = mem
+
     def _add_virtual_register(self, vreg: uvm_vreg) -> None:
         raise NotImplementedError
 

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -12,6 +12,7 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_elem_kind_e,
     uvm_endianness_e,
     uvm_hier_e,
+    uvm_reg_map_addr_range,
 )
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._s14_15_python_sequences import uvm_sequence, uvm_sequence_base
@@ -27,10 +28,7 @@ if TYPE_CHECKING:
     from pyuvm._reg.uvm_reg_block import uvm_reg_block
     from pyuvm._reg.uvm_reg_field import uvm_reg_field
     from pyuvm._reg.uvm_reg_item import uvm_reg_item
-    from pyuvm._reg.uvm_reg_model import (
-        uvm_reg_addr_t,
-        uvm_reg_map_addr_range,
-    )
+    from pyuvm._reg.uvm_reg_model import uvm_reg_addr_t
     from pyuvm._reg.uvm_reg_sequence import uvm_reg_frontdoor
     from pyuvm._reg.uvm_vreg import uvm_vreg
     from pyuvm._reg.uvm_vreg_field import uvm_vreg_field
@@ -145,10 +143,44 @@ class uvm_reg_map(uvm_object):
                     # TODO: check memory overlap uvm_reg_map.svh:1619
                 self._regs_info[reg].addr = reg_addrs
         for mem, mem_info in self._mems_info.items():
-            raise NotImplementedError
+            mem_info.is_initialized = True
+            if not mem_info.unmapped:
+                bus_width, mem_addrs, mem_range = self._compute_mem_addr_info(
+                    mem, mem_info.offset
+                )
+                for range in root_map._mems_by_offset.keys():
+                    if mem_range.min <= range.max and mem_range.max >= range.min:
+                        other_mem = root_map._mems_by_offset[range]
+                        if other_mem is not mem:
+                            logger.warning(
+                                f"In map {repr(self.get_full_name())} "
+                                f"memory {repr(mem.get_full_name())} overlaps "
+                                "with address range of memory "
+                                f"{repr(other_mem.get_full_name())}"
+                            )
+                root_map._mems_by_offset[mem_range] = mem
+                mem_info.addr = mem_addrs
+                mem_info.mem_range = mem_range
         if bus_width == 0:
             bus_width = self._n_bytes
         self._system_n_bytes = bus_width
+
+    def _compute_mem_addr_info(
+        self, mem: uvm_mem, offset: uvm_reg_addr_t
+    ) -> tuple[int, list[uvm_reg_addr_t], uvm_reg_map_addr_range]:
+        bus_width, addrs0, _ = self._get_physical_addresses_to_map(
+            offset, 0, mem.get_n_bytes(), None, mem
+        )
+        if mem.get_size() > 1:
+            _, addrs1, _ = self._get_physical_addresses_to_map(
+                offset, 1, mem.get_n_bytes(), None, mem
+            )
+            stride = addrs1[0] - addrs0[0]
+        else:
+            stride = 0
+        max_addr = addrs0[-1] + (mem.get_size() - 1) * stride
+        mem_range = uvm_reg_map_addr_range(addrs0[0], max_addr, stride)
+        return bus_width, addrs0, mem_range
 
     @staticmethod
     def backdoor() -> uvm_reg_backdoor:
@@ -218,7 +250,25 @@ class uvm_reg_map(uvm_object):
         unmapped: bool = False,
         frontdoor: uvm_reg_frontdoor = None,
     ):
-        raise NotImplementedError
+        if mem in self._mems_info:
+            logger.error(
+                f"Memory {repr(mem.get_name())} has already been added "
+                f"to map {repr(self.get_full_name())}"
+            )
+        if mem.get_parent() != self.get_parent():
+            logger.error(
+                f"Memory {repr(mem.get_name())} may not be added to "
+                f"the address map {repr(self.get_full_name())}: they  "
+                "are not in the same block"
+            )
+        mem.add_map(self)
+        info = uvm_reg_map_info()
+        info.offset = offset
+        info.rights = rights
+        info.unmapped = unmapped
+        info.frontdoor = frontdoor
+        info.is_initialized = False
+        self._mems_info[mem] = info
 
     def add_submap(self, child_map: uvm_reg_map, offset: uvm_reg_addr_t) -> None:
         if not child_map:
@@ -387,7 +437,45 @@ class uvm_reg_map(uvm_object):
     def _set_mem_offset(
         self, mem: uvm_mem, offset: uvm_reg_addr_t, unmapped: bool
     ) -> None:
-        raise NotImplementedError
+        if mem not in self._mems_info:
+            logger.error(
+                f"Cannot modify offset of memory "
+                f"{repr(mem.get_full_name())} in address map "
+                f"{repr(self.get_full_name())} memory is not "
+                "mapped in that address map"
+            )
+            return
+        info = self._mems_info[mem]
+        blk = self.get_parent()
+        root_map = self.get_root_map()
+        # When block is locked we need to resolve the map. This is otherwise
+        # handled by the init addresses when the block is locked
+        if blk.is_locked():
+            if not info.unmapped and info.mem_range is not None:
+                if info.mem_range in root_map._mems_by_offset:
+                    del root_map._mems_by_offset[info.mem_range]
+        # remapping
+        if not unmapped:
+            bus_width, mem_addrs, mem_range = self._compute_mem_addr_info(mem, offset)
+            for range in root_map._mems_by_offset.keys():
+                if mem_range.min <= range.max and mem_range.max >= range.min:
+                    other_mem = root_map._mems_by_offset[range]
+                    if other_mem is not mem:
+                        logger.warning(
+                            f"In map {repr(self.get_full_name())} "
+                            f"memory {repr(mem.get_full_name())} overlaps "
+                            "with address range of memory "
+                            f"{repr(other_mem.get_full_name())}"
+                        )
+            root_map._mems_by_offset[mem_range] = mem
+            info.addr = mem_addrs
+            info.mem_range = mem_range
+        if unmapped:
+            info.offset = -1
+            info.unmapped = True
+        else:
+            info.offset = offset
+            info.unmapped = False
 
     def get_full_name(self) -> str:
         parent = self.get_parent()
@@ -507,8 +595,24 @@ class uvm_reg_map(uvm_object):
             )
         return map_info
 
-    def get_mem_map_info(self, mem: uvm_mem, error: bool) -> uvm_reg_map_info:
-        raise NotImplementedError
+    def get_mem_map_info(
+        self, mem: uvm_mem, error: bool = True
+    ) -> uvm_reg_map_info | None:
+        if mem not in self._mems_info:
+            if error:
+                logger.error(
+                    f"Memory {repr(mem.get_name())} not in map "
+                    f"{repr(self.get_full_name())}"
+                )
+            return
+        map_info = self._mems_info[mem]
+        if not map_info.is_initialized:
+            logger.warning(
+                f"Map {repr(self.get_full_name())} does not seem to "
+                "initialized correctly, check that the top "
+                "register model is locked()"
+            )
+        return map_info
 
     def get_size(self) -> int:
         raise NotImplementedError
@@ -540,7 +644,16 @@ class uvm_reg_map(uvm_object):
         return None
 
     def get_mem_by_offset(self, offset: uvm_reg_addr_t) -> uvm_mem:
-        raise NotImplementedError
+        if not self.get_parent().is_locked():
+            logger.error(
+                "Cannot get memory by offset : block "
+                f"{repr(self.get_parent().get_full_name())} is not locked"
+            )
+            return None
+        for range, mem in self._mems_by_offset.items():
+            if range.min <= offset <= range.max:
+                return mem
+        return None
 
     def set_auto_predict(self, on: bool = True) -> None:
         self._auto_predict = on
@@ -559,10 +672,21 @@ class uvm_reg_map(uvm_object):
     async def do_bus_write(
         self, rw: uvm_reg_item, sequencer: uvm_sequencer_base, adapter: uvm_reg_adapter
     ) -> None:
-        reg = rw.get_element()
-        bus_width, addrs, _ = self._get_physical_addresses_to_map(
-            self._regs_info[reg].offset, 0x0, reg.get_n_bytes(), None, None
-        )
+        element = rw.get_element()
+        if rw.get_element_kind() == uvm_elem_kind_e.UVM_MEM:
+            mem = element
+            bus_width, addrs, _ = self._get_physical_addresses_to_map(
+                self._mems_info[mem].offset,
+                rw.get_offset(),
+                mem.get_n_bytes(),
+                None,
+                mem,
+            )
+        else:
+            reg = element
+            bus_width, addrs, _ = self._get_physical_addresses_to_map(
+                self._regs_info[reg].offset, 0x0, reg.get_n_bytes(), None, None
+            )
         bus_op = uvm_reg_bus_op()
         bus_op.kind = uvm_access_e.UVM_WRITE
         bus_op.addr = addrs[0]
@@ -584,10 +708,21 @@ class uvm_reg_map(uvm_object):
     async def do_bus_read(
         self, rw: uvm_reg_item, sequencer: uvm_sequencer_base, adapter: uvm_reg_adapter
     ) -> None:
-        reg = rw.get_element()
-        bus_width, addrs, _ = self._get_physical_addresses_to_map(
-            self._regs_info[reg].offset, 0x0, reg.get_n_bytes(), None, None
-        )
+        element = rw.get_element()
+        if rw.get_element_kind() == uvm_elem_kind_e.UVM_MEM:
+            mem = element
+            bus_width, addrs, _ = self._get_physical_addresses_to_map(
+                self._mems_info[mem].offset,
+                rw.get_offset(),
+                mem.get_n_bytes(),
+                None,
+                mem,
+            )
+        else:
+            reg = element
+            bus_width, addrs, _ = self._get_physical_addresses_to_map(
+                self._regs_info[reg].offset, 0x0, reg.get_n_bytes(), None, None
+            )
         bus_op = uvm_reg_bus_op()
         bus_op.kind = uvm_access_e.UVM_READ
         bus_op.addr = addrs[0]

--- a/pyuvm/_reg/uvm_reg_model.py
+++ b/pyuvm/_reg/uvm_reg_model.py
@@ -147,8 +147,15 @@ class uvm_reg_frontdoor:
 
 
 class uvm_reg_map_addr_range:
-    def __init__(self):
-        raise NotImplementedError
+    def __init__(
+        self,
+        min: uvm_reg_addr_t = 0,
+        max: uvm_reg_addr_t = 0,
+        stride: int = 0,
+    ) -> None:
+        self.min = min
+        self.max = max
+        self.stride = stride
 
 
 class uvm_object_string_pool(uvm_object):

--- a/tests/pytests/reg/test_uvm_mem.py
+++ b/tests/pytests/reg/test_uvm_mem.py
@@ -1,0 +1,165 @@
+"""
+Main Packages for the entire memory RAL model
+"""
+
+import pytest
+
+from pyuvm._reg.uvm_mem import uvm_mem
+from pyuvm._reg.uvm_reg_block import uvm_reg_block
+from pyuvm._reg.uvm_reg_map import uvm_reg_map
+from pyuvm._reg.uvm_reg_model import uvm_endianness_e
+
+##############################################################################
+# TIPS
+##############################################################################
+"""
+Use this to execute the test which will not be counted into the entire
+number of FAILING tests
+@pytest.mark.xfail
+
+Use this to just skip the execution of a specific test
+@pytest.mark.skip
+
+Use this to give a specific test method a name ID the execute it by
+using py.test -m ID_NAME
+@pytest.mark.ID_NAME
+
+Use this to give a specific test parameters to be used
+@pytest.mark.parametrize("name1, name2",value_type_1, value_type_2)
+
+If pip install pytest-sugar is ran then pytest is gonna likely execute a bar
+progression while
+running tests (especially if in Parallel)
+"""
+
+##############################################################################
+# TESTS UVM_MEM
+##############################################################################
+
+
+@pytest.fixture
+def model():
+    class MemA(uvm_mem):
+        def __init__(self, name="MemA"):
+            super().__init__(name, size=1024, n_bits=32)
+
+    block = uvm_reg_block()
+    map = block.create_map("map", 0x0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, False)
+    mem = MemA()
+    mem.configure(block, "")
+    map.add_mem(mem, 0x1000, "RW", False, None)
+    block.lock_model()
+    return block, map, mem
+
+
+def test_get_name(model):
+    _, _, mem = model
+    assert mem.get_name() == "MemA"
+
+
+def test_get_size(model):
+    _, _, mem = model
+    assert mem.get_size() == 1024
+
+
+def test_get_n_bits(model):
+    _, _, mem = model
+    assert mem.get_n_bits() == 32
+
+
+def test_get_n_bytes(model):
+    _, _, mem = model
+    assert mem.get_n_bytes() == 4
+
+
+def test_get_access(model):
+    _, _, mem = model
+    assert mem.get_access() == "RW"
+
+
+def test_get_parent(model):
+    block, _, mem = model
+    assert mem.get_parent() is block
+    assert mem.get_block() is not uvm_reg_block()
+
+
+def test_get_block(model):
+    block, _, mem = model
+    assert mem.get_block() is block
+
+
+def test_get_address(model):
+    _, _, mem = model
+    assert mem.get_address() == 0x1000
+
+
+def test_get_addresses(model):
+    _, _, mem = model
+    n_bytes, addresses = mem.get_addresses()
+    assert n_bytes == 4
+    assert addresses == [0x1000]
+
+
+def test_get_addresses_with_offset(model):
+    _, _, mem = model
+    n_bytes, addresses = mem.get_addresses(offset=4)
+    assert n_bytes == 4
+    assert addresses == [0x1004]
+
+
+def test_get_addresses_out_of_range(model):
+    _, _, mem = model
+    n_bytes, addresses = mem.get_addresses(offset=1024)
+    assert n_bytes == -1
+    assert addresses == []
+
+
+def test_set_offset(model):
+    _, map, mem = model
+    mem.set_offset(map, 0x2000, unmapped=False)
+    assert mem.get_address() == 0x2000
+
+
+def test_get_n_maps(model):
+    _, _, mem = model
+    assert mem.get_n_maps() == 1
+
+
+def test_is_in_map(model):
+    _, map, mem = model
+    assert mem.is_in_map(map)
+    assert not mem.is_in_map(uvm_reg_map("other_map"))
+
+
+def test_map_get_mem_by_offset(model):
+    _, map, mem = model
+    assert map.get_mem_by_offset(0x1000) is mem
+
+
+def test_map_get_memories(model):
+    _, map, mem = model
+    assert map.get_memories() == [mem]
+
+
+def test_block_get_memories(model):
+    block, _, mem = model
+    assert block.get_memories() == [mem]
+
+
+def test_block_get_mem_by_name(model):
+    block, _, mem = model
+    assert block.get_mem_by_name("MemA") is mem
+
+
+def test_add_memory_to_locked_block_fails(model):
+    block, _, _ = model
+
+    class MemB(uvm_mem):
+        def __init__(self, name="MemB"):
+            super().__init__(name, size=16, n_bits=8)
+
+    mem_b = MemB()
+    # The block is already locked; configure() should not raise, but the
+    # memory must not be registered with the (locked) block.
+    mem_b.configure(block, "")
+    assert block.get_mem_by_name("MemB") is None


### PR DESCRIPTION
Adds working uvm_mem functionality per pyuvm/pyuvm#392:

- uvm_mem: fix configure()/init/_lock_model bugs that prevented memories from ever registering with their parent block; implement frontdoor write/read/burst_write/burst_read, do_write/do_read, and _check_access, mirroring the uvm_reg frontdoor pattern.
- uvm_mem: fix get_addresses() (map_info.stride -> mem_range.stride) and get_n_bytes() (operator-precedence bug that returned ~n_bits instead of the byte count).
- uvm_reg_map: implement memory address-map plumbing - mem loop in _init_address_map, add_mem(), _set_mem_offset(), get_mem_map_info(), get_mem_by_offset(), and mem branches in do_bus_write()/do_bus_read().
- uvm_reg_model: implement uvm_reg_map_addr_range.__init__.
- uvm_reg_block: add _add_memory() mirroring _add_register().
- tests: add tests/pytests/reg/test_uvm_mem.py covering name/size/ n_bits/n_bytes/access, parent/block linkage, address computation (including offset and out-of-range), map registration, and the locked-block registration-rejection path.

Backdoor access (poke/peek, do_*_backdoor) and uvm_mem_mam are left as NotImplementedError, consistent with uvm_reg's current stub state, and are deferred to a follow-up PR.

Fixes pyuvm/pyuvm#392