### PR TITLE
[uvm_report, logging] Add opt-in SV-UVM-style reporting over Python logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can read the API documentation for **pyuvm** on [ReadTheDocs](https://pyuvm.
 |Section|Name|Description|
 |-------|----|-----------|
 |5|Base Classes|Basic classes such as `uvm_void` and `uvm_object`|
-|6|Reporting Classes|**pyuvm** uses the **logging** package to implement reporting, but integrates it within some of the UVM reporting functionality.|
+|6|Reporting Classes|**pyuvm** uses the **logging** package as the reporting backend and provides optional SV-UVM-style reporting APIs, verbosity filtering, report IDs, severity counts, and summaries.|
 |8|Factory Classes|**pyuvm** implements all the UVM factory functionality without using the macros needed in SystemVerilog.  The factory supports any class extended from `uvm_void`.|
 |9|Phasing|IEEE 1800.2 describes basic phasing that everyone uses and a complicated custom phasing system that almost nobody uses.  **pyuvm** only implmenents the phasing that everyone uses, but you can extend phasing using Python OOP techniques.|
 |12|UVM TLM Interfaces|**pyuvm** fully implements the UVM *Transaction Level Modeling* (TLM) system. |
@@ -170,7 +170,7 @@ You'll see the following in the test:
 
 * The `ConfigDB()` singleton acts the same way as the `uvm_config_db` interface in the SystemVerilog UVM. **pyuvm** refactored away the `uvm_resource_db` as there are no issues with classes to manage.
 
-* **pyuvm** leverages the Python logging system and does not implement the UVM reporting system. Every descendent of `uvm_report_object` has a `logger` data member.
+* **pyuvm**'s default reporting use model leverages the Python logging system. Every `uvm_object` instance, including descendant instances, has a logger available through `self.logger`. The optional SV-UVM-style reporting path is described below.
 
 * Sequences work as they do in the SystemVerilog UVM.
 
@@ -275,7 +275,7 @@ The scoreboard receives commands from the command monitor and results from the r
 * The scoreboard exposes the FIFO exports by copying them into class data members.  As we see in the environment above, this allows us to connect the exports without reaching into the `Scoreboard's` inner workings.
 * We connect the exports in the `connect_phase()`
 * The `check_phase()` runs after the `run_phase()`.  At this point the scoreboard has all operations and results. It loops through the operations and predicts the result, then it compares the predicted and actual result.
-* Notice that we do not use UVM reporting. Instead we us the Python `logging` module. Every `uvm_report_object` and its children has its own logger stored in `self.logger.`
+* This example uses the Python `logging` module directly. Every `uvm_object` instance, including descendant instances, has a logger available through `self.logger`. Tests that need UVM-style report IDs and verbosity filtering can use `self.uvm_report` instead.
 
 ```python
 class Scoreboard(uvm_component):
@@ -454,12 +454,76 @@ class AluSeqItem(uvm_sequence_item):
 
 ```
 
+## SV-UVM-style reporting
+
+Existing pyuvm testbenches can continue to use Python logging directly:
+
+```python
+self.logger.info("Covered all operations")
+self.logger.error("Functional coverage error")
+```
+
+For testbenches that need UVM-style report IDs, UVM verbosity filtering, severity counts, report summaries, or report catching, pyuvm also provides an opt-in SV-UVM-style reporting path. Python logging remains the backend; the UVM-style layer decides whether a report is enabled, assigns UVM severity and report ID metadata, and then emits through logging.
+
+Enable the shared SV-UVM-style reporting mode before creating UVM objects or components:
+
+```bash
+PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1 
+```
+
+You can also enable it from Python before constructing the testbench:
+
+```python
+from pyuvm import set_sv_uvm_style_reporting_enabled
+
+set_sv_uvm_style_reporting_enabled(True)
+```
+
+The enable flag changes the logging topology so `uvm_object` loggers propagate to the shared `uvm` logger. In this mode, `uvm_report_object` does not install a default stream handler on every report object. If you also want centralized counts, summaries, and report catching, create the report server early in the test:
+
+```python
+from pyuvm import UVM_LOW, uvm_report_server
+
+report_server = uvm_report_server.create(verbosity=UVM_LOW)
+```
+
+Then write reports through `self.uvm_report`:
+
+```python
+from pyuvm import UVM_HIGH, UVM_LOW, uvm_component
+
+
+class Scoreboard(uvm_component):
+    def check_phase(self):
+        self.uvm_report.info("SCOREBOARD", "checking final results", UVM_LOW)
+
+        if self.mismatch_seen:
+            self.uvm_report.error("SCOREBOARD", "result mismatch detected")
+        else:
+            self.uvm_report.info("SCOREBOARD", "all results matched", UVM_HIGH)
+```
+
+UVM verbosity is handled separately from Python logging levels. A UVM info report passes when its message verbosity is less than or equal to the configured verbosity. Warning, error, and fatal reports are severity reports and are not suppressed by info verbosity. Python logging levels still carry severity to the backend formatter and handlers.
+
+At the end of a test, the report server can emit a summary and check failure policy:
+
+```python
+import logging
+from pyuvm import uvm_report_server
+
+report_server = uvm_report_server.get()
+report_server.log_summary(logging.getLogger("uvm"))
+report_server.assert_no_failures("end of test")
+```
+
+Output formatting still uses Python logging formatters. pyuvm's `PyuvmFormatter` remains the customization point for teams that want a different log layout while keeping the UVM-style report metadata and filtering behavior.
+
 
 # Contributing
 
 You can contribute to **pyuvm** by forking this repository and submitting pull requests.
 
-### Development Environment Setup
+## Development Environment Setup
 
 The pyuvm project uses forked Github rebase flow.
 The first step is to [fork the project](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
@@ -485,7 +549,7 @@ Next install the main development tools using `pip`.
 pip install .[dev]
 ```
 
-### Linting
+## Linting
 
 Linting is done with various tools: ruff, pre-commit, codespell, and others.
 These tools are all run using [pre-commit](https://pre-commit.com/).
@@ -502,7 +566,7 @@ pre-commit install
 ```
 
 
-### Testing
+## Testing
 
 The repository runs all needed tests using [tox](https://tox.wiki/en/stable/).
 This will run the full set of tests for all supported operating systems, Python versions, and cocotb versions.

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ For testbenches that need UVM-style report IDs, UVM verbosity filtering, severit
 Enable the shared SV-UVM-style reporting mode before creating UVM objects or components:
 
 ```bash
-PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1 
+PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1
 ```
 
 You can also enable it from Python before constructing the testbench:

--- a/docs/docsources/SV_UVM_Style_Reporting.rst
+++ b/docs/docsources/SV_UVM_Style_Reporting.rst
@@ -1,0 +1,141 @@
+SV-UVM-Style Reporting
+======================
+
+pyuvm uses Python logging as its reporting backend. Existing testbenches can
+continue to use ``self.logger.info()``, ``self.logger.warning()``, and
+``self.logger.error()`` directly.
+
+For testbenches that need UVM-style report IDs, UVM verbosity filtering,
+severity counts, report summaries, or report catching, pyuvm also provides an
+opt-in SV-UVM-style reporting path. The UVM-style layer performs the UVM
+reporting decisions and then emits through Python logging.
+
+Enabling SV-UVM-Style Reporting
+-------------------------------
+
+Enable the shared reporting mode before creating UVM objects or components:
+
+.. code-block:: bash
+
+   PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1 make sim
+
+You can also enable it from Python before constructing the testbench:
+
+.. code-block:: python
+
+   from pyuvm import set_sv_uvm_style_reporting_enabled
+
+   set_sv_uvm_style_reporting_enabled(True)
+
+When this mode is enabled, ``uvm_object`` loggers propagate to the shared
+``uvm`` logger. In this mode, ``uvm_report_object`` does not install a default
+stream handler on every report object. This preserves Python logging as the
+transport while giving the testbench a shared path for report rendering.
+
+To collect severity counts, use report summaries, or install report catcher
+rules, create the report server early in the test:
+
+.. code-block:: python
+
+   from pyuvm import UVM_LOW, uvm_report_server
+
+   report_server = uvm_report_server.create(verbosity=UVM_LOW)
+
+Writing Reports
+---------------
+
+Every ``uvm_object`` has a ``uvm_report`` property. Use it when you want
+UVM-style report IDs and UVM verbosity semantics:
+
+.. code-block:: python
+
+   from pyuvm import UVM_HIGH, UVM_LOW, uvm_component
+
+
+   class Scoreboard(uvm_component):
+       def check_phase(self):
+           self.uvm_report.info("SCOREBOARD", "checking final results", UVM_LOW)
+
+           if self.mismatch_seen:
+               self.uvm_report.error("SCOREBOARD", "result mismatch detected")
+           else:
+               self.uvm_report.info("SCOREBOARD", "all results matched", UVM_HIGH)
+
+The available report methods are:
+
+* ``self.uvm_report.info(report_id, message, verbosity)``
+* ``self.uvm_report.warning(report_id, message)``
+* ``self.uvm_report.error(report_id, message)``
+* ``self.uvm_report.fatal(report_id, message)``
+
+UVM Verbosity
+-------------
+
+UVM verbosity is not mapped onto Python logging levels. It is evaluated before
+the logging call using UVM semantics: an info report passes when its message
+verbosity is less than or equal to the configured verbosity.
+
+.. code-block:: python
+
+   from pyuvm import UVM_HIGH, UVM_LOW, uvm_report_server
+
+   uvm_report_server.create(verbosity=UVM_LOW)
+
+   self.uvm_report.info("LOW_ID", "visible", UVM_LOW)
+   self.uvm_report.info("HIGH_ID", "suppressed", UVM_HIGH)
+
+Warning, error, and fatal reports are severity reports. They are not suppressed
+by info verbosity. Python logging levels still carry severity to the backend
+formatter and handlers.
+
+Report Summary and Failure Policy
+---------------------------------
+
+The report server tracks UVM severity counts. At the end of a test, emit a
+summary and assert the failure policy:
+
+.. code-block:: python
+
+   import logging
+   from pyuvm import uvm_report_server
+
+   report_server = uvm_report_server.get()
+   report_server.log_summary(logging.getLogger("uvm"))
+   report_server.assert_no_failures("end of test")
+
+By default, warnings do not fail the test, while errors and fatals do. The
+policy can be changed when the report server is created:
+
+.. code-block:: python
+
+   from pyuvm import uvm_report_policy, uvm_report_server
+
+   policy = uvm_report_policy(fail_on_warning=True, max_quit_count=5)
+   uvm_report_server.create(policy=policy)
+
+Report Catching
+---------------
+
+The report server supports simple severity rewrites by report ID and message
+regular expression:
+
+.. code-block:: python
+
+   from pyuvm import UVM_WARNING, uvm_report_server
+
+   report_server = uvm_report_server.get()
+   report_server.add_change_sev("KNOWN_ISSUE", "temporary", UVM_WARNING)
+
+   self.uvm_report.error("KNOWN_ISSUE", "temporary mismatch")
+
+Formatter Relationship
+----------------------
+
+SV-UVM-style reporting does not replace Python logging. It provides UVM-shaped
+report metadata and filtering before the message reaches logging. The rendered
+timestamp, hierarchy, filename, line number, and final text layout still come
+from the active Python logging formatter.
+
+pyuvm's ``PyuvmFormatter`` remains the customization point for teams that want
+a different log layout while keeping the UVM-style report metadata, verbosity
+filtering, counts, summaries, and catcher behavior.

--- a/docs/docsources/UVM_and_Python.rst
+++ b/docs/docsources/UVM_and_Python.rst
@@ -141,4 +141,29 @@ There are no field macros and thus no need to implement this class.
 Reporting Classes
 ^^^^^^^^^^^^^^^^^
 
-We use Python logging instead of the UVM reporting system.
+pyuvm uses Python logging as the reporting backend. Existing tests can keep
+using ``self.logger`` directly, and every ``uvm_object`` instance, including
+descendant instances, has a logger available through ``self.logger``.
+
+pyuvm also provides an opt-in SV-UVM-style reporting path for tests that need
+report IDs, UVM verbosity filtering, severity counts, summaries, and report
+catching. Enable it before constructing the testbench:
+
+.. code-block:: python
+
+   from pyuvm import set_sv_uvm_style_reporting_enabled
+
+   set_sv_uvm_style_reporting_enabled(True)
+
+or from the shell:
+
+.. code-block:: bash
+
+   PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1 make sim
+
+UVM verbosity is handled separately from Python logging levels. Info reports
+pass when the report verbosity is less than or equal to the configured UVM
+verbosity. Python logging levels continue to represent severity for the backend
+formatter and handlers.
+
+See :doc:`SV_UVM_Style_Reporting` for examples.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,4 +6,5 @@ pyuvm
 
    docsources/README.md
    docsources/UVM_and_Python
+   docsources/SV_UVM_Style_Reporting
    apidocs/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,11 @@ known-third-party = [
 [tool.ruff.lint.per-file-ignores]
 "pyuvm/__init__.py" = [
     "F401",
+    "I001",
+]
+"pyuvm/uvm_reporting/__init__.py" = [
+    "E402",
+    "I001",
 ]
 
 [tool.codespell]

--- a/pyuvm/__init__.py
+++ b/pyuvm/__init__.py
@@ -109,6 +109,35 @@ from pyuvm._s05_base_classes import (
 
 # Section 6
 from pyuvm._s06_reporting_classes import uvm_report_object
+from pyuvm.uvm_reporting.uvm_report_catcher import (
+    uvm_report_action_e,
+    uvm_report_catcher,
+    uvm_report_message,
+)
+from pyuvm.uvm_reporting.uvm_report_server import (
+    uvm_report_policy,
+    uvm_report_server,
+    uvm_report_stats,
+)
+from pyuvm.uvm_reporting import (
+    get_sv_uvm_style_reporting_enabled,
+    set_sv_uvm_style_reporting_enabled,
+)
+from pyuvm.uvm_reporting.uvm_verbosity import (
+    UVM_DEBUG,
+    UVM_ERROR,
+    UVM_FATAL,
+    UVM_FULL,
+    UVM_HIGH,
+    UVM_INFO,
+    UVM_LOW,
+    UVM_MEDIUM,
+    UVM_NONE,
+    UVM_WARNING,
+    parse_uvm_verbosity,
+    resolve_uvm_verbosity,
+    uvm_reporter,
+)
 
 # Section 8
 from pyuvm._s08_factory_classes import uvm_factory
@@ -342,7 +371,28 @@ __all__ = [
     "uvm_policy",
     "uvm_transaction",
     # Section 6 - Reporting classes
+    "UVM_DEBUG",
+    "UVM_ERROR",
+    "UVM_FATAL",
+    "UVM_FULL",
+    "UVM_HIGH",
+    "UVM_INFO",
+    "UVM_LOW",
+    "UVM_MEDIUM",
+    "UVM_NONE",
+    "UVM_WARNING",
+    "parse_uvm_verbosity",
+    "resolve_uvm_verbosity",
+    "get_sv_uvm_style_reporting_enabled",
+    "set_sv_uvm_style_reporting_enabled",
+    "uvm_report_action_e",
+    "uvm_report_catcher",
+    "uvm_report_message",
     "uvm_report_object",
+    "uvm_report_policy",
+    "uvm_report_server",
+    "uvm_report_stats",
+    "uvm_reporter",
     # Section 8 - Factory classes
     "uvm_factory",
     # Section 9 - Phasing classes
@@ -458,7 +508,8 @@ __all__ = [
 # Set the __module__ attribute for all re-exported names.
 # This is necessary for the documentation generation tools to link objects correctly.
 for _name in __all__:
-    # Skip non-classes and non-functions.
-    if _name in {"__version__", "FIFO_DEBUG", "PYUVM_DEBUG", "uvm_common_phases"}:
-        continue
-    globals()[_name].__module__ = __name__
+    _obj = globals()[_name]
+    # Constants and collection exports do not have __module__; re-home only
+    # exported objects that expose it for autodoc links.
+    if hasattr(_obj, "__module__"):
+        _obj.__module__ = __name__

--- a/pyuvm/_s05_base_classes.py
+++ b/pyuvm/_s05_base_classes.py
@@ -2,16 +2,24 @@
 This file defines the UVM base classes
 """
 
+import logging
+
 from cocotb.utils import get_sim_time
 
 from pyuvm._error_classes import UsePythonMethod, UVMFatalError, UVMNotImplemented
 from pyuvm._s08_factory_classes import uvm_factory
 from pyuvm._utility_classes import uvm_void
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting.uvm_base_core_report import uvm_base_core_report
+from pyuvm.uvm_reporting.uvm_report_server import uvm_report_server
+from pyuvm.uvm_reporting.uvm_verbosity import UVM_LOW
 
 
 # 5.3.1
 class uvm_object(uvm_void):
     """The most basic UVM object"""
+
+    __default_logging_level = logging.INFO
 
     # 5.3.2
     def __init__(self, name=""):
@@ -19,7 +27,99 @@ class uvm_object(uvm_void):
         :param name: Name of the object. Default is empty string.
         """
         assert isinstance(name, str), f"{name} is not a string it is a {type(name)}"
+        self._logger = None
+        self._uvm_report_core = None
+        parent = getattr(self, "parent", None)
+        self._uvm_verbosity = int(getattr(parent, "uvm_verbosity", UVM_LOW))
         self.set_name(name)
+
+    def get_initial_logger_name(self):
+        """
+        :returns: The name of the initial logger
+
+        Override this method if you want to change the way the logger name is
+        generated.
+
+        The default looks like this:
+
+        .. code-block:: python
+            return self.get_full_name() + str(id(self))
+
+        """
+        return self.get_full_name() + str(id(self))
+
+    @staticmethod
+    def set_default_logging_level(default_logging_level):
+        """
+        :param default_logging_level: The default logging level
+        :returns: None
+
+        """
+        uvm_object.__default_logging_level = default_logging_level
+
+    @staticmethod
+    def get_default_logging_level():
+        """
+        :returns: The default logging level
+
+        """
+        return uvm_object.__default_logging_level
+
+    @property
+    def logger(self):
+        if self._logger is None:
+            uvm_root_logger = logging.getLogger("uvm")
+            logger_name = self.get_initial_logger_name()
+            self._logger = uvm_root_logger.getChild(logger_name) if logger_name else uvm_root_logger
+            self._logger.setLevel(level=uvm_object.get_default_logging_level())
+            self._logger.propagate = get_sv_uvm_style_reporting_enabled()
+            manager = uvm_report_server.get_or_none()
+            if manager is not None:
+                manager.register_logger(self._logger)
+        return self._logger
+
+    @logger.setter
+    def logger(self, logger):
+        assert isinstance(logger, logging.Logger), (
+            f"You must pass a logging.Logger not {type(logger)}"
+        )
+        self._logger = logger
+        manager = uvm_report_server.get_or_none()
+        if manager is not None:
+            manager.register_logger(logger)
+        if self._uvm_report_core is not None:
+            self._uvm_report_core.set_logger(logger)
+
+    @property
+    def uvm_verbosity(self):
+        return self._uvm_verbosity
+
+    @uvm_verbosity.setter
+    def uvm_verbosity(self, verbosity):
+        self.set_report_verbosity(verbosity)
+
+    def get_report_verbosity(self):
+        return self._uvm_verbosity
+
+    def set_report_verbosity(self, verbosity):
+        self._uvm_verbosity = int(verbosity)
+        if self._uvm_report_core is None:
+            _ = self.uvm_report
+        self._uvm_report_core.set_verbosity(self._uvm_verbosity)
+        return self._uvm_verbosity
+
+    def set_report_logger(self, logger):
+        self.logger = logger
+
+    @property
+    def uvm_report(self):
+        if self._uvm_report_core is None:
+            self._uvm_report_core = uvm_base_core_report(
+                owner=self,
+                parent=None,
+                default_verbosity=self._uvm_verbosity,
+            )
+        return self._uvm_report_core.uvm_report
 
     # 5.3.3.1
     def get_uvm_seeding(self):

--- a/pyuvm/_s05_base_classes.py
+++ b/pyuvm/_s05_base_classes.py
@@ -70,7 +70,11 @@ class uvm_object(uvm_void):
         if self._logger is None:
             uvm_root_logger = logging.getLogger("uvm")
             logger_name = self.get_initial_logger_name()
-            self._logger = uvm_root_logger.getChild(logger_name) if logger_name else uvm_root_logger
+            self._logger = (
+                uvm_root_logger.getChild(logger_name)
+                if logger_name
+                else uvm_root_logger
+            )
             self._logger.setLevel(level=uvm_object.get_default_logging_level())
             self._logger.propagate = get_sv_uvm_style_reporting_enabled()
             manager = uvm_report_server.get_or_none()

--- a/pyuvm/_s06_reporting_classes.py
+++ b/pyuvm/_s06_reporting_classes.py
@@ -11,6 +11,8 @@ import sys
 
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._utils import cocotb_version_info
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting.uvm_report_server import uvm_report_server
 
 if cocotb_version_info < (2, 0):
     from cocotb.log import SimColourLogFormatter, SimLogFormatter, SimTimeContextFilter
@@ -24,6 +26,19 @@ else:
     from cocotb.logging import SimLogFormatter, SimTimeContextFilter
 
     FormatterBase = SimLogFormatter
+
+
+class PyuvmSimTimeContextFilter(SimTimeContextFilter):
+    """Use cocotb sim time, but tolerate pytest/docs runs outside simulation."""
+
+    def filter(self, record):
+        try:
+            return super().filter(record)
+        except RuntimeError:
+            # cocotb's filter needs a running simulator. Plain pytest and docs
+            # imports do not have one, but should still be able to log.
+            record.created_sim_time = None
+            return True
 
 
 class PyuvmFormatter(FormatterBase):
@@ -51,9 +66,36 @@ class PyuvmFormatter(FormatterBase):
         return formatted_msg
 
 
+def configure_uvm_root_logger():
+    """Attach pyuvm's default stream handler once to the shared uvm logger."""
+    if not get_sv_uvm_style_reporting_enabled():
+        return None
+
+    uvm_root_logger = logging.getLogger("uvm")
+    uvm_root_logger.setLevel(logging.INFO)
+    uvm_root_logger.propagate = False
+    for handler in uvm_root_logger.handlers:
+        if getattr(handler, "_pyuvm_default_handler", False):
+            return handler
+
+    streaming_handler = logging.StreamHandler(sys.stdout)
+    streaming_handler._pyuvm_default_handler = True
+    streaming_handler.addFilter(PyuvmSimTimeContextFilter())
+    streaming_handler.setLevel(logging.NOTSET)
+    streaming_handler.setFormatter(FormatterBase())
+    uvm_root_logger.addHandler(streaming_handler)
+
+    manager = uvm_report_server.get_or_none()
+    if manager is not None:
+        manager.register_logger(uvm_root_logger)
+    return streaming_handler
+
+
+configure_uvm_root_logger()
+
+
 # 6.2.1
 class uvm_report_object(uvm_object):
-    __default_logging_level = logging.INFO
     """ The basis of all classes that can report """
 
     def __init__(self, name):
@@ -63,35 +105,21 @@ class uvm_report_object(uvm_object):
 
         """
         super().__init__(name)
-        uvm_root_logger = logging.getLogger("uvm")
-        # Every object gets its own logger
-        logger_name = self.get_initial_logger_name()
-        self.logger = uvm_root_logger.getChild(logger_name)
-        self.logger.setLevel(level=uvm_report_object.get_default_logging_level())
-        # We are not sending log messages up the hierarchy
-        self.logger.propagate = False
-        self._streaming_handler = logging.StreamHandler(sys.stdout)
-        self._streaming_handler.addFilter(SimTimeContextFilter())
-        # Don't let the handler interfere with logger level
-        self._streaming_handler.setLevel(logging.NOTSET)
-        # Make log messages look like UVM messages
         self._uvm_formatter = PyuvmFormatter(self.get_full_name())
-        self.add_logging_handler(self._streaming_handler)
-
-    def get_initial_logger_name(self):
-        """
-        :returns: The name of the initial logger
-
-        Override this method if you want to change the way the logger name is
-        generated.
-
-        The default looks like this:
-
-        .. code-block:: python
-            return self.get_full_name() + str(id(self))
-
-        """
-        return self.get_full_name() + str(id(self))
+        if get_sv_uvm_style_reporting_enabled():
+            configure_uvm_root_logger()
+            self.logger.propagate = True
+            for handler in list(self.logger.handlers):
+                if getattr(handler, "_pyuvm_object_default_handler", False):
+                    self.logger.removeHandler(handler)
+            self._streaming_handler = None
+        else:
+            self.logger.propagate = False
+            self._streaming_handler = logging.StreamHandler(sys.stdout)
+            self._streaming_handler._pyuvm_object_default_handler = True
+            self._streaming_handler.addFilter(PyuvmSimTimeContextFilter())
+            self._streaming_handler.setLevel(logging.NOTSET)
+            self.add_logging_handler(self._streaming_handler)
 
     @staticmethod
     def set_default_logging_level(default_logging_level):
@@ -100,7 +128,7 @@ class uvm_report_object(uvm_object):
         :returns: None
 
         """
-        uvm_report_object.__default_logging_level = default_logging_level
+        uvm_object.set_default_logging_level(default_logging_level)
 
     @staticmethod
     def get_default_logging_level():
@@ -108,7 +136,7 @@ class uvm_report_object(uvm_object):
         :returns: The default logging level
 
         """
-        return uvm_report_object.__default_logging_level
+        return uvm_object.get_default_logging_level()
 
     def set_logging_level(self, logging_level):
         """
@@ -128,9 +156,12 @@ class uvm_report_object(uvm_object):
             f"You must pass a logging.Handler not {type(handler)}"
         )
         if handler.formatter is None:
-            handler.addFilter(SimTimeContextFilter())
+            handler.addFilter(PyuvmSimTimeContextFilter())
             handler.setFormatter(self._uvm_formatter)
         self.logger.addHandler(handler)
+        manager = uvm_report_server.get_or_none()
+        if manager is not None:
+            manager.register_logger(self.logger)
 
     def remove_logging_handler(self, handler):
         """
@@ -149,7 +180,10 @@ class uvm_report_object(uvm_object):
 
         Removes the streaming handler
         """
+        if self._streaming_handler is None:
+            return
         self.logger.removeHandler(self._streaming_handler)
+        self._streaming_handler = None
 
     def disable_logging(self):
         """
@@ -158,4 +192,5 @@ class uvm_report_object(uvm_object):
         Disables logging
         """
         self.remove_streaming_handler()
+        self.logger.propagate = False
         self.add_logging_handler(logging.NullHandler())

--- a/pyuvm/_s06_reporting_classes.py
+++ b/pyuvm/_s06_reporting_classes.py
@@ -96,7 +96,7 @@ configure_uvm_root_logger()
 
 # 6.2.1
 class uvm_report_object(uvm_object):
-    """ The basis of all classes that can report """
+    """The basis of all classes that can report"""
 
     def __init__(self, name):
         """

--- a/pyuvm/uvm_reporting/__init__.py
+++ b/pyuvm/uvm_reporting/__init__.py
@@ -1,0 +1,71 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""UVM reporting helpers."""
+
+import os
+from typing import Any
+
+
+_ENV_VAR = "PYUVM_ENABLE_SV_UVM_STYLE_REPORTING"
+_TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "f", "no", "n", "off", ""}
+
+
+def _parse_bool(value: Any) -> bool:
+    text = str(value).strip().lower()
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return False
+
+
+_sv_uvm_style_reporting_enabled = _parse_bool(os.getenv(_ENV_VAR, "0"))
+
+
+def set_sv_uvm_style_reporting_enabled(enabled: bool) -> None:
+    """Enable or disable SV-UVM-style centralized reporting behavior."""
+    global _sv_uvm_style_reporting_enabled
+    _sv_uvm_style_reporting_enabled = bool(enabled)
+
+
+def get_sv_uvm_style_reporting_enabled() -> bool:
+    """Return whether SV-UVM-style centralized reporting behavior is enabled."""
+    return _sv_uvm_style_reporting_enabled
+
+
+from pyuvm.uvm_reporting.uvm_verbosity import (
+    UVM_DEBUG,
+    UVM_ERROR,
+    UVM_FATAL,
+    UVM_FULL,
+    UVM_HIGH,
+    UVM_INFO,
+    UVM_LOW,
+    UVM_MEDIUM,
+    UVM_NONE,
+    UVM_WARNING,
+    parse_uvm_verbosity,
+    resolve_uvm_verbosity,
+    uvm_reporter,
+)
+
+__all__ = [
+    "UVM_DEBUG",
+    "UVM_ERROR",
+    "UVM_FATAL",
+    "UVM_FULL",
+    "UVM_HIGH",
+    "UVM_INFO",
+    "UVM_LOW",
+    "UVM_MEDIUM",
+    "UVM_NONE",
+    "UVM_WARNING",
+    "parse_uvm_verbosity",
+    "resolve_uvm_verbosity",
+    "get_sv_uvm_style_reporting_enabled",
+    "set_sv_uvm_style_reporting_enabled",
+    "uvm_reporter",
+]

--- a/pyuvm/uvm_reporting/uvm_base_core_report.py
+++ b/pyuvm/uvm_reporting/uvm_base_core_report.py
@@ -1,0 +1,47 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composed reporting helper for UVM objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyuvm.uvm_reporting.uvm_verbosity import (
+    UVM_LOW,
+    resolve_uvm_verbosity,
+    uvm_reporter,
+)
+
+
+class uvm_base_core_report:
+    """Owns logger, effective verbosity, and the bound UVM reporter."""
+
+    def __init__(
+        self,
+        owner: Any,
+        parent: Any | None = None,
+        default_verbosity: int = UVM_LOW,
+    ) -> None:
+        self.owner = owner
+        self.logger = getattr(owner, "logger")
+        inherited = getattr(parent, "uvm_verbosity", default_verbosity)
+        self.verbosity: int = int(inherited)
+        self.uvm_report = uvm_reporter(self.logger, self.verbosity)
+
+    def apply_cfg(self, cfg: Any | None = None) -> int:
+        """Resolve effective verbosity with an optional cfg override."""
+        self.verbosity = resolve_uvm_verbosity(self.verbosity, cfg)
+        self.uvm_report.set_logger(self.logger)
+        self.uvm_report.set_verbosity(self.verbosity)
+        return self.verbosity
+
+    def set_verbosity(self, verbosity: int) -> int:
+        self.verbosity = int(verbosity)
+        self.uvm_report.set_verbosity(self.verbosity)
+        return self.verbosity
+
+    def set_logger(self, logger: Any) -> None:
+        self.logger = logger
+        self.uvm_report.set_logger(logger)

--- a/pyuvm/uvm_reporting/uvm_report_catcher.py
+++ b/pyuvm/uvm_reporting/uvm_report_catcher.py
@@ -94,6 +94,8 @@ class uvm_report_catcher:
         - action (always ``THROW``)
         - possibly rewritten severity
         """
-        report = uvm_report_message(report_id=report_id, message=message, severity=severity)
+        report = uvm_report_message(
+            report_id=report_id, message=message, severity=severity
+        )
         action = self.catch(report)
         return action, report.severity

--- a/pyuvm/uvm_reporting/uvm_report_catcher.py
+++ b/pyuvm/uvm_reporting/uvm_report_catcher.py
@@ -1,0 +1,99 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Report catcher/demoter utility."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class uvm_report_action_e(str, Enum):
+    """Mirror UVM catcher action enum values used by this utility."""
+
+    THROW = "THROW"
+
+
+@dataclass
+class uvm_report_message:
+    """Report payload passed to ``uvm_report_catcher.catch()``."""
+
+    report_id: str
+    message: str
+    severity: Any
+
+
+class uvm_report_catcher:
+    """
+    Severity rewrite utility.
+
+    The API mirrors the SV methods:
+    - ``add_change_sev(id, msg, sev)``
+    - ``remove_change_sev(id, msg="")``
+    - ``catch(report)``
+    """
+
+    def __init__(self, name: str = "uvm_report_catcher") -> None:
+        self.name = name
+        self._changed_sev: dict[str, dict[str, Any]] = {}
+
+    def catch(self, report: uvm_report_message) -> uvm_report_action_e:
+        """
+        Apply severity rewrite rules to a report in-place.
+
+        Returns ``THROW`` to mirror SV behavior: let report continue after mutation.
+        """
+        for key in (report.report_id, "*"):
+            rules = self._changed_sev.get(key)
+            if rules is None:
+                continue
+            for msg_regex, severity in rules.items():
+                if re.search(msg_regex, report.message):
+                    report.severity = severity
+        return uvm_report_action_e.THROW
+
+    def add_change_sev(self, report_id: str, msg: str, sev: Any) -> None:
+        """Change severity for reports with matching ID and message regex."""
+        self._changed_sev.setdefault(report_id, {})[msg] = sev
+
+    def remove_change_sev(self, report_id: str, msg: str = "") -> None:
+        """
+        Remove a severity change entry.
+
+        If ``msg == ""``, remove all rules for the report ID.
+        """
+        if report_id not in self._changed_sev:
+            return
+
+        if msg == "":
+            del self._changed_sev[report_id]
+            return
+
+        self._changed_sev[report_id].pop(msg, None)
+        if not self._changed_sev[report_id]:
+            del self._changed_sev[report_id]
+
+    def clear(self) -> None:
+        """Remove all severity rewrite rules."""
+        self._changed_sev.clear()
+
+    def catch_fields(
+        self,
+        report_id: str,
+        message: str,
+        severity: Any,
+    ) -> tuple[uvm_report_action_e, Any]:
+        """
+        Convenience wrapper for call sites that pass raw fields.
+
+        Returns:
+        - action (always ``THROW``)
+        - possibly rewritten severity
+        """
+        report = uvm_report_message(report_id=report_id, message=message, severity=severity)
+        action = self.catch(report)
+        return action, report.severity

--- a/pyuvm/uvm_reporting/uvm_report_server.py
+++ b/pyuvm/uvm_reporting/uvm_report_server.py
@@ -61,7 +61,9 @@ class uvm_report_stats:
         return total
 
     def error_quit_reached(self, policy: uvm_report_policy) -> bool:
-        return int(policy.max_quit_count) > 0 and self.error_quit_count >= int(policy.max_quit_count)
+        return int(policy.max_quit_count) > 0 and self.error_quit_count >= int(
+            policy.max_quit_count
+        )
 
 
 class _uvm_report_filter(logging.Filter):
@@ -210,7 +212,9 @@ class uvm_report_server:
         print_char_len: int = 300,
     ) -> None:
         self.shutdown()
-        self._root_logger = root_logger if root_logger is not None else logging.getLogger("uvm")
+        self._root_logger = (
+            root_logger if root_logger is not None else logging.getLogger("uvm")
+        )
         self._verbosity = int(verbosity)
         self._print_char_len = int(print_char_len)
         self._policy = policy if policy is not None else uvm_report_policy()
@@ -364,7 +368,11 @@ class uvm_report_server:
         prior_failure_msg: str | None = None,
     ) -> str | None:
         """Log DV_TEST_STATUS and return terminal failure message if present."""
-        fail_msg = prior_failure_msg if prior_failure_msg is not None else self.failure_message(context)
+        fail_msg = (
+            prior_failure_msg
+            if prior_failure_msg is not None
+            else self.failure_message(context)
+        )
         if fail_msg is not None:
             logger.info("DV_TEST_STATUS: FAILED")
             return fail_msg
@@ -413,7 +421,9 @@ class uvm_report_server:
                     )
                     base_formatter = base_formatter.base_formatter
                 else:
-                    wrapped = _uvm_wrapped_formatter(base_formatter, self._print_char_len)
+                    wrapped = _uvm_wrapped_formatter(
+                        base_formatter, self._print_char_len
+                    )
                 handler.setFormatter(wrapped)
             self._attached.append((handler, True, original_formatter))
             self._attached_keys.add(hkey)

--- a/pyuvm/uvm_reporting/uvm_report_server.py
+++ b/pyuvm/uvm_reporting/uvm_report_server.py
@@ -1,0 +1,470 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Centralized SV-UVM style reporting server."""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+import weakref
+from dataclasses import dataclass
+from typing import Any
+
+from pyuvm.uvm_reporting.uvm_report_catcher import (
+    uvm_report_catcher,
+    uvm_report_message,
+)
+
+UVM_INFO = "INFO"
+UVM_WARNING = "WARNING"
+UVM_ERROR = "ERROR"
+UVM_FATAL = "FATAL"
+
+
+@dataclass
+class uvm_report_policy:
+    """End-of-test fail policy."""
+
+    fail_on_warning: bool = False
+    fail_on_error: bool = True
+    fail_on_fatal: bool = True
+    max_quit_count: int = 1
+
+
+@dataclass
+class uvm_report_stats:
+    """Aggregated severities for the current test run."""
+
+    info_count: int = 0
+    warning_count: int = 0
+    error_count: int = 0
+    fatal_count: int = 0
+    error_quit_count: int = 0
+
+    def clear(self) -> None:
+        self.info_count = 0
+        self.warning_count = 0
+        self.error_count = 0
+        self.fatal_count = 0
+        self.error_quit_count = 0
+
+    def total_fails(self, policy: uvm_report_policy) -> int:
+        total = 0
+        if policy.fail_on_warning:
+            total += self.warning_count
+        if policy.fail_on_error:
+            total += self.error_count
+        if policy.fail_on_fatal:
+            total += self.fatal_count
+        return total
+
+    def error_quit_reached(self, policy: uvm_report_policy) -> bool:
+        return int(policy.max_quit_count) > 0 and self.error_quit_count >= int(policy.max_quit_count)
+
+
+class _uvm_report_filter(logging.Filter):
+    """Filter that normalizes severities and updates global counters."""
+
+    def __init__(self, manager: uvm_report_server) -> None:
+        super().__init__("uvm_report_filter")
+        self._manager_ref = weakref.ref(manager)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        manager = self._manager_ref()
+        if manager is not None:
+            manager.process_record(record)
+        return True
+
+
+class _uvm_wrapped_formatter(logging.Formatter):
+    """Wrap rendered log lines without changing the underlying formatter layout."""
+
+    def __init__(self, base_formatter: logging.Formatter, max_chars: int) -> None:
+        super().__init__()
+        self._base_formatter = base_formatter
+        self._max_chars = int(max_chars)
+
+    @property
+    def base_formatter(self) -> logging.Formatter:
+        return self._base_formatter
+
+    def _display_message(self, record: logging.LogRecord) -> str:
+        message = record.getMessage()
+        report_id = str(getattr(record, "report_id", "") or "")
+        if report_id:
+            return f"[{report_id}] {message}"
+        return message
+
+    def format(self, record: logging.LogRecord) -> str:
+        display_message = self._display_message(record)
+        clone = logging.makeLogRecord(record.__dict__.copy())
+        clone.msg = display_message
+        clone.args = ()
+
+        rendered = self._base_formatter.format(clone)
+        if self._max_chars <= 0 or len(rendered) <= self._max_chars:
+            return rendered
+
+        if not display_message:
+            return rendered
+
+        msg_start = rendered.rfind(display_message)
+        if msg_start < 0:
+            return rendered
+
+        prefix = rendered[:msg_start]
+        indent = " " * len(prefix)
+        wrapped_lines: list[str] = []
+        message_lines = display_message.splitlines() or [display_message]
+
+        for idx, msg_line in enumerate(message_lines):
+            line_prefix = prefix if idx == 0 else indent
+            chunks = textwrap.wrap(
+                msg_line,
+                width=max(1, self._max_chars),
+                break_long_words=False,
+                break_on_hyphens=False,
+                replace_whitespace=False,
+                drop_whitespace=False,
+            )
+            if chunks:
+                wrapped_lines.append(f"{line_prefix}{chunks[0]}")
+                wrapped_lines.extend(f"{indent}{chunk}" for chunk in chunks[1:])
+            else:
+                wrapped_lines.append(line_prefix.rstrip())
+        return "\n".join(wrapped_lines)
+
+
+class uvm_report_server:
+    """Singleton server that emulates SV report_server/report_catcher behavior."""
+
+    _instance: uvm_report_server | None = None
+
+    def __init__(self) -> None:
+        self._root_logger: logging.Logger = logging.getLogger("uvm")
+        self._verbosity: int = 100
+        self._print_char_len: int = 300
+        self._verbosity_hier: dict[str, int] = {}
+        self._policy = uvm_report_policy()
+        self._stats = uvm_report_stats()
+        self._catcher = uvm_report_catcher("uvm_report_catcher")
+        self._filter = _uvm_report_filter(self)
+        self._attached: list[tuple[Any, bool, logging.Formatter | None]] = []
+        self._attached_keys: set[tuple[str, int]] = set()
+        self._initialized = False
+
+    @classmethod
+    def get(cls) -> uvm_report_server:
+        if cls._instance is None:
+            cls._instance = uvm_report_server()
+        return cls._instance
+
+    @classmethod
+    def get_or_none(cls) -> uvm_report_server | None:
+        if cls._instance is not None and cls._instance._initialized:
+            return cls._instance
+        return None
+
+    @classmethod
+    def create(
+        cls,
+        root_logger: logging.Logger | None = None,
+        verbosity: int = 100,
+        policy: uvm_report_policy | None = None,
+        print_char_len: int = 300,
+    ) -> uvm_report_server:
+        manager = cls.get()
+        manager.initialize(
+            root_logger=root_logger,
+            verbosity=verbosity,
+            policy=policy,
+            print_char_len=print_char_len,
+        )
+        return manager
+
+    @property
+    def catcher(self) -> uvm_report_catcher:
+        return self._catcher
+
+    @property
+    def verbosity(self) -> int:
+        return self._verbosity
+
+    @property
+    def policy(self) -> uvm_report_policy:
+        return self._policy
+
+    def get_stats(self) -> uvm_report_stats:
+        return self._stats
+
+    def clear_counts(self) -> None:
+        self._stats.clear()
+
+    def initialize(
+        self,
+        root_logger: logging.Logger | None = None,
+        verbosity: int = 100,
+        policy: uvm_report_policy | None = None,
+        print_char_len: int = 300,
+    ) -> None:
+        self.shutdown()
+        self._root_logger = root_logger if root_logger is not None else logging.getLogger("uvm")
+        self._verbosity = int(verbosity)
+        self._print_char_len = int(print_char_len)
+        self._policy = policy if policy is not None else uvm_report_policy()
+        self._stats.clear()
+        self._catcher = uvm_report_catcher("uvm_report_catcher")
+        self._filter = _uvm_report_filter(self)
+        self._attach_filters()
+        self._initialized = True
+
+    def shutdown(self) -> None:
+        for target, is_handler, formatter in self._attached:
+            try:
+                target.removeFilter(self._filter)
+            except Exception:
+                pass
+            if is_handler:
+                try:
+                    target.setFormatter(formatter)
+                except Exception:
+                    pass
+        self._attached.clear()
+        self._attached_keys.clear()
+        self._initialized = False
+
+    def set_verbosity(self, verbosity: int) -> None:
+        self._verbosity = int(verbosity)
+
+    def set_verbosity_hier(self, prefix: str, verbosity: int) -> None:
+        self._verbosity_hier[str(prefix)] = int(verbosity)
+
+    def add_change_sev(self, report_id: str, msg_regex: str, sev: Any) -> None:
+        self._catcher.add_change_sev(report_id, msg_regex, sev)
+
+    def remove_change_sev(self, report_id: str, msg_regex: str = "") -> None:
+        self._catcher.remove_change_sev(report_id, msg_regex)
+
+    def emit_uvm(
+        self,
+        severity: str,
+        msg: str,
+        report_id: str = "",
+        verbosity: int = 100,
+        logger: logging.Logger | None = None,
+        stacklevel: int = 2,
+    ) -> None:
+        sev = self._normalize_severity(severity)
+        log = logger if logger is not None else self._root_logger
+
+        if sev == UVM_INFO:
+            eff = self._effective_verbosity(log.name if hasattr(log, "name") else "")
+            if int(verbosity) > eff:
+                return
+
+        sev = self._apply_catcher(msg, sev, report_id)
+        level = self._severity_to_level(sev)
+
+        # Count directly at emission time so fail-on-error is deterministic even if
+        # the logging filter chain changes underneath us.
+        if sev == UVM_INFO:
+            self._stats.info_count += 1
+        elif sev == UVM_WARNING:
+            self._stats.warning_count += 1
+        elif sev == UVM_ERROR:
+            self._stats.error_count += 1
+            self._stats.error_quit_count += 1
+        elif sev == UVM_FATAL:
+            self._stats.fatal_count += 1
+
+        extra = {"_uvm_counted_by_emit": True}
+        if report_id:
+            extra["report_id"] = report_id
+        try:
+            log.log(level, msg, extra=extra, stacklevel=stacklevel)
+        except TypeError:
+            log.log(level, msg, extra=extra)
+
+        if sev == UVM_FATAL:
+            raise RuntimeError(f"UVM_FATAL: {msg}")
+
+    def process_record(self, record: logging.LogRecord) -> None:
+        if getattr(record, "_uvm_report_processed", False):
+            return
+        setattr(record, "_uvm_report_processed", True)
+
+        if getattr(record, "_uvm_counted_by_emit", False):
+            return
+
+        severity = self._severity_from_level(record.levelno)
+        report_id = str(getattr(record, "report_id", "") or "")
+        message = record.getMessage()
+        new_severity = self._apply_catcher(message, severity, report_id)
+
+        if new_severity != severity:
+            self._set_record_level(record, self._severity_to_level(new_severity))
+
+        if new_severity == UVM_INFO:
+            self._stats.info_count += 1
+        elif new_severity == UVM_WARNING:
+            self._stats.warning_count += 1
+        elif new_severity == UVM_ERROR:
+            self._stats.error_count += 1
+            self._stats.error_quit_count += 1
+        elif new_severity == UVM_FATAL:
+            self._stats.fatal_count += 1
+
+    def assert_no_failures(self, context: str = "") -> None:
+        msg = self.failure_message(context)
+        if msg is not None:
+            raise RuntimeError(msg)
+
+    def failure_message(self, context: str = "") -> str | None:
+        total_fails = self._stats.total_fails(self._policy)
+        if total_fails <= 0:
+            return None
+
+        summary = (
+            f"{self._stats.info_count} info(s), "
+            f"{self._stats.warning_count} warning(s), "
+            f"{self._stats.error_count} error(s), "
+            f"{self._stats.fatal_count} fatal(s)"
+        )
+        prefix = f"{context}: " if context else ""
+        if self._stats.error_quit_reached(self._policy):
+            return (
+                f"{prefix}Quit count reached: {self._stats.error_quit_count} "
+                f"of {self._policy.max_quit_count} (UVM_ERROR). "
+                f"Detected report failures at termination ({summary})"
+            )
+        return f"{prefix}Detected report failures at termination ({summary})"
+
+    def log_summary(self, logger: logging.Logger) -> None:
+        stats = self._stats
+        logger.info("")
+        logger.info("--- UVM Report Summary ---")
+        logger.info("")
+        logger.info("** Report counts by severity")
+        logger.info(f"UVM_INFO    : {stats.info_count:4d}")
+        logger.info(f"UVM_WARNING : {stats.warning_count:4d}")
+        logger.info(f"UVM_ERROR   : {stats.error_count:4d}")
+        logger.info(f"UVM_FATAL   : {stats.fatal_count:4d}")
+        logger.info(
+            f"Quit count : {stats.error_quit_count:5d} of {self._policy.max_quit_count:5d} "
+            "(UVM_ERROR)"
+        )
+        logger.info("")
+
+    def log_final_status(
+        self,
+        logger: logging.Logger,
+        context: str = "",
+        prior_failure_msg: str | None = None,
+    ) -> str | None:
+        """Log DV_TEST_STATUS and return terminal failure message if present."""
+        fail_msg = prior_failure_msg if prior_failure_msg is not None else self.failure_message(context)
+        if fail_msg is not None:
+            logger.info("DV_TEST_STATUS: FAILED")
+            return fail_msg
+        logger.info("DV_TEST_STATUS: PASSED")
+        return None
+
+    def _attach_filters(self) -> None:
+        loggers: list[logging.Logger] = []
+
+        loggers.append(logging.getLogger())
+        loggers.append(logging.getLogger("uvm"))
+        loggers.append(self._root_logger)
+        loggers.append(logging.getLogger("cocotb"))
+        loggers.append(logging.getLogger("pyuvm"))
+        loggers.append(logging.getLogger("test"))
+
+        for logger_obj in logging.Logger.manager.loggerDict.values():
+            if isinstance(logger_obj, logging.Logger):
+                loggers.append(logger_obj)
+
+        for log in loggers:
+            self.register_logger(log)
+
+    def register_logger(self, log: logging.Logger | None) -> None:
+        if log is None:
+            return
+
+        key = ("logger", id(log))
+        if key not in self._attached_keys:
+            log.addFilter(self._filter)
+            self._attached.append((log, False, None))
+            self._attached_keys.add(key)
+
+        for handler in log.handlers:
+            hkey = ("handler", id(handler))
+            if hkey in self._attached_keys:
+                continue
+            handler.addFilter(self._filter)
+            original_formatter = handler.formatter
+            base_formatter = original_formatter or logging.Formatter("%(message)s")
+            if self._print_char_len > 0:
+                if isinstance(base_formatter, _uvm_wrapped_formatter):
+                    wrapped = _uvm_wrapped_formatter(
+                        base_formatter.base_formatter,
+                        self._print_char_len,
+                    )
+                    base_formatter = base_formatter.base_formatter
+                else:
+                    wrapped = _uvm_wrapped_formatter(base_formatter, self._print_char_len)
+                handler.setFormatter(wrapped)
+            self._attached.append((handler, True, original_formatter))
+            self._attached_keys.add(hkey)
+
+    def _effective_verbosity(self, logger_name: str) -> int:
+        best = self._verbosity
+        best_len = -1
+        for prefix, level in self._verbosity_hier.items():
+            if logger_name.startswith(prefix) and len(prefix) > best_len:
+                best = level
+                best_len = len(prefix)
+        return best
+
+    def _apply_catcher(self, msg: str, severity: str, report_id: str = "") -> str:
+        report = uvm_report_message(report_id=report_id, message=msg, severity=severity)
+        self._catcher.catch(report)
+        return self._normalize_severity(report.severity)
+
+    def _normalize_severity(self, severity: Any) -> str:
+        text = str(severity).strip().upper()
+        if text.endswith(".INFO"):
+            return UVM_INFO
+        if text.endswith(".WARNING"):
+            return UVM_WARNING
+        if text.endswith(".ERROR"):
+            return UVM_ERROR
+        if text.endswith(".FATAL") or text.endswith(".CRITICAL"):
+            return UVM_FATAL
+        if text in {UVM_INFO, UVM_WARNING, UVM_ERROR, UVM_FATAL}:
+            return text
+        return UVM_INFO
+
+    def _severity_to_level(self, severity: str) -> int:
+        sev = self._normalize_severity(severity)
+        if sev == UVM_INFO:
+            return logging.INFO
+        if sev == UVM_WARNING:
+            return logging.WARNING
+        if sev == UVM_ERROR:
+            return logging.ERROR
+        return logging.CRITICAL
+
+    def _severity_from_level(self, level: int) -> str:
+        if level >= logging.CRITICAL:
+            return UVM_FATAL
+        if level >= logging.ERROR:
+            return UVM_ERROR
+        if level >= logging.WARNING:
+            return UVM_WARNING
+        return UVM_INFO
+
+    def _set_record_level(self, record: logging.LogRecord, level: int) -> None:
+        record.levelno = int(level)
+        record.levelname = logging.getLevelName(level)

--- a/pyuvm/uvm_reporting/uvm_verbosity.py
+++ b/pyuvm/uvm_reporting/uvm_verbosity.py
@@ -1,0 +1,229 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SV-UVM style verbosity helpers and reporter."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pyuvm.uvm_reporting.uvm_report_catcher import uvm_report_catcher
+from pyuvm.uvm_reporting.uvm_report_server import uvm_report_server
+
+UVM_NONE = 0
+UVM_LOW = 100
+UVM_MEDIUM = 200
+UVM_HIGH = 300
+UVM_FULL = 400
+UVM_DEBUG = 500
+
+UVM_INFO = "INFO"
+UVM_WARNING = "WARNING"
+UVM_ERROR = "ERROR"
+UVM_FATAL = "FATAL"
+
+
+_VERBOSITY_MAP = {
+    "NONE": UVM_NONE,
+    "LOW": UVM_LOW,
+    "MEDIUM": UVM_MEDIUM,
+    "HIGH": UVM_HIGH,
+    "FULL": UVM_FULL,
+    "DEBUG": UVM_DEBUG,
+}
+
+
+def parse_uvm_verbosity(raw: str | None, default: int = UVM_LOW) -> int:
+    """Parse UVM_VERBOSITY from symbolic level or integer string."""
+    if raw is None:
+        return default
+    text = str(raw).strip()
+    if not text:
+        return default
+    key = text.upper()
+    if key in _VERBOSITY_MAP:
+        return _VERBOSITY_MAP[key]
+    try:
+        return int(text, 0)
+    except ValueError:
+        return default
+
+
+def resolve_uvm_verbosity(inherited: int, cfg: Any | None = None) -> int:
+    """Resolve verbosity with optional cfg override."""
+    if cfg is None:
+        return int(inherited)
+    raw = getattr(cfg, "uvm_verbosity", None)
+    if raw is None:
+        return int(inherited)
+    if isinstance(raw, int):
+        return int(raw)
+    return parse_uvm_verbosity(str(raw), int(inherited))
+
+
+class uvm_reporter:
+    """Centralized UVM-style reporter."""
+
+    def __init__(self, logger: logging.Logger, verbosity: int = UVM_LOW) -> None:
+        self._logger = logger
+        self._verbosity = int(verbosity)
+        self._local_catcher = uvm_report_catcher("uvm_report_catcher")
+        self._sync_with_manager()
+
+    @property
+    def verbosity(self) -> int:
+        return self._verbosity
+
+    @property
+    def catcher(self) -> uvm_report_catcher:
+        manager = uvm_report_server.get_or_none()
+        if manager is not None:
+            return manager.catcher
+        return self._local_catcher
+
+    def set_logger(self, logger: logging.Logger) -> None:
+        self._logger = logger
+        self._sync_with_manager()
+
+    def _sync_with_manager(self) -> None:
+        manager = uvm_report_server.get_or_none()
+        if manager is not None:
+            manager.register_logger(self._logger)
+
+    def set_verbosity(self, verbosity: int) -> None:
+        self._verbosity = int(verbosity)
+        manager = uvm_report_server.get_or_none()
+        if manager is not None:
+            manager.register_logger(self._logger)
+            manager.set_verbosity(self._verbosity)
+
+    def should_log(self, msg_verbosity: int = UVM_LOW) -> bool:
+        return int(msg_verbosity) <= self._verbosity
+
+    def _format_fallback_message(self, report_id: str, msg: str) -> str:
+        if report_id:
+            return f"[{report_id}] {msg}"
+        return msg
+
+    def _emit(self, level: str, msg: str, stacklevel: int = 2) -> None:
+        log_fn = getattr(self._logger, level)
+        try:
+            log_fn(msg, stacklevel=stacklevel)
+        except TypeError:
+            # Fallback for logger adapters that do not accept stacklevel.
+            log_fn(msg)
+
+    def _normalize_severity(self, severity: Any) -> str:
+        text = str(severity).strip().upper()
+        if text.endswith(".INFO"):
+            return UVM_INFO
+        if text.endswith(".WARNING"):
+            return UVM_WARNING
+        if text.endswith(".ERROR"):
+            return UVM_ERROR
+        if text.endswith(".FATAL") or text.endswith(".CRITICAL"):
+            return UVM_FATAL
+        if text in {UVM_INFO, UVM_WARNING, UVM_ERROR, UVM_FATAL}:
+            return text
+        return UVM_INFO
+
+    def _apply_local_catcher(self, severity: str, report_id: str, msg: str) -> str:
+        _action, new_severity = self._local_catcher.catch_fields(report_id, msg, severity)
+        return self._normalize_severity(new_severity)
+
+    def add_change_sev(self, report_id: str, msg_regex: str, sev: Any) -> None:
+        manager = uvm_report_server.get_or_none()
+        if manager is not None:
+            manager.add_change_sev(report_id, msg_regex, sev)
+        else:
+            self._local_catcher.add_change_sev(report_id, msg_regex, sev)
+
+    def remove_change_sev(self, report_id: str, msg_regex: str = "") -> None:
+        manager = uvm_report_server.get_or_none()
+        if manager is not None:
+            manager.remove_change_sev(report_id, msg_regex)
+        else:
+            self._local_catcher.remove_change_sev(report_id, msg_regex)
+
+    def info(self, report_id: str, msg: str, verbosity: int) -> None:
+        manager = uvm_report_server.get_or_none()
+        if manager is None:
+            if not self.should_log(verbosity):
+                return
+            severity = self._apply_local_catcher(UVM_INFO, report_id, msg)
+            level = "info"
+            if severity == UVM_WARNING:
+                level = "warning"
+            elif severity == UVM_ERROR:
+                level = "error"
+            elif severity == UVM_FATAL:
+                level = "critical"
+            self._emit(level, self._format_fallback_message(report_id, msg), 4)
+            if severity == UVM_FATAL:
+                raise RuntimeError(f"UVM_FATAL: {msg}")
+            return
+        self._sync_with_manager()
+        manager.emit_uvm(
+            UVM_INFO,
+            msg,
+            report_id=report_id,
+            verbosity=verbosity,
+            logger=self._logger,
+            stacklevel=3,
+        )
+
+    def warning(self, report_id: str, msg: str) -> None:
+        manager = uvm_report_server.get_or_none()
+        if manager is None:
+            severity = self._apply_local_catcher(UVM_WARNING, report_id, msg)
+            level = "warning"
+            if severity == UVM_INFO:
+                level = "info"
+            elif severity == UVM_ERROR:
+                level = "error"
+            elif severity == UVM_FATAL:
+                level = "critical"
+            self._emit(level, self._format_fallback_message(report_id, msg), 4)
+            if severity == UVM_FATAL:
+                raise RuntimeError(f"UVM_FATAL: {msg}")
+            return
+        self._sync_with_manager()
+        manager.emit_uvm(UVM_WARNING, msg, report_id=report_id, logger=self._logger, stacklevel=3)
+
+    def error(self, report_id: str, msg: str) -> None:
+        manager = uvm_report_server.get_or_none()
+        if manager is None:
+            severity = self._apply_local_catcher(UVM_ERROR, report_id, msg)
+            level = "error"
+            if severity == UVM_INFO:
+                level = "info"
+            elif severity == UVM_WARNING:
+                level = "warning"
+            elif severity == UVM_FATAL:
+                level = "critical"
+            self._emit(level, self._format_fallback_message(report_id, msg), 4)
+            if severity == UVM_FATAL:
+                raise RuntimeError(f"UVM_FATAL: {msg}")
+            return
+        self._sync_with_manager()
+        manager.emit_uvm(UVM_ERROR, msg, report_id=report_id, logger=self._logger, stacklevel=3)
+
+    def fatal(self, report_id: str, msg: str) -> None:
+        manager = uvm_report_server.get_or_none()
+        if manager is None:
+            severity = self._apply_local_catcher(UVM_FATAL, report_id, msg)
+            level = "critical"
+            if severity == UVM_INFO:
+                level = "info"
+            elif severity == UVM_WARNING:
+                level = "warning"
+            elif severity == UVM_ERROR:
+                level = "error"
+            self._emit(level, self._format_fallback_message(report_id, msg), 4)
+            if severity == UVM_FATAL:
+                raise RuntimeError(f"UVM_FATAL: {msg}")
+            return
+        self._sync_with_manager()
+        manager.emit_uvm(UVM_FATAL, msg, report_id=report_id, logger=self._logger, stacklevel=3)

--- a/pyuvm/uvm_reporting/uvm_verbosity.py
+++ b/pyuvm/uvm_reporting/uvm_verbosity.py
@@ -130,7 +130,9 @@ class uvm_reporter:
         return UVM_INFO
 
     def _apply_local_catcher(self, severity: str, report_id: str, msg: str) -> str:
-        _action, new_severity = self._local_catcher.catch_fields(report_id, msg, severity)
+        _action, new_severity = self._local_catcher.catch_fields(
+            report_id, msg, severity
+        )
         return self._normalize_severity(new_severity)
 
     def add_change_sev(self, report_id: str, msg_regex: str, sev: Any) -> None:
@@ -190,7 +192,9 @@ class uvm_reporter:
                 raise RuntimeError(f"UVM_FATAL: {msg}")
             return
         self._sync_with_manager()
-        manager.emit_uvm(UVM_WARNING, msg, report_id=report_id, logger=self._logger, stacklevel=3)
+        manager.emit_uvm(
+            UVM_WARNING, msg, report_id=report_id, logger=self._logger, stacklevel=3
+        )
 
     def error(self, report_id: str, msg: str) -> None:
         manager = uvm_report_server.get_or_none()
@@ -208,7 +212,9 @@ class uvm_reporter:
                 raise RuntimeError(f"UVM_FATAL: {msg}")
             return
         self._sync_with_manager()
-        manager.emit_uvm(UVM_ERROR, msg, report_id=report_id, logger=self._logger, stacklevel=3)
+        manager.emit_uvm(
+            UVM_ERROR, msg, report_id=report_id, logger=self._logger, stacklevel=3
+        )
 
     def fatal(self, report_id: str, msg: str) -> None:
         manager = uvm_report_server.get_or_none()
@@ -226,4 +232,6 @@ class uvm_reporter:
                 raise RuntimeError(f"UVM_FATAL: {msg}")
             return
         self._sync_with_manager()
-        manager.emit_uvm(UVM_FATAL, msg, report_id=report_id, logger=self._logger, stacklevel=3)
+        manager.emit_uvm(
+            UVM_FATAL, msg, report_id=report_id, logger=self._logger, stacklevel=3
+        )

--- a/tests/pytests/test_uvm_reporting.py
+++ b/tests/pytests/test_uvm_reporting.py
@@ -217,7 +217,9 @@ def test_direct_logger_error_is_counted_when_report_server_is_active(reporting_l
     assert stats.error_quit_count == 1
 
 
-def test_direct_logger_error_is_counted_once_through_uvm_propagation(uvm_root_reporting):
+def test_direct_logger_error_is_counted_once_through_uvm_propagation(
+    uvm_root_reporting,
+):
     manager, stream = uvm_root_reporting
     child_logger = logging.getLogger("uvm.phase5.direct")
     child_logger.handlers.clear()
@@ -289,7 +291,10 @@ def test_legacy_disable_logging_installs_null_handler():
 
     assert report_object._streaming_handler is None
     assert not report_object.logger.propagate
-    assert any(isinstance(handler, logging.NullHandler) for handler in report_object.logger.handlers)
+    assert any(
+        isinstance(handler, logging.NullHandler)
+        for handler in report_object.logger.handlers
+    )
 
 
 def test_legacy_custom_handler_receives_logger_messages():
@@ -393,7 +398,9 @@ def test_component_supports_uvm_report(initialize_pyuvm, uvm_root_reporting):
         (uvm_transaction, "transaction", "transaction report"),
     ],
 )
-def test_non_component_objects_support_uvm_report(cls, name, message, uvm_root_reporting):
+def test_non_component_objects_support_uvm_report(
+    cls, name, message, uvm_root_reporting
+):
     _manager, stream = uvm_root_reporting
     obj = cls(name)
 

--- a/tests/pytests/test_uvm_reporting.py
+++ b/tests/pytests/test_uvm_reporting.py
@@ -1,0 +1,402 @@
+import io
+import logging
+import uuid
+
+import pytest
+
+from pyuvm import (
+    UVM_HIGH,
+    UVM_INFO,
+    UVM_LOW,
+    UVM_NONE,
+    UVM_WARNING,
+    get_sv_uvm_style_reporting_enabled,
+    set_sv_uvm_style_reporting_enabled,
+    uvm_component,
+    uvm_report_object,
+    uvm_report_server,
+    uvm_reporter,
+    uvm_sequence,
+    uvm_sequence_item,
+    uvm_transaction,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_report_server():
+    set_sv_uvm_style_reporting_enabled(False)
+    manager = uvm_report_server.get_or_none()
+    if manager is not None:
+        manager.shutdown()
+        manager.clear_counts()
+        manager.catcher.clear()
+    yield
+    set_sv_uvm_style_reporting_enabled(False)
+    manager = uvm_report_server.get_or_none()
+    if manager is not None:
+        manager.shutdown()
+        manager.clear_counts()
+        manager.catcher.clear()
+
+
+@pytest.fixture()
+def reporting_logger():
+    created = []
+
+    def make(verbosity=UVM_LOW, print_char_len=300):
+        name = f"uvm_reporting_test.{uuid.uuid4().hex}"
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = False
+
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.NOTSET)
+        handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+        logger.addHandler(handler)
+
+        manager = uvm_report_server.create(
+            root_logger=logger,
+            verbosity=verbosity,
+            print_char_len=print_char_len,
+        )
+        manager.register_logger(logger)
+        created.append((logger, handler))
+        return manager, logger, stream
+
+    yield make
+
+    for logger, handler in created:
+        logger.removeHandler(handler)
+
+
+@pytest.fixture()
+def uvm_root_reporting():
+    set_sv_uvm_style_reporting_enabled(True)
+    logger = logging.getLogger("uvm")
+    old_level = logger.level
+    old_propagate = logger.propagate
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.NOTSET)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    manager = uvm_report_server.create(root_logger=logger, verbosity=UVM_LOW)
+    manager.register_logger(logger)
+    yield manager, stream
+
+    manager.shutdown()
+    logger.removeHandler(handler)
+    logger.setLevel(old_level)
+    logger.propagate = old_propagate
+
+
+def test_info_obeys_verbosity(reporting_logger):
+    manager, logger, stream = reporting_logger(verbosity=UVM_LOW)
+    reporter = uvm_reporter(logger, UVM_LOW)
+
+    reporter.info("LOW_ID", "visible info", UVM_LOW)
+    reporter.info("HIGH_ID", "suppressed info", UVM_HIGH)
+
+    output = stream.getvalue()
+    assert "[LOW_ID] visible info" in output
+    assert "suppressed info" not in output
+    assert manager.get_stats().info_count == 1
+
+
+def test_warning_error_and_fatal_ignore_info_verbosity(reporting_logger):
+    manager, logger, stream = reporting_logger(verbosity=UVM_NONE)
+    reporter = uvm_reporter(logger, UVM_NONE)
+
+    reporter.warning("WARN_ID", "visible warning")
+    reporter.error("ERR_ID", "visible error")
+    with pytest.raises(RuntimeError):
+        reporter.fatal("FATAL_ID", "visible fatal")
+
+    output = stream.getvalue()
+    assert "[WARN_ID] visible warning" in output
+    assert "[ERR_ID] visible error" in output
+    assert "[FATAL_ID] visible fatal" in output
+    stats = manager.get_stats()
+    assert stats.warning_count == 1
+    assert stats.error_count == 1
+    assert stats.fatal_count == 1
+
+
+def test_fatal_logs_once_and_raises(reporting_logger):
+    manager, logger, stream = reporting_logger()
+    reporter = uvm_reporter(logger)
+
+    with pytest.raises(RuntimeError):
+        reporter.fatal("FATAL_ONCE", "fatal once")
+
+    assert stream.getvalue().count("[FATAL_ONCE] fatal once") == 1
+    assert manager.get_stats().fatal_count == 1
+
+
+def test_severity_counts_match_reports(reporting_logger):
+    manager, logger, _stream = reporting_logger()
+    reporter = uvm_reporter(logger)
+
+    reporter.info("INFO_ID", "info", UVM_LOW)
+    reporter.warning("WARN_ID", "warning")
+    reporter.error("ERR_ID", "error")
+
+    stats = manager.get_stats()
+    assert stats.info_count == 1
+    assert stats.warning_count == 1
+    assert stats.error_count == 1
+    assert stats.fatal_count == 0
+    assert stats.error_quit_count == 1
+
+
+def test_demotion_changes_emitted_severity_and_counts(reporting_logger):
+    manager, logger, stream = reporting_logger()
+    reporter = uvm_reporter(logger)
+
+    reporter.add_change_sev("DEMOTE_ID", "downgrade", UVM_WARNING)
+    reporter.error("DEMOTE_ID", "please downgrade this")
+
+    output = stream.getvalue()
+    assert "WARNING:[DEMOTE_ID] please downgrade this" in output
+    stats = manager.get_stats()
+    assert stats.warning_count == 1
+    assert stats.error_count == 0
+
+
+def test_wildcard_report_id_demotion(reporting_logger):
+    manager, logger, stream = reporting_logger()
+    reporter = uvm_reporter(logger)
+
+    reporter.add_change_sev("*", "wildcard", UVM_INFO)
+    reporter.error("ANY_ID", "wildcard demotion")
+
+    output = stream.getvalue()
+    assert "INFO:[ANY_ID] wildcard demotion" in output
+    stats = manager.get_stats()
+    assert stats.info_count == 1
+    assert stats.error_count == 0
+
+
+def test_summary_text_contains_key_lines(reporting_logger):
+    manager, logger, stream = reporting_logger()
+    reporter = uvm_reporter(logger)
+
+    reporter.info("INFO_ID", "info", UVM_LOW)
+    reporter.warning("WARN_ID", "warning")
+    manager.log_summary(logger)
+
+    output = stream.getvalue()
+    assert "--- UVM Report Summary ---" in output
+    assert "** Report counts by severity" in output
+    assert "UVM_INFO" in output
+    assert "UVM_WARNING" in output
+    assert "Quit count" in output
+
+
+def test_wrapped_formatter_includes_report_id(reporting_logger):
+    _manager, logger, stream = reporting_logger(print_char_len=40)
+    reporter = uvm_reporter(logger)
+
+    reporter.info("WRAP_ID", "wrapped message", UVM_LOW)
+
+    assert "[WRAP_ID] wrapped message" in stream.getvalue()
+
+
+def test_direct_logger_error_is_counted_when_report_server_is_active(reporting_logger):
+    manager, logger, _stream = reporting_logger()
+
+    logger.error("direct logger error")
+
+    stats = manager.get_stats()
+    assert stats.error_count == 1
+    assert stats.error_quit_count == 1
+
+
+def test_direct_logger_error_is_counted_once_through_uvm_propagation(uvm_root_reporting):
+    manager, stream = uvm_root_reporting
+    child_logger = logging.getLogger("uvm.phase5.direct")
+    child_logger.handlers.clear()
+    child_logger.setLevel(logging.DEBUG)
+    child_logger.propagate = True
+    manager.register_logger(child_logger)
+
+    child_logger.error("propagated error")
+
+    assert stream.getvalue().count("ERROR:propagated error") == 1
+    assert manager.get_stats().error_count == 1
+
+
+def test_report_server_shutdown_makes_get_or_none_inactive(reporting_logger):
+    manager, logger, _stream = reporting_logger()
+
+    assert uvm_report_server.get_or_none() is manager
+    manager.shutdown()
+
+    assert uvm_report_server.get_or_none() is None
+    logger.error("not counted after shutdown")
+    assert manager.get_stats().error_count == 0
+
+
+def test_reporter_local_catcher_applies_without_report_server():
+    logger = logging.getLogger(f"uvm_reporting_test.{uuid.uuid4().hex}")
+    logger.handlers.clear()
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+    logger.addHandler(handler)
+
+    reporter = uvm_reporter(logger)
+    reporter.add_change_sev("LOCAL_ID", "known issue", UVM_WARNING)
+    reporter.error("LOCAL_ID", "known issue was demoted")
+
+    assert "WARNING:[LOCAL_ID] known issue was demoted" in stream.getvalue()
+
+
+def test_sv_uvm_style_reporting_mode_defaults_to_disabled():
+    assert not get_sv_uvm_style_reporting_enabled()
+
+
+def test_legacy_report_object_creates_default_stream_handler():
+    report_object = uvm_report_object("report_object")
+
+    assert not report_object.logger.propagate
+    assert report_object._streaming_handler in report_object.logger.handlers
+    assert isinstance(report_object._streaming_handler, logging.StreamHandler)
+
+
+def test_legacy_remove_streaming_handler_removes_default_handler():
+    report_object = uvm_report_object("report_object")
+    streaming_handler = report_object._streaming_handler
+
+    report_object.remove_streaming_handler()
+
+    assert report_object._streaming_handler is None
+    assert streaming_handler not in report_object.logger.handlers
+
+
+def test_legacy_disable_logging_installs_null_handler():
+    report_object = uvm_report_object("report_object")
+
+    report_object.disable_logging()
+
+    assert report_object._streaming_handler is None
+    assert not report_object.logger.propagate
+    assert any(isinstance(handler, logging.NullHandler) for handler in report_object.logger.handlers)
+
+
+def test_legacy_custom_handler_receives_logger_messages():
+    report_object = uvm_report_object("report_object")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+
+    report_object.add_logging_handler(handler)
+    report_object.logger.info("custom logger message")
+
+    assert "custom logger message" in stream.getvalue()
+
+
+def test_sv_uvm_style_report_object_does_not_create_default_stream_handler():
+    set_sv_uvm_style_reporting_enabled(True)
+    report_object = uvm_report_object("report_object")
+
+    assert report_object.logger.propagate
+    assert report_object._streaming_handler is None
+    assert not any(
+        isinstance(handler, logging.StreamHandler)
+        for handler in report_object.logger.handlers
+    )
+
+
+def test_uvm_report_uses_existing_object_verbosity():
+    transaction = uvm_transaction("transaction")
+
+    transaction.set_report_verbosity(UVM_HIGH)
+
+    assert transaction.uvm_verbosity == UVM_HIGH
+    assert transaction.uvm_report.verbosity == UVM_HIGH
+
+
+def test_object_report_verbosity_updates_global_server(reporting_logger):
+    manager, logger, stream = reporting_logger(verbosity=UVM_LOW)
+    first = uvm_transaction("first")
+    second = uvm_transaction("second")
+    first.set_report_logger(logger.getChild("first"))
+    second.set_report_logger(logger.getChild("second"))
+
+    first.set_report_verbosity(UVM_HIGH)
+
+    first.uvm_report.info("FIRST", "local high visible", UVM_HIGH)
+    second.uvm_report.info("SECOND", "global high shows high", UVM_HIGH)
+
+    output = stream.getvalue()
+    assert "[FIRST] local high visible" in output
+    assert "[SECOND] global high shows high" in output
+    assert manager.verbosity == UVM_HIGH
+    assert manager.get_stats().info_count == 2
+
+
+def test_pre_server_report_verbosity_does_not_override_created_server():
+    set_sv_uvm_style_reporting_enabled(True)
+    logger = logging.getLogger("uvm")
+    old_level = logger.level
+    old_propagate = logger.propagate
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+    logger.addHandler(handler)
+
+    transaction = uvm_transaction("transaction")
+    transaction.set_report_verbosity(UVM_HIGH)
+    report = transaction.uvm_report
+
+    manager = uvm_report_server.create(root_logger=logger, verbosity=UVM_LOW)
+    try:
+        report.info("LOCAL_BEFORE_SERVER", "hidden after server starts", UVM_HIGH)
+        report.info("LOCAL_BEFORE_SERVER", "visible low report", UVM_LOW)
+
+        output = stream.getvalue()
+        assert "[LOCAL_BEFORE_SERVER] hidden after server starts" not in output
+        assert "[LOCAL_BEFORE_SERVER] visible low report" in output
+        assert manager.verbosity == UVM_LOW
+    finally:
+        manager.shutdown()
+        logger.removeHandler(handler)
+        logger.setLevel(old_level)
+        logger.propagate = old_propagate
+
+
+def test_component_supports_uvm_report(initialize_pyuvm, uvm_root_reporting):
+    _manager, stream = uvm_root_reporting
+    component = uvm_component("component", None)
+
+    component.uvm_report.info("COMP_ID", "component report", UVM_LOW)
+
+    assert "[COMP_ID] component report" in stream.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("cls", "name", "message"),
+    [
+        (uvm_sequence, "sequence", "sequence report"),
+        (uvm_sequence_item, "sequence_item", "sequence item report"),
+        (uvm_transaction, "transaction", "transaction report"),
+    ],
+)
+def test_non_component_objects_support_uvm_report(cls, name, message, uvm_root_reporting):
+    _manager, stream = uvm_root_reporting
+    obj = cls(name)
+
+    obj.uvm_report.info("OBJ_ID", message, UVM_LOW)
+
+    assert f"[OBJ_ID] {message}" in stream.getvalue()

--- a/tests/pytests/tmp_06_reporting_classes.py
+++ b/tests/pytests/tmp_06_reporting_classes.py
@@ -1,6 +1,8 @@
+import logging
+
 import pytest
 
-from pyuvm import *
+from pyuvm import uvm_report_object
 
 
 def test_object_creation():
@@ -10,6 +12,7 @@ def test_object_creation():
     ro = uvm_report_object("ro")
     assert hasattr(ro, "logger")
     assert not ro.logger.propagate
+    assert ro._streaming_handler in ro.logger.handlers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# TL;DR

Adds an opt-in SV-UVM-style reporting layer while keeping Python logging as the
backend and preserving existing `self.logger.*` behavior by default. The new
path provides `self.uvm_report`, UVM severity and verbosity constants, report
IDs, UVM-style verbosity filtering, centralized counts, summaries, and basic
severity demotion. The Phase 5 hardening pass keeps global/default report
server verbosity explicit, makes report-server lifecycle state explicit, and
verifies direct Python logging is counted once through the shared `uvm` logger
path. It also keeps reused report-object loggers from carrying legacy per-object
stream handlers into the shared SV-UVM-style logger path. Formatting stays on
the Python logging / `PyuvmFormatter` path, and UVM verbosity remains separate
from Python logging levels.

# Summary

This PR adds the first SV-UVM-style reporting layer on top of pyuvm's existing
Python logging backend.

The default pyuvm logging behavior remains unchanged. Existing tests can keep
using `self.logger.info(...)`, `self.logger.warning(...)`, and
`self.logger.error(...)` without enabling the new reporting path.

When enabled, the new reporting path provides:

- UVM severity constants: `UVM_INFO`, `UVM_WARNING`, `UVM_ERROR`, `UVM_FATAL`
- UVM verbosity constants: `UVM_NONE`, `UVM_LOW`, `UVM_MEDIUM`, `UVM_HIGH`,
  `UVM_FULL`, `UVM_DEBUG`
- a lazy `uvm_object.uvm_report` reporter with
  `info()`, `warning()`, `error()`, and `fatal()` methods
- UVM-style verbosity filtering for info reports
- global/default report-server verbosity updates through `set_verbosity()`
- report IDs carried through logging records and formatter wrapping
- centralized `uvm_report_server` severity counts and summary output
- configurable fail policy and quit-count handling
- simple report catching through severity rewrite rules
- direct Python logging count integration when the report server is active
- top-level `pyuvm` exports for the new reporting symbols
- an opt-in shared reporting mode controlled by
  `PYUVM_ENABLE_SV_UVM_STYLE_REPORTING` or
  `set_sv_uvm_style_reporting_enabled(True)`
  
 # RFC Alignment

This implements the staged reporting direction discussed in
https://github.com/pyuvm/pyuvm/issues/374.

The RFC feedback called out two important design points:

- SV-UVM-style output should remain compatible with pyuvm's formatter path.
- UVM verbosity must not be confused with Python logging levels.

This PR keeps Python logging as the backend. Python logging levels continue to
represent severity only: info, warning, error, and critical. UVM verbosity is
evaluated before the logging call using UVM semantics:

```python
message_verbosity <= configured_verbosity
```

That means a `UVM_LOW` report passes at `UVM_LOW`, while a `UVM_HIGH` info
report is suppressed at `UVM_LOW`. Warning, error, and fatal reports are not
suppressed by info verbosity.

The report server's configured verbosity is the global/default verbosity. This
matches the common SV-UVM use model where raising the configured UVM verbosity
runs the testbench at that higher reporting level. Reporter construction before
server creation does not carry a delayed global verbosity override; the
verbosity passed to `uvm_report_server.create()` remains authoritative until
`set_verbosity()` is called while the server is active.

The rendered log layout still comes from Python logging formatters. This keeps
`PyuvmFormatter` as the customization point for teams that want stricter
SV-UVM-like line rendering while preserving the new report IDs, counts,
summaries, and catcher behavior.

# Deliberate Differences from SystemVerilog UVM

This PR is a Python-native compatibility layer, not a complete IEEE 1800.2
reporting implementation.

Important differences from SystemVerilog UVM:

- **Python logging remains the transport.** SV-UVM owns the reporting pipeline
  inside the UVM library. pyuvm keeps Python logging as the backend so existing
  handlers, formatters, filters, and logger configuration continue to work.
- **Formatting stays customizable through Python logging.** This PR carries
  report IDs and UVM report metadata into logging records, but it does not make
  one exact SV-UVM transcript format mandatory. Teams that need stricter
  checker-compatible lines can provide that through `PyuvmFormatter` or another
  logging formatter.
- **Verbosity is UVM-style, logging levels are severity-only.** SV-UVM
  verbosity uses the "low bridge" rule. pyuvm matches that for info reports
  with `message_verbosity <= configured_verbosity`, while Python logging levels
  continue to represent severity. The reporter `set_verbosity()` path updates
  the global/default report server verbosity. Finer-grained per-ID or
  per-hierarchy verbosity remains follow-up scope.
- **The API is Python-shaped.** SystemVerilog users often write macros such as
  `` `uvm_info`` or call report methods directly. pyuvm exposes a lazy
  `self.uvm_report` reporter with `info()`, `warning()`, `error()`, and
  `fatal()` methods instead of adding preprocessor-style macros.
- **The new topology is opt-in.** SV-UVM reporting is the default reporting
  model in SystemVerilog UVM. pyuvm keeps its existing logger propagation and
  handler behavior by default. Object loggers use the shared `uvm` logger path
  only when `PYUVM_ENABLE_SV_UVM_STYLE_REPORTING` or
  `set_sv_uvm_style_reporting_enabled(True)` is used.
- **Report server lifecycle is explicit.** `uvm_report_server.get_or_none()`
  returns an active initialized report server. After `shutdown()`, reporters
  fall back to local behavior until a server is created again.
- **Fatal behavior is Python exception based.** `fatal()` logs the report and
  raises `RuntimeError`. This gives Python tests normal exception semantics
  rather than trying to exactly model every SV-UVM action/finish path.
- **Report catching is intentionally minimal.** This PR supports severity
  rewrite rules by report ID and message regular expression. It does not yet
  implement the full SV-UVM report action, callback, file-routing, or
  severity/ID override surface.

# Compatibility

The new shared reporting topology is disabled by default.

By default, `uvm_report_object` continues to:

- create a per-object stream handler
- keep object loggers from propagating to the shared `uvm` logger
- support existing handler management APIs such as `add_logging_handler()`,
  `remove_streaming_handler()`, and `disable_logging()`

When SV-UVM-style reporting is enabled, `uvm_object` loggers propagate to the
shared `uvm` logger path. In this mode, `uvm_report_object` does not add a
default stream handler to every report object.

Enable from the shell:

```bash
PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1 make sim
```

Enable from Python before constructing the testbench:

```python
from pyuvm import set_sv_uvm_style_reporting_enabled

set_sv_uvm_style_reporting_enabled(True)
```

Create a report server when centralized counts, summaries, or catcher rules are
needed:

```python
from pyuvm import UVM_LOW, uvm_report_server

report_server = uvm_report_server.create(verbosity=UVM_LOW)
```

Use reports from any `uvm_object`:

```python
from pyuvm import UVM_HIGH, UVM_LOW, uvm_component


class Scoreboard(uvm_component):
    def check_phase(self):
        self.uvm_report.info("SCOREBOARD", "checking final results", UVM_LOW)

        if self.mismatch_seen:
            self.uvm_report.error("SCOREBOARD", "result mismatch detected")
        else:
            self.uvm_report.info("SCOREBOARD", "all results matched", UVM_HIGH)
```

## Implementation Notes

- `pyuvm/uvm_reporting/uvm_verbosity.py` adds UVM verbosity constants,
  parsing helpers, the bound `uvm_reporter`, fallback report-ID formatting, and
  local catcher support when no report server is active.
- `pyuvm/uvm_reporting/uvm_report_server.py` adds the centralized report server,
  severity statistics, fail policy, quit-count handling, summary logging, and
  formatter wrapping for report IDs. `get_or_none()` only returns an active
  initialized server.
- `pyuvm/uvm_reporting/uvm_report_catcher.py` adds simple severity rewrite
  support by report ID and message regular expression.
- `pyuvm/uvm_reporting/uvm_base_core_report.py` owns per-object reporting state
  and binds the reporter to the object's logger.
- `uvm_object` now creates reporting state lazily through the `uvm_report`
  property and exposes report verbosity setters/getters. `set_report_verbosity()`
  updates the active global/default report-server verbosity when a server has
  already been created.
- `uvm_report_object` preserves the existing handler use model by default and
  skips the default stream handler when the SV-UVM-style reporting flag is
  enabled. If a logger name is reused across legacy and SV-UVM-style modes,
  stale pyuvm default stream handlers are removed before propagation through the
  shared `uvm` logger path.
- `pyuvm/__init__.py` exports the new public reporting constants, helpers, and
  classes from top-level `pyuvm`.
- `pyproject.toml` keeps Ruff import-order checks focused away from top-level
  re-export modules whose ordering follows pyuvm section structure.

## Tests Added

The reporting tests cover:

- UVM info verbosity filtering
- warning/error/fatal reports ignoring info verbosity
- fatal logging once and raising `RuntimeError`
- severity counts and quit-count behavior
- report catching and severity demotion
- wildcard report ID demotion
- summary output
- report ID formatter wrapping
- direct Python logging count integration when the report server is active
- direct Python logging count integration through propagated `uvm.*` loggers
  without double-counting
- report server shutdown making `get_or_none()` inactive
- local catcher demotion when no report server is active
- report verbosity updates changing the global report server verbosity
- report verbosity set before server creation not overriding the created
  server's configured global/default verbosity
- default legacy logging behavior with SV-UVM-style reporting disabled
- shared `uvm` logger behavior with SV-UVM-style reporting enabled
- no per-object default stream handler leaking into SV-UVM-style reporting when
  report-object logger names are reused
- lazy `uvm_report` support for components, sequences, sequence items, and
  transactions
