### PR TITLE
[examples, TinyALU] Add TinyALU UVM-style reporting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,75 +121,6 @@ You should be able to run the simulation like this:
 250000.00ns INFO     testbench.py(209)[uvm_test_top.env.scoreboard]: PASSED: 0xff MUL 0xff = 0xfe01
 ```
 
-## TinyALU with SV-UVM-style reporting
-
-The original `examples/TinyALU` example intentionally shows pyuvm's direct
-Python logging style. A sibling example, `examples/TinyALU_uvm_reporting`,
-uses the same TinyALU RTL and BFM while demonstrating the opt-in
-SV-UVM-style reporting API:
-
-```bash
-% cd <path>/pyuvm/examples/TinyALU_uvm_reporting
-% make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
-```
-
-This example enables shared SV-UVM-style reporting before constructing UVM
-objects, creates a `uvm_report_server`, and reports through `self.uvm_report`.
-The output includes source file and line information, UVM hierarchy, report
-IDs, UVM verbosity filtering, severity counts, and a final report summary:
-
-```text
-INFO     .._uvm_reporting/testbench.py(262) [uvm_test_top.env.scoreboard]: [scoreboard] PASSED: 0xff MUL 0xff = 0xfe01
-INFO     .._uvm_reporting/testbench.py(221) [uvm_test_top.env.coverage]: [coverage] Covered all operations
-INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: --- UVM Report Summary ---
-INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: ** Report counts by severity
-INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_INFO    :    9
-INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_WARNING :    0
-INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_ERROR   :    0
-INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_FATAL   :    0
-INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: TEST_STATUS: PASSED
-```
-
-UVM verbosity is separate from Python logging levels. The monitors report at
-`UVM_DEBUG`, so debug-level monitor output can be enabled without changing the
-Python logging setup:
-
-```bash
-% UVM_VERBOSITY=DEBUG make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
-```
-
-Verilator-style plusargs are also accepted:
-
-```bash
-% make SIM=verilator TOPLEVEL_LANG=verilog \
-    COCOTB_PLUSARGS="+UVM_VERBOSITY=DEBUG +max_quit_count=25 +test_status_label=MY_TEST_STATUS +print_char_len=80" sim checkclean
-```
-
-Set `+max_quit_count=0` to report all errors without quit-count suppression;
-the summary prints the limit as `UNLIMITED`. The `maxquit-demo` target runs the
-intentional-error test at `0`, `1`, `2`, and `25`:
-
-```bash
-% make SIM=verilator TOPLEVEL_LANG=verilog maxquit-demo
-```
-
-The final status line defaults to `TEST_STATUS: PASSED` or `TEST_STATUS: FAILED`;
-set `+test_status_label=...` to match a local log-scraping convention.
-
-The reporting example also includes negative cocotb regression tests. `AluTestErrors`
-uses the normal scoreboard mismatch path and reports errors until the quit count
-is reached. `FatalReportTest` drives the same ALU traffic but reports the first
-scoreboard mismatch through `self.uvm_report.fatal(...)`; cocotb marks it as
-passing because the test expects the resulting `RuntimeError`.
-`FatalDowngradeToErrorTest` uses the fatal path with a report catcher rule that
-downgrades the scoreboard report ID to `UVM_ERROR`, so the test reaches the
-normal summary/status path and fails through the final error count. The report
-server also prints a count-neutral `[SEVCHG]` diagnostic at the fatal call site
-when the downgrade happens.
-`FatalDowngradeToInfoTest` and `ErrorDowngradeToInfoTest` use the same real
-scoreboard mismatch paths but downgrade the reports to `UVM_INFO`, demonstrating
-that waived fatal and error reports no longer contribute to failure counts.
-
 ## The `TinyAluBfm` in `tinyalu_utils.py`
 
 The `TinyAluBfm` is a singleton that uses **cocotb** to communicate with the TinyALU.  The BFM exposes three coroutines to the user: `send_op()`, `get_cmd()`, and `get_result()`.
@@ -608,6 +539,75 @@ such as `[uvm_test_top.env.scoreboard]: [scoreboard] ...`. Direct Python logger
 records are not rewritten or counted by the report server.
 
 Output formatting still uses Python logging formatters. pyuvm's `PyuvmFormatter` remains the customization point for teams that want a different log layout while keeping the UVM-style report metadata and filtering behavior.
+
+## TinyALU with SV-UVM-style reporting
+
+The original `examples/TinyALU` example intentionally shows pyuvm's direct
+Python logging style. A sibling example, `examples/TinyALU_uvm_reporting`,
+uses the same TinyALU RTL and BFM while demonstrating the opt-in
+SV-UVM-style reporting API:
+
+```bash
+% cd <path>/pyuvm/examples/TinyALU_uvm_reporting
+% make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
+```
+
+This example enables shared SV-UVM-style reporting before constructing UVM
+objects, creates a `uvm_report_server`, and reports through `self.uvm_report`.
+The output includes source file and line information, UVM hierarchy, report
+IDs, UVM verbosity filtering, severity counts, and a final report summary:
+
+```text
+INFO     .._uvm_reporting/testbench.py(262) [uvm_test_top.env.scoreboard]: [scoreboard] PASSED: 0xff MUL 0xff = 0xfe01
+INFO     .._uvm_reporting/testbench.py(221) [uvm_test_top.env.coverage]: [coverage] Covered all operations
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: --- UVM Report Summary ---
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: ** Report counts by severity
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_INFO    :    9
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_WARNING :    0
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_ERROR   :    0
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_FATAL   :    0
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: TEST_STATUS: PASSED
+```
+
+UVM verbosity is separate from Python logging levels. The monitors report at
+`UVM_DEBUG`, so debug-level monitor output can be enabled without changing the
+Python logging setup:
+
+```bash
+% UVM_VERBOSITY=DEBUG make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
+```
+
+Verilator-style plusargs are also accepted:
+
+```bash
+% make SIM=verilator TOPLEVEL_LANG=verilog \
+    COCOTB_PLUSARGS="+UVM_VERBOSITY=DEBUG +max_quit_count=25 +test_status_label=MY_TEST_STATUS +print_char_len=80" sim checkclean
+```
+
+Set `+max_quit_count=0` to report all errors without quit-count suppression;
+the summary prints the limit as `UNLIMITED`. The `maxquit-demo` target runs the
+intentional-error test at `0`, `1`, `2`, and `25`:
+
+```bash
+% make SIM=verilator TOPLEVEL_LANG=verilog maxquit-demo
+```
+
+The final status line defaults to `TEST_STATUS: PASSED` or `TEST_STATUS: FAILED`;
+set `+test_status_label=...` to match a local log-scraping convention.
+
+The reporting example also includes negative cocotb regression tests. `AluTestErrors`
+uses the normal scoreboard mismatch path and reports errors until the quit count
+is reached. `FatalReportTest` drives the same ALU traffic but reports the first
+scoreboard mismatch through `self.uvm_report.fatal(...)`; cocotb marks it as
+passing because the test expects the resulting `RuntimeError`.
+`FatalDowngradeToErrorTest` uses the fatal path with a report catcher rule that
+downgrades the scoreboard report ID to `UVM_ERROR`, so the test reaches the
+normal summary/status path and fails through the final error count. The report
+server also prints a count-neutral `[SEVCHG]` diagnostic at the fatal call site
+when the downgrade happens.
+`FatalDowngradeToInfoTest` and `ErrorDowngradeToInfoTest` use the same real
+scoreboard mismatch paths but downgrade the reports to `UVM_INFO`, demonstrating
+that waived fatal and error reports no longer contribute to failure counts.
 
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -121,6 +121,75 @@ You should be able to run the simulation like this:
 250000.00ns INFO     testbench.py(209)[uvm_test_top.env.scoreboard]: PASSED: 0xff MUL 0xff = 0xfe01
 ```
 
+## TinyALU with SV-UVM-style reporting
+
+The original `examples/TinyALU` example intentionally shows pyuvm's direct
+Python logging style. A sibling example, `examples/TinyALU_uvm_reporting`,
+uses the same TinyALU RTL and BFM while demonstrating the opt-in
+SV-UVM-style reporting API:
+
+```bash
+% cd <path>/pyuvm/examples/TinyALU_uvm_reporting
+% make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
+```
+
+This example enables shared SV-UVM-style reporting before constructing UVM
+objects, creates a `uvm_report_server`, and reports through `self.uvm_report`.
+The output includes source file and line information, UVM hierarchy, report
+IDs, UVM verbosity filtering, severity counts, and a final report summary:
+
+```text
+INFO     .._uvm_reporting/testbench.py(262) [uvm_test_top.env.scoreboard]: [scoreboard] PASSED: 0xff MUL 0xff = 0xfe01
+INFO     .._uvm_reporting/testbench.py(221) [uvm_test_top.env.coverage]: [coverage] Covered all operations
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: --- UVM Report Summary ---
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: ** Report counts by severity
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_INFO    :    9
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_WARNING :    0
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_ERROR   :    0
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_FATAL   :    0
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: TEST_STATUS: PASSED
+```
+
+UVM verbosity is separate from Python logging levels. The monitors report at
+`UVM_DEBUG`, so debug-level monitor output can be enabled without changing the
+Python logging setup:
+
+```bash
+% UVM_VERBOSITY=DEBUG make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
+```
+
+Verilator-style plusargs are also accepted:
+
+```bash
+% make SIM=verilator TOPLEVEL_LANG=verilog \
+    COCOTB_PLUSARGS="+UVM_VERBOSITY=DEBUG +max_quit_count=25 +test_status_label=MY_TEST_STATUS +print_char_len=80" sim checkclean
+```
+
+Set `+max_quit_count=0` to report all errors without quit-count suppression;
+the summary prints the limit as `UNLIMITED`. The `maxquit-demo` target runs the
+intentional-error test at `0`, `1`, `2`, and `25`:
+
+```bash
+% make SIM=verilator TOPLEVEL_LANG=verilog maxquit-demo
+```
+
+The final status line defaults to `TEST_STATUS: PASSED` or `TEST_STATUS: FAILED`;
+set `+test_status_label=...` to match a local log-scraping convention.
+
+The reporting example also includes negative cocotb regression tests. `AluTestErrors`
+uses the normal scoreboard mismatch path and reports errors until the quit count
+is reached. `FatalReportTest` drives the same ALU traffic but reports the first
+scoreboard mismatch through `self.uvm_report.fatal(...)`; cocotb marks it as
+passing because the test expects the resulting `RuntimeError`.
+`FatalDowngradeToErrorTest` uses the fatal path with a report catcher rule that
+downgrades the scoreboard report ID to `UVM_ERROR`, so the test reaches the
+normal summary/status path and fails through the final error count. The report
+server also prints a count-neutral `[SEVCHG]` diagnostic at the fatal call site
+when the downgrade happens.
+`FatalDowngradeToInfoTest` and `ErrorDowngradeToInfoTest` use the same real
+scoreboard mismatch paths but downgrade the reports to `UVM_INFO`, demonstrating
+that waived fatal and error reports no longer contribute to failure counts.
+
 ## The `TinyAluBfm` in `tinyalu_utils.py`
 
 The `TinyAluBfm` is a singleton that uses **cocotb** to communicate with the TinyALU.  The BFM exposes three coroutines to the user: `send_op()`, `get_cmd()`, and `get_result()`.
@@ -468,6 +537,10 @@ self.logger.error("Functional coverage error")
 
 For testbenches that need UVM-style report IDs, UVM verbosity filtering, severity counts, report summaries, or report catching, pyuvm also provides an opt-in SV-UVM-style reporting path. Python logging remains the backend; the UVM-style layer decides whether a report is enabled, assigns UVM severity and report ID metadata, and then emits through logging.
 
+The runnable `examples/TinyALU_uvm_reporting` testbench shows this pattern in a
+complete cocotb simulation while leaving the original `examples/TinyALU`
+walkthrough on direct Python logging.
+
 Enable the shared SV-UVM-style reporting mode before creating UVM objects or components:
 
 ```bash
@@ -511,13 +584,28 @@ UVM verbosity is handled separately from Python logging levels. A UVM info repor
 At the end of a test, the report server can emit a summary and check failure policy:
 
 ```python
-import logging
 from pyuvm import uvm_report_server
 
 report_server = uvm_report_server.get()
-report_server.log_summary(logging.getLogger("uvm"))
-report_server.assert_no_failures("end of test")
+try:
+    report_server.log_summary(self.logger, self.get_full_name())
+    fail_msg = report_server.log_final_status(
+        self.logger,
+        self.get_name(),
+        uvm_full_name=self.get_full_name(),
+    )
+finally:
+    report_server.shutdown()
+
+if fail_msg is not None:
+    raise AssertionError(fail_msg) from None
 ```
+
+When a UVM-style report reaches the formatter, pyuvm marks the record so the
+rendered logger name can show the reporting source location, such as
+`testbench.py(278)`, and the message can include the UVM full name and report ID,
+such as `[uvm_test_top.env.scoreboard]: [scoreboard] ...`. Direct Python logger
+records are not rewritten or counted by the report server.
 
 Output formatting still uses Python logging formatters. pyuvm's `PyuvmFormatter` remains the customization point for teams that want a different log layout while keeping the UVM-style report metadata and filtering behavior.
 

--- a/docs/docsources/SV_UVM_Style_Reporting.rst
+++ b/docs/docsources/SV_UVM_Style_Reporting.rst
@@ -10,6 +10,11 @@ severity counts, report summaries, or report catching, pyuvm also provides an
 opt-in SV-UVM-style reporting path. The UVM-style layer performs the UVM
 reporting decisions and then emits through Python logging.
 
+The runnable ``examples/TinyALU_uvm_reporting/testbench.py`` example shows this
+flow in a complete TinyALU simulation, including report IDs, runtime verbosity,
+source file and line formatting, severity counts, quit-count handling, fatal
+reports, and a final report summary.
+
 Enabling SV-UVM-Style Reporting
 -------------------------------
 
@@ -18,6 +23,12 @@ Enable the shared reporting mode before creating UVM objects or components:
 .. code-block:: bash
 
    PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1 make sim
+
+In cocotb simulations, the same mode can be enabled with a plusarg:
+
+.. code-block:: bash
+
+   make sim COCOTB_PLUSARGS="+PYUVM_ENABLE_SV_UVM_STYLE_REPORTING=1"
 
 You can also enable it from Python before constructing the testbench:
 
@@ -32,8 +43,24 @@ When this mode is enabled, ``uvm_object`` loggers propagate to the shared
 stream handler on every report object. This preserves Python logging as the
 transport while giving the testbench a shared path for report rendering.
 
-To collect severity counts, use report summaries, or install report catcher
-rules, create the report server early in the test:
+When this mode is enabled, ``uvm_test`` creates the shared report server during
+test construction. This gives every component and sequence a common server for
+severity counts, summaries, quit-count handling, and report catcher rules
+before build phase starts.
+
+Runtime reporting options are resolved from cocotb plusargs first, then
+environment variables, then defaults:
+
+* ``UVM_VERBOSITY``
+* ``UVM_FAIL_ON_WARNING``
+* ``UVM_FAIL_ON_ERROR``
+* ``UVM_FAIL_ON_FATAL``
+* ``max_quit_count`` or ``UVM_MAX_QUIT_COUNT``
+* ``test_status_label`` or ``TEST_STATUS_LABEL``
+* ``print_char_len`` or ``UVM_PRINT_CHAR_LEN``
+
+For objects that are not under a ``uvm_test``-managed simulation, the report
+server can still be created explicitly:
 
 .. code-block:: python
 
@@ -96,37 +123,107 @@ summary and assert the failure policy:
 
 .. code-block:: python
 
-   import logging
    from pyuvm import uvm_report_server
 
    report_server = uvm_report_server.get()
-   report_server.log_summary(logging.getLogger("uvm"))
-   report_server.assert_no_failures("end of test")
+   fail_msg = None
+   try:
+       report_server.log_summary(self.logger, self.get_full_name())
+       fail_msg = report_server.log_final_status(
+           self.logger,
+           self.get_name(),
+           uvm_full_name=self.get_full_name(),
+       )
+   finally:
+       report_server.shutdown()
+
+   if fail_msg is not None:
+       raise AssertionError(fail_msg) from None
+
+Call ``log_summary()`` and ``log_final_status()`` before ``shutdown()`` if you
+want those lines to use the UVM-style source-location formatter. ``shutdown()``
+restores the original Python logging formatters.
 
 By default, warnings do not fail the test, while errors and fatals do. The
-policy can be changed when the report server is created:
+policy can be changed with runtime options, or when the report server is
+created explicitly:
 
 .. code-block:: python
 
    from pyuvm import uvm_report_policy, uvm_report_server
 
-   policy = uvm_report_policy(fail_on_warning=True, max_quit_count=5)
+   policy = uvm_report_policy(
+       fail_on_warning=True,
+       max_quit_count=5,
+       test_status_label="MY_TEST_STATUS",
+   )
    uvm_report_server.create(policy=policy)
+
+``log_final_status()`` emits ``TEST_STATUS: PASSED`` or
+``TEST_STATUS: FAILED`` by default. Set ``test_status_label`` in the policy, or
+pass ``test_status_label=...`` to ``log_final_status()``, when local automation
+expects a different status token.
+
+``max_quit_count`` controls how many UVM error reports are emitted before later
+UVM error reports are suppressed. A value of ``0`` means unlimited: all UVM
+errors are reported, no ``MAXQUIT`` warning is emitted, and the summary prints
+``UNLIMITED`` as the limit.
+
+.. code-block:: text
+
+   INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_ERROR   :    8
+   INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: Quit count :     8 of UNLIMITED (UVM_ERROR)
+   INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: TEST_STATUS: FAILED
+
+When the quit count is positive and reached, the triggering UVM error is logged,
+then the report server emits a ``[MAXQUIT]`` warning. The summary and final
+status are still printed so the simulation exits with a complete report.
+
+.. code-block:: text
+
+   ERROR    .._uvm_reporting/testbench.py(278) [uvm_test_top.env.scoreboard]: [scoreboard] FAILED: ...
+   WARNING  .._uvm_reporting/testbench.py(278) [uvm_test_top.env.scoreboard]: [MAXQUIT] Quit count reached: 1 of 1 (UVM_ERROR)
+   INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_ERROR   :    1
+   INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: TEST_STATUS: FAILED
 
 Report Catching
 ---------------
 
 The report server supports simple severity rewrites by report ID and message
-regular expression:
+regular expression. Tests can install project- or test-specific demotions by
+overriding ``add_message_demotes(self, catcher)``:
 
 .. code-block:: python
 
-   from pyuvm import UVM_WARNING, uvm_report_server
+   from pyuvm import UVM_WARNING, uvm_test
 
-   report_server = uvm_report_server.get()
-   report_server.add_change_sev("KNOWN_ISSUE", "temporary", UVM_WARNING)
+   class MyTest(uvm_test):
+       def add_message_demotes(self, catcher):
+           super().add_message_demotes(catcher)
+           catcher.add_change_sev("KNOWN_ISSUE", "temporary", UVM_WARNING)
 
-   self.uvm_report.error("KNOWN_ISSUE", "temporary mismatch")
+       def run_phase(self):
+           self.uvm_report.error("KNOWN_ISSUE", "temporary mismatch")
+
+A fatal report can also be downgraded before it is emitted. In that case it is
+counted and logged at the downgraded severity and does not raise the
+``RuntimeError`` used for an actual ``UVM_FATAL``:
+
+.. code-block:: python
+
+   from pyuvm import UVM_ERROR, uvm_test
+
+   class MyTest(uvm_test):
+       def add_message_demotes(self, catcher):
+           super().add_message_demotes(catcher)
+           catcher.add_change_sev("KNOWN_FATAL", "expected", UVM_ERROR)
+
+       def run_phase(self):
+           self.uvm_report.fatal("KNOWN_FATAL", "expected fatal condition")
+
+When a catcher changes severity, the report server emits a UVM-style
+``[SEVCHG]`` info record at the original report call site. This diagnostic is
+not included in report severity counts.
 
 Formatter Relationship
 ----------------------
@@ -136,6 +233,66 @@ report metadata and filtering before the message reaches logging. The rendered
 timestamp, hierarchy, filename, line number, and final text layout still come
 from the active Python logging formatter.
 
+Only UVM-style records emitted through ``self.uvm_report`` or
+``uvm_report_server`` summary/status helpers are rewritten with UVM report
+metadata. Direct Python logger records keep their normal logger name and are not
+counted by the report server.
+
+The default UVM-style wrapped formatter changes the rendered logger name for
+UVM records to the source location, such as ``testbench.py(278)``, and prefixes
+the message with the UVM full name and report ID:
+
+.. code-block:: text
+
+   CRITICAL .._uvm_reporting/testbench.py(278) [uvm_test_top.env.scoreboard]: [scoreboard] FAILED: ...
+
+The ``stacklevel`` used by ``uvm_reporter`` preserves the user report call site
+instead of pointing at the reporting helper. Summary and final-status records
+intentionally point at ``uvm_report_server.py`` because those records originate
+from the report server.
+
 pyuvm's ``PyuvmFormatter`` remains the customization point for teams that want
 a different log layout while keeping the UVM-style report metadata, verbosity
 filtering, counts, summaries, and catcher behavior.
+
+TinyALU Reporting Example
+-------------------------
+
+Run the complete TinyALU reporting regression with:
+
+.. code-block:: bash
+
+   cd examples/TinyALU_uvm_reporting
+   make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
+
+The regression includes:
+
+* ``AluTest``: passing ALU traffic with summary and ``TEST_STATUS: PASSED``.
+* ``ParallelTest``: forked random/max sequences.
+* ``FibonacciTest``: sequence reporting through its own ``self.uvm_report``.
+* ``AluTestErrors``: real scoreboard mismatches reported as UVM errors.
+* ``FatalReportTest``: the same mismatch path reported through
+  ``self.uvm_report.fatal()`` and expected by cocotb as ``RuntimeError``.
+* ``FatalDowngradeToErrorTest``: the fatal mismatch path downgraded to
+  ``UVM_ERROR`` so it exits through the normal summary/status failure path and
+  shows a ``[SEVCHG]`` diagnostic.
+* ``FatalDowngradeToInfoTest``: the fatal mismatch path downgraded to
+  ``UVM_INFO`` so the waived mismatches pass through the final status check.
+* ``ErrorDowngradeToInfoTest``: the error mismatch path downgraded to
+  ``UVM_INFO`` with no UVM error count.
+
+The example accepts reporting controls through plusargs or matching environment
+variables:
+
+.. code-block:: bash
+
+   make SIM=verilator TOPLEVEL_LANG=verilog \
+       COCOTB_PLUSARGS="+UVM_VERBOSITY=DEBUG +max_quit_count=25 +test_status_label=MY_TEST_STATUS +print_char_len=80" \
+       sim checkclean
+
+The ``maxquit-demo`` target runs the error test at ``0``, ``1``, ``2``, and
+``25`` so the quit-count behavior is visible in one command:
+
+.. code-block:: bash
+
+   make SIM=verilator TOPLEVEL_LANG=verilog maxquit-demo

--- a/docs/docsources/UVM_and_Python.rst
+++ b/docs/docsources/UVM_and_Python.rst
@@ -166,4 +166,8 @@ pass when the report verbosity is less than or equal to the configured UVM
 verbosity. Python logging levels continue to represent severity for the backend
 formatter and handlers.
 
-See :doc:`SV_UVM_Style_Reporting` for examples.
+The ``examples/TinyALU_uvm_reporting`` directory demonstrates this opt-in path
+in a runnable cocotb simulation while the original ``examples/TinyALU`` example
+continues to show direct Python logging.
+
+See :doc:`SV_UVM_Style_Reporting` for the reporting API details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,4 @@ pyuvm
    docsources/UVM_and_Python
    docsources/SV_UVM_Style_Reporting
    apidocs/index
+   apidocs/pyuvm/pyuvm.uvm_reporting

--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -127,6 +127,10 @@ class FibonacciSeq(uvm_sequence):
         super().__init__(name)
         self.seqr = ConfigDB().get(None, "", "SEQR")
 
+    def report_fibonacci_sequence(self, fib_list):
+        uvm_root().logger.info("Fibonacci Sequence: " + str(fib_list))
+        uvm_root().set_logging_level_hier(logging.CRITICAL)
+
     async def body(self):
         prev_num = 0
         cur_num = 1
@@ -136,8 +140,7 @@ class FibonacciSeq(uvm_sequence):
             fib_list.append(sum)
             prev_num = cur_num
             cur_num = sum
-        uvm_root().logger.info("Fibonacci Sequence: " + str(fib_list))
-        uvm_root().set_logging_level_hier(logging.CRITICAL)
+        self.report_fibonacci_sequence(fib_list)
 
 
 class Driver(uvm_driver):
@@ -170,20 +173,25 @@ class Coverage(uvm_subscriber):
         (_, _, op) = cmd
         self.cvg.add(op)
 
+    def report_coverage_error(self, missed):
+        self.logger.error(f"Functional coverage error. Missed: {missed}")
+        assert False
+
+    def report_coverage_pass(self):
+        self.logger.info("Covered all operations")
+        assert True
+
     def report_phase(self):
         try:
             disable_errors = ConfigDB().get(self, "", "DISABLE_COVERAGE_ERRORS")
         except UVMConfigItemNotFound:
             disable_errors = False
         if not disable_errors:
-            if len(set(Ops) - self.cvg) > 0:
-                self.logger.error(
-                    f"Functional coverage error. Missed: {set(Ops) - self.cvg}"
-                )
-                assert False
+            missed = set(Ops) - self.cvg
+            if len(missed) > 0:
+                self.report_coverage_error(missed)
             else:
-                self.logger.info("Covered all operations")
-                assert True
+                self.report_coverage_pass()
 
 
 class Scoreboard(uvm_component):
@@ -199,6 +207,33 @@ class Scoreboard(uvm_component):
         self.cmd_get_port.connect(self.cmd_fifo.get_export)
         self.result_get_port.connect(self.result_fifo.get_export)
 
+    def pass_message(self, A, B, op, actual_result):
+        return f"PASSED: 0x{A:02x} {op.name} 0x{B:02x} = 0x{actual_result:04x}"
+
+    def mismatch_message(self, A, B, op, actual_result, predicted_result):
+        return (
+            f"FAILED: 0x{A:02x} {op.name} 0x{B:02x} "
+            f"= 0x{actual_result:04x} "
+            f"expected 0x{predicted_result:04x}"
+        )
+
+    def report_missing_command(self, actual_result):
+        self.logger.critical(f"result {actual_result} had no command")
+
+    def report_pass(self, A, B, op, actual_result):
+        self.logger.info(self.pass_message(A, B, op, actual_result))
+
+    def report_mismatch(self, A, B, op, actual_result, predicted_result):
+        self.logger.error(
+            self.mismatch_message(A, B, op, actual_result, predicted_result)
+        )
+
+    def quit_count_reached(self):
+        return False
+
+    def finish_check(self, passed):
+        assert passed
+
     def check_phase(self):
         passed = True
         try:
@@ -209,23 +244,19 @@ class Scoreboard(uvm_component):
             _, actual_result = self.result_get_port.try_get()
             cmd_success, cmd = self.cmd_get_port.try_get()
             if not cmd_success:
-                self.logger.critical(f"result {actual_result} had no command")
+                self.report_missing_command(actual_result)
             else:
                 (A, B, op_numb) = cmd
                 op = Ops(op_numb)
                 predicted_result = alu_prediction(A, B, op, self.errors)
                 if predicted_result == actual_result:
-                    self.logger.info(
-                        f"PASSED: 0x{A:02x} {op.name} 0x{B:02x} = 0x{actual_result:04x}"
-                    )
+                    self.report_pass(A, B, op, actual_result)
                 else:
-                    self.logger.error(
-                        f"FAILED: 0x{A:02x} {op.name} 0x{B:02x} "
-                        f"= 0x{actual_result:04x} "
-                        f"expected 0x{predicted_result:04x}"
-                    )
+                    self.report_mismatch(A, B, op, actual_result, predicted_result)
                     passed = False
-        assert passed
+                    if self.quit_count_reached():
+                        break
+        self.finish_check(passed)
 
 
 class Monitor(uvm_component):
@@ -238,11 +269,19 @@ class Monitor(uvm_component):
         self.bfm = TinyAluBfm()
         self.get_method = getattr(self.bfm, self.method_name)
 
+    def report_monitored(self, datum):
+        self.logger.debug(f"MONITORED {datum}")
+
     async def run_phase(self):
         while True:
             datum = await self.get_method()
-            self.logger.debug(f"MONITORED {datum}")
+            self.report_monitored(datum)
             self.ap.write(datum)
+
+
+class CommandMonitor(Monitor):
+    def __init__(self, name, parent):
+        super().__init__(name, parent, "get_cmd")
 
 
 class AluEnv(uvm_env):
@@ -252,9 +291,9 @@ class AluEnv(uvm_env):
         self.seqr = uvm_sequencer("seqr", self)
         ConfigDB().set(None, "*", "SEQR", self.seqr)
         self.driver = Driver.create("driver", self)
-        self.cmd_mon = Monitor("cmd_mon", self, "get_cmd")
-        self.coverage = Coverage("coverage", self)
-        self.scoreboard = Scoreboard("scoreboard", self)
+        self.cmd_mon = CommandMonitor.create("cmd_mon", self)
+        self.coverage = Coverage.create("coverage", self)
+        self.scoreboard = Scoreboard.create("scoreboard", self)
 
     def connect_phase(self):
         self.driver.seq_item_port.connect(self.seqr.seq_item_export)
@@ -268,7 +307,7 @@ class AluTest(uvm_test):
     """Test ALU with random and max values"""
 
     def build_phase(self):
-        self.env = AluEnv("env", self)
+        self.env = AluEnv.create("env", self)
 
     def end_of_elaboration_phase(self):
         self.test_all = TestAllSeq.create("test_all")

--- a/examples/TinyALU_uvm_reporting/Makefile
+++ b/examples/TinyALU_uvm_reporting/Makefile
@@ -1,0 +1,37 @@
+CWD=$(shell pwd)
+export COCOTB_REDUCED_LOG_FMT = 1
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+MAX_QUIT_COUNTS ?= 0 1 2 25
+MAX_QUIT_TEST_FILTER ?= AluTestErrors
+ifeq ($(TOPLEVEL_LANG),verilog)
+	VERILOG_SOURCES =$(CWD)/../TinyALU/hdl/verilog/tinyalu.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+	VHDL_SOURCES=$(CWD)/../TinyALU/hdl/vhdl/single_cycle_add_and_xor.vhd \
+				$(CWD)/../TinyALU/hdl/vhdl/three_cycle_mult.vhd \
+				$(CWD)/../TinyALU/hdl/vhdl/tinyalu.vhd
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
+ifeq ($(SIM), verilator)
+    # Enable processing of #delay statements
+    COMPILE_ARGS += --timing
+endif
+MODULE := testbench
+TOPLEVEL = tinyalu
+GHDL_ARGS := --ieee=synopsys
+COCOTB_HDL_TIMEUNIT = 1us
+COCOTB_HDL_TIMEPRECISION = 1us
+include $(shell cocotb-config --makefiles)/Makefile.sim
+include ../../checkclean.mk
+
+.PHONY: maxquit-demo
+maxquit-demo:
+	@set -e; \
+	for q in $(MAX_QUIT_COUNTS); do \
+		printf '\n===== %s +max_quit_count=%s =====\n' "$(MAX_QUIT_TEST_FILTER)" "$$q"; \
+		$(MAKE) SIM=$(SIM) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
+			COCOTB_TEST_FILTER=$(MAX_QUIT_TEST_FILTER) \
+			COCOTB_PLUSARGS="$(COCOTB_PLUSARGS) +max_quit_count=$$q" \
+			sim checkclean; \
+	done

--- a/examples/TinyALU_uvm_reporting/README.md
+++ b/examples/TinyALU_uvm_reporting/README.md
@@ -1,0 +1,63 @@
+# TinyALU SV-UVM-Style Reporting Example
+
+This example uses the same TinyALU RTL and BFM as `examples/TinyALU`, but it
+demonstrates pyuvm's opt-in SV-UVM-style reporting path. The original TinyALU
+example remains the direct Python logging walkthrough.
+
+Run the full reporting regression:
+
+```sh
+make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
+```
+
+The regression runs:
+
+- `AluTest`: passing ALU traffic with a report summary and `TEST_STATUS: PASSED`.
+- `ParallelTest`: forked random and max-value sequences.
+- `FibonacciTest`: sequence reporting through the sequence's own
+  `self.uvm_report`.
+- `AluTestErrors`: real scoreboard mismatches reported as UVM errors.
+- `FatalReportTest`: the same mismatch path reported with
+  `self.uvm_report.fatal()`, expected by cocotb as `RuntimeError`.
+- `FatalDowngradeToErrorTest`: the fatal mismatch path with the scoreboard
+  report ID downgraded to `UVM_ERROR`, including a `[SEVCHG]` diagnostic.
+- `FatalDowngradeToInfoTest`: the fatal mismatch path downgraded to `UVM_INFO`.
+- `ErrorDowngradeToInfoTest`: the error mismatch path downgraded to `UVM_INFO`.
+
+Run one test by name:
+
+```sh
+COCOTB_TEST_FILTER=FatalDowngradeToErrorTest make SIM=verilator TOPLEVEL_LANG=verilog sim checkclean
+```
+
+Useful reporting controls can be passed as plusargs:
+
+```sh
+make SIM=verilator TOPLEVEL_LANG=verilog \
+    COCOTB_PLUSARGS="+UVM_VERBOSITY=DEBUG +max_quit_count=25 +test_status_label=MY_TEST_STATUS +print_char_len=80" \
+    sim checkclean
+```
+
+`+max_quit_count=0` means unlimited errors. The summary prints that limit as
+`UNLIMITED`:
+
+```text
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: UVM_ERROR   :    8
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: Quit count :     8 of UNLIMITED (UVM_ERROR)
+INFO     ..orting/uvm_report_server.py(...) [uvm_test_top]: TEST_STATUS: FAILED
+```
+
+Run the quit-count demo at `0`, `1`, `2`, and `25`:
+
+```sh
+make SIM=verilator TOPLEVEL_LANG=verilog maxquit-demo
+```
+
+UVM-style records show the source file and line, UVM hierarchy, and report ID:
+
+```text
+CRITICAL .._uvm_reporting/testbench.py(278) [uvm_test_top.env.scoreboard]: [scoreboard] FAILED: ...
+```
+
+Direct Python logger records are still ordinary logging records; they are not
+counted by the report server and are not rewritten as UVM reports.

--- a/examples/TinyALU_uvm_reporting/testbench.py
+++ b/examples/TinyALU_uvm_reporting/testbench.py
@@ -1,0 +1,391 @@
+import random
+
+# All testbenches use tinyalu_utils, so store it in a central
+# place and add its path to the sys path so we can import it.
+import sys
+from pathlib import Path
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import Combine
+
+import pyuvm
+from pyuvm import *
+
+set_sv_uvm_style_reporting_enabled(True)
+
+sys.path.append(str(Path("../TinyALU").resolve()))
+from tinyalu_utils import Ops, TinyAluBfm, alu_prediction  # noqa: E402
+
+
+# Sequence classes
+
+
+class AluSeqItem(uvm_sequence_item):
+    def __init__(self, name, aa, bb, op):
+        super().__init__(name)
+        self.A = aa
+        self.B = bb
+        self.op = Ops(op)
+
+    def randomize_operands(self):
+        self.A = random.randint(0, 255)
+        self.B = random.randint(0, 255)
+
+    def randomize(self):
+        self.randomize_operands()
+        self.op = random.choice(list(Ops))
+
+    def __eq__(self, other):
+        same = self.A == other.A and self.B == other.B and self.op == other.op
+        return same
+
+    __hash__: None  # type: ignore
+
+    def __str__(self):
+        return f"{self.get_name()} : A: 0x{self.A:02x} \
+        OP: {self.op.name} ({self.op.value}) B: 0x{self.B:02x}"
+
+
+class RandomSeq(uvm_sequence):
+    async def body(self):
+        for op in list(Ops):
+            cmd_tr = AluSeqItem("cmd_tr", None, None, op)
+            await self.start_item(cmd_tr)
+            cmd_tr.randomize_operands()
+            await self.finish_item(cmd_tr)
+
+
+class MaxSeq(uvm_sequence):
+    async def body(self):
+        for op in list(Ops):
+            cmd_tr = AluSeqItem("cmd_tr", 0xFF, 0xFF, op)
+            await self.start_item(cmd_tr)
+            await self.finish_item(cmd_tr)
+
+
+class TestAllSeq(uvm_sequence):
+    async def body(self):
+        seqr = ConfigDB().get(None, "", "SEQR")
+        random = RandomSeq("random")
+        max = MaxSeq("max")
+        await random.start(seqr)
+        await max.start(seqr)
+
+
+class TestAllForkSeq(uvm_sequence):
+    async def body(self):
+        seqr = ConfigDB().get(None, "", "SEQR")
+        random = RandomSeq("random")
+        max = MaxSeq("max")
+        random_task = cocotb.start_soon(random.start(seqr))
+        max_task = cocotb.start_soon(max.start(seqr))
+        await Combine(random_task, max_task)
+
+
+# Sequence library example
+
+
+class OpSeq(uvm_sequence):
+    def __init__(self, name, aa, bb, op):
+        super().__init__(name)
+        self.aa = aa
+        self.bb = bb
+        self.op = Ops(op)
+
+    async def body(self):
+        seq_item = AluSeqItem("seq_item", self.aa, self.bb, self.op)
+        await self.start_item(seq_item)
+        await self.finish_item(seq_item)
+        self.result = seq_item.result
+
+
+async def do_add(seqr, aa, bb):
+    seq = OpSeq("seq", aa, bb, Ops.ADD)
+    await seq.start(seqr)
+    return seq.result
+
+
+async def do_and(seqr, aa, bb):
+    seq = OpSeq("seq", aa, bb, Ops.AND)
+    await seq.start(seqr)
+    return seq.result
+
+
+async def do_xor(seqr, aa, bb):
+    seq = OpSeq("seq", aa, bb, Ops.XOR)
+    await seq.start(seqr)
+    return seq.result
+
+
+async def do_mul(seqr, aa, bb):
+    seq = OpSeq("seq", aa, bb, Ops.MUL)
+    await seq.start(seqr)
+    return seq.result
+
+
+class FibonacciSeq(uvm_sequence):
+    def __init__(self, name):
+        super().__init__(name)
+        self.seqr = ConfigDB().get(None, "", "SEQR")
+
+    async def body(self):
+        prev_num = 0
+        cur_num = 1
+        fib_list = [prev_num, cur_num]
+        for _ in range(7):
+            sum = await do_add(self.seqr, prev_num, cur_num)
+            fib_list.append(sum)
+            prev_num = cur_num
+            cur_num = sum
+        self.uvm_report.info(
+            self.get_name(), "Fibonacci Sequence: " + str(fib_list), UVM_LOW
+        )
+
+
+class Driver(uvm_driver):
+    def build_phase(self):
+        self.ap = uvm_analysis_port("ap", self)
+
+    def start_of_simulation_phase(self):
+        self.bfm = TinyAluBfm()
+
+    async def launch_tb(self):
+        await self.bfm.reset()
+        self.bfm.start_bfm()
+
+    async def run_phase(self):
+        await self.launch_tb()
+        while True:
+            cmd = await self.seq_item_port.get_next_item()
+            await self.bfm.send_op(cmd.A, cmd.B, cmd.op)
+            result = await self.bfm.get_result()
+            self.ap.write(result)
+            cmd.result = result
+            self.seq_item_port.item_done()
+
+
+class Coverage(uvm_subscriber):
+    def end_of_elaboration_phase(self):
+        self.cvg = set()
+
+    def write(self, cmd):
+        (_, _, op) = cmd
+        self.cvg.add(op)
+
+    def report_phase(self):
+        try:
+            disable_errors = ConfigDB().get(self, "", "DISABLE_COVERAGE_ERRORS")
+        except UVMConfigItemNotFound:
+            disable_errors = False
+        if not disable_errors:
+            if len(set(Ops) - self.cvg) > 0:
+                self.uvm_report.error(
+                    self.get_name(),
+                    f"Functional coverage error. Missed: {set(Ops) - self.cvg}",
+                )
+            else:
+                self.uvm_report.info(
+                    self.get_name(), "Covered all operations", UVM_LOW
+                )
+
+
+class Scoreboard(uvm_component):
+    def build_phase(self):
+        self.cmd_fifo = uvm_tlm_analysis_fifo("cmd_fifo", self)
+        self.result_fifo = uvm_tlm_analysis_fifo("result_fifo", self)
+        self.cmd_get_port = uvm_get_port("cmd_get_port", self)
+        self.result_get_port = uvm_get_port("result_get_port", self)
+        self.cmd_export = self.cmd_fifo.analysis_export
+        self.result_export = self.result_fifo.analysis_export
+
+    def connect_phase(self):
+        self.cmd_get_port.connect(self.cmd_fifo.get_export)
+        self.result_get_port.connect(self.result_fifo.get_export)
+
+    def _quit_count_reached(self):
+        report_server = uvm_report_server.get_or_none()
+        return (
+            report_server is not None and report_server.error_quit_count_reached()
+        )
+
+    def check_phase(self):
+        try:
+            self.errors = ConfigDB().get(self, "", "CREATE_ERRORS")
+        except UVMConfigItemNotFound:
+            self.errors = False
+        try:
+            self.fatals = ConfigDB().get(self, "", "CREATE_FATALS")
+        except UVMConfigItemNotFound:
+            self.fatals = False
+        while self.result_get_port.can_get():
+            _, actual_result = self.result_get_port.try_get()
+            cmd_success, cmd = self.cmd_get_port.try_get()
+            if not cmd_success:
+                self.uvm_report.fatal(
+                    self.get_name(), f"result {actual_result} had no command"
+                )
+            else:
+                (A, B, op_numb) = cmd
+                op = Ops(op_numb)
+                predicted_result = alu_prediction(A, B, op, self.errors)
+                if predicted_result == actual_result:
+                    self.uvm_report.info(
+                        self.get_name(),
+                        f"PASSED: 0x{A:02x} {op.name} 0x{B:02x} = 0x{actual_result:04x}",
+                        UVM_LOW,
+                    )
+                else:
+                    mismatch_msg = (
+                        f"FAILED: 0x{A:02x} {op.name} 0x{B:02x} "
+                        f"= 0x{actual_result:04x} "
+                        f"expected 0x{predicted_result:04x}"
+                    )
+                    if self.fatals:
+                        self.uvm_report.fatal(self.get_name(), mismatch_msg)
+                    else:
+                        self.uvm_report.error(self.get_name(), mismatch_msg)
+                    if self._quit_count_reached():
+                        break
+
+
+class Monitor(uvm_component):
+    def __init__(self, name, parent, method_name):
+        super().__init__(name, parent)
+        self.method_name = method_name
+
+    def build_phase(self):
+        self.ap = uvm_analysis_port("ap", self)
+        self.bfm = TinyAluBfm()
+        self.get_method = getattr(self.bfm, self.method_name)
+
+    async def run_phase(self):
+        while True:
+            datum = await self.get_method()
+            self.uvm_report.info(self.get_name(), f"MONITORED {datum}", UVM_DEBUG)
+            self.ap.write(datum)
+
+
+class AluEnv(uvm_env):
+    def build_phase(self):
+        self.clk_drv = Clock(cocotb.top.clk, 2, "us")
+        cocotb.start_soon(self.clk_drv.start())
+        self.seqr = uvm_sequencer("seqr", self)
+        ConfigDB().set(None, "*", "SEQR", self.seqr)
+        self.driver = Driver.create("driver", self)
+        self.cmd_mon = Monitor("cmd_mon", self, "get_cmd")
+        self.coverage = Coverage("coverage", self)
+        self.scoreboard = Scoreboard("scoreboard", self)
+
+    def connect_phase(self):
+        self.driver.seq_item_port.connect(self.seqr.seq_item_export)
+        self.cmd_mon.ap.connect(self.scoreboard.cmd_export)
+        self.cmd_mon.ap.connect(self.coverage.analysis_export)
+        self.driver.ap.connect(self.scoreboard.result_export)
+
+
+@pyuvm.test()
+class AluTest(uvm_test):
+    """Test ALU with random and max values"""
+
+    def build_phase(self):
+        self.env = AluEnv("env", self)
+
+    def end_of_elaboration_phase(self):
+        self.test_all = TestAllSeq.create("test_all")
+
+    async def run_phase(self):
+        self.raise_objection("Keep simulation alive")
+        await self.test_all.start()
+        self.drop_objection("Simulation may end now")
+
+    def final_phase(self):
+        report_server = getattr(self, "report_server", None)
+        if report_server is None:
+            return
+        fail_msg = None
+        try:
+            report_server.log_summary(self.logger, self.get_full_name())
+            fail_msg = report_server.log_final_status(
+                self.logger,
+                self.get_name(),
+                uvm_full_name=self.get_full_name(),
+            )
+        finally:
+            report_server.shutdown()
+        if fail_msg is not None:
+            raise AssertionError(fail_msg) from None
+
+
+@pyuvm.test()
+class ParallelTest(AluTest):
+    """Test ALU random and max forked"""
+
+    def build_phase(self):
+        uvm_factory().set_type_override_by_type(TestAllSeq, TestAllForkSeq)
+        super().build_phase()
+
+
+@pyuvm.test()
+class FibonacciTest(AluTest):
+    """Run Fibonacci program"""
+
+    def build_phase(self):
+        ConfigDB().set(None, "*", "DISABLE_COVERAGE_ERRORS", True)
+        uvm_factory().set_type_override_by_type(TestAllSeq, FibonacciSeq)
+        return super().build_phase()
+
+
+@pyuvm.test(expect_error=(AssertionError,))
+class AluTestErrors(AluTest):
+    """Test ALU with errors on all operations"""
+
+    def start_of_simulation_phase(self):
+        ConfigDB().set(None, "*", "CREATE_ERRORS", True)
+
+
+@pyuvm.test(expect_error=(RuntimeError,))
+class FatalReportTest(AluTest):
+    """Report a real ALU mismatch through self.uvm_report.fatal."""
+
+    def start_of_simulation_phase(self):
+        ConfigDB().set(None, "*", "CREATE_ERRORS", True)
+        ConfigDB().set(None, "*", "CREATE_FATALS", True)
+
+
+@pyuvm.test(expect_error=(AssertionError,))
+class FatalDowngradeToErrorTest(AluTest):
+    """Report a real fatal mismatch after downgrading it to UVM_ERROR."""
+
+    def add_message_demotes(self, catcher):
+        super().add_message_demotes(catcher)
+        catcher.add_change_sev("scoreboard", "FAILED:", UVM_ERROR)
+
+    def start_of_simulation_phase(self):
+        ConfigDB().set(None, "*", "CREATE_ERRORS", True)
+        ConfigDB().set(None, "*", "CREATE_FATALS", True)
+
+
+@pyuvm.test()
+class FatalDowngradeToInfoTest(AluTest):
+    """Report real fatal mismatches after downgrading them to UVM_INFO."""
+
+    def add_message_demotes(self, catcher):
+        super().add_message_demotes(catcher)
+        catcher.add_change_sev("scoreboard", "FAILED:", UVM_INFO)
+
+    def start_of_simulation_phase(self):
+        ConfigDB().set(None, "*", "CREATE_ERRORS", True)
+        ConfigDB().set(None, "*", "CREATE_FATALS", True)
+
+
+@pyuvm.test()
+class ErrorDowngradeToInfoTest(AluTest):
+    """Report real error mismatches after downgrading them to UVM_INFO."""
+
+    def add_message_demotes(self, catcher):
+        super().add_message_demotes(catcher)
+        catcher.add_change_sev("scoreboard", "FAILED:", UVM_INFO)
+
+    def start_of_simulation_phase(self):
+        ConfigDB().set(None, "*", "CREATE_ERRORS", True)

--- a/examples/TinyALU_uvm_reporting/testbench.py
+++ b/examples/TinyALU_uvm_reporting/testbench.py
@@ -17,7 +17,6 @@ set_sv_uvm_style_reporting_enabled(True)
 sys.path.append(str(Path("../TinyALU").resolve()))
 from tinyalu_utils import Ops, TinyAluBfm, alu_prediction  # noqa: E402
 
-
 # Sequence classes
 
 
@@ -185,9 +184,7 @@ class Coverage(uvm_subscriber):
                     f"Functional coverage error. Missed: {set(Ops) - self.cvg}",
                 )
             else:
-                self.uvm_report.info(
-                    self.get_name(), "Covered all operations", UVM_LOW
-                )
+                self.uvm_report.info(self.get_name(), "Covered all operations", UVM_LOW)
 
 
 class Scoreboard(uvm_component):
@@ -205,9 +202,7 @@ class Scoreboard(uvm_component):
 
     def _quit_count_reached(self):
         report_server = uvm_report_server.get_or_none()
-        return (
-            report_server is not None and report_server.error_quit_count_reached()
-        )
+        return report_server is not None and report_server.error_quit_count_reached()
 
     def check_phase(self):
         try:

--- a/examples/TinyALU_uvm_reporting/testbench.py
+++ b/examples/TinyALU_uvm_reporting/testbench.py
@@ -1,298 +1,98 @@
-import random
-
-# All testbenches use tinyalu_utils, so store it in a central
-# place and add its path to the sys path so we can import it.
+import importlib.util
 import sys
 from pathlib import Path
-
-import cocotb
-from cocotb.clock import Clock
-from cocotb.triggers import Combine
 
 import pyuvm
 from pyuvm import *
 
 set_sv_uvm_style_reporting_enabled(True)
 
-sys.path.append(str(Path("../TinyALU").resolve()))
-from tinyalu_utils import Ops, TinyAluBfm, alu_prediction  # noqa: E402
+_TINYALU_DIR = Path(__file__).resolve().parents[1] / "TinyALU"
+if str(_TINYALU_DIR) not in sys.path:
+    sys.path.insert(0, str(_TINYALU_DIR))
 
-# Sequence classes
+_BASE_MODULE_NAME = "_pyuvm_tinyalu_base_testbench"
+_BASE_MODULE_PATH = _TINYALU_DIR / "testbench.py"
 
-
-class AluSeqItem(uvm_sequence_item):
-    def __init__(self, name, aa, bb, op):
-        super().__init__(name)
-        self.A = aa
-        self.B = bb
-        self.op = Ops(op)
-
-    def randomize_operands(self):
-        self.A = random.randint(0, 255)
-        self.B = random.randint(0, 255)
-
-    def randomize(self):
-        self.randomize_operands()
-        self.op = random.choice(list(Ops))
-
-    def __eq__(self, other):
-        same = self.A == other.A and self.B == other.B and self.op == other.op
-        return same
-
-    __hash__: None  # type: ignore
-
-    def __str__(self):
-        return f"{self.get_name()} : A: 0x{self.A:02x} \
-        OP: {self.op.name} ({self.op.value}) B: 0x{self.B:02x}"
+if _BASE_MODULE_NAME in sys.modules:
+    tinyalu_base = sys.modules[_BASE_MODULE_NAME]
+else:
+    _base_spec = importlib.util.spec_from_file_location(
+        _BASE_MODULE_NAME, _BASE_MODULE_PATH
+    )
+    if _base_spec is None or _base_spec.loader is None:
+        raise ImportError(f"Could not load TinyALU testbench from {_BASE_MODULE_PATH}")
+    tinyalu_base = importlib.util.module_from_spec(_base_spec)
+    sys.modules[_BASE_MODULE_NAME] = tinyalu_base
+    _base_spec.loader.exec_module(tinyalu_base)
 
 
-class RandomSeq(uvm_sequence):
-    async def body(self):
-        for op in list(Ops):
-            cmd_tr = AluSeqItem("cmd_tr", None, None, op)
-            await self.start_item(cmd_tr)
-            cmd_tr.randomize_operands()
-            await self.finish_item(cmd_tr)
-
-
-class MaxSeq(uvm_sequence):
-    async def body(self):
-        for op in list(Ops):
-            cmd_tr = AluSeqItem("cmd_tr", 0xFF, 0xFF, op)
-            await self.start_item(cmd_tr)
-            await self.finish_item(cmd_tr)
-
-
-class TestAllSeq(uvm_sequence):
-    async def body(self):
-        seqr = ConfigDB().get(None, "", "SEQR")
-        random = RandomSeq("random")
-        max = MaxSeq("max")
-        await random.start(seqr)
-        await max.start(seqr)
-
-
-class TestAllForkSeq(uvm_sequence):
-    async def body(self):
-        seqr = ConfigDB().get(None, "", "SEQR")
-        random = RandomSeq("random")
-        max = MaxSeq("max")
-        random_task = cocotb.start_soon(random.start(seqr))
-        max_task = cocotb.start_soon(max.start(seqr))
-        await Combine(random_task, max_task)
-
-
-# Sequence library example
-
-
-class OpSeq(uvm_sequence):
-    def __init__(self, name, aa, bb, op):
-        super().__init__(name)
-        self.aa = aa
-        self.bb = bb
-        self.op = Ops(op)
-
-    async def body(self):
-        seq_item = AluSeqItem("seq_item", self.aa, self.bb, self.op)
-        await self.start_item(seq_item)
-        await self.finish_item(seq_item)
-        self.result = seq_item.result
-
-
-async def do_add(seqr, aa, bb):
-    seq = OpSeq("seq", aa, bb, Ops.ADD)
-    await seq.start(seqr)
-    return seq.result
-
-
-async def do_and(seqr, aa, bb):
-    seq = OpSeq("seq", aa, bb, Ops.AND)
-    await seq.start(seqr)
-    return seq.result
-
-
-async def do_xor(seqr, aa, bb):
-    seq = OpSeq("seq", aa, bb, Ops.XOR)
-    await seq.start(seqr)
-    return seq.result
-
-
-async def do_mul(seqr, aa, bb):
-    seq = OpSeq("seq", aa, bb, Ops.MUL)
-    await seq.start(seqr)
-    return seq.result
-
-
-class FibonacciSeq(uvm_sequence):
-    def __init__(self, name):
-        super().__init__(name)
-        self.seqr = ConfigDB().get(None, "", "SEQR")
-
-    async def body(self):
-        prev_num = 0
-        cur_num = 1
-        fib_list = [prev_num, cur_num]
-        for _ in range(7):
-            sum = await do_add(self.seqr, prev_num, cur_num)
-            fib_list.append(sum)
-            prev_num = cur_num
-            cur_num = sum
+class ReportingFibonacciSeq(tinyalu_base.FibonacciSeq):
+    def report_fibonacci_sequence(self, fib_list):
         self.uvm_report.info(
             self.get_name(), "Fibonacci Sequence: " + str(fib_list), UVM_LOW
         )
 
 
-class Driver(uvm_driver):
-    def build_phase(self):
-        self.ap = uvm_analysis_port("ap", self)
-
-    def start_of_simulation_phase(self):
-        self.bfm = TinyAluBfm()
-
-    async def launch_tb(self):
-        await self.bfm.reset()
-        self.bfm.start_bfm()
-
-    async def run_phase(self):
-        await self.launch_tb()
-        while True:
-            cmd = await self.seq_item_port.get_next_item()
-            await self.bfm.send_op(cmd.A, cmd.B, cmd.op)
-            result = await self.bfm.get_result()
-            self.ap.write(result)
-            cmd.result = result
-            self.seq_item_port.item_done()
+class ReportingCommandMonitor(tinyalu_base.CommandMonitor):
+    def report_monitored(self, datum):
+        self.uvm_report.info(self.get_name(), f"MONITORED {datum}", UVM_DEBUG)
 
 
-class Coverage(uvm_subscriber):
-    def end_of_elaboration_phase(self):
-        self.cvg = set()
+class ReportingCoverage(tinyalu_base.Coverage):
+    def report_coverage_error(self, missed):
+        self.uvm_report.error(
+            self.get_name(),
+            f"Functional coverage error. Missed: {missed}",
+        )
 
-    def write(self, cmd):
-        (_, _, op) = cmd
-        self.cvg.add(op)
+    def report_coverage_pass(self):
+        self.uvm_report.info(self.get_name(), "Covered all operations", UVM_LOW)
 
-    def report_phase(self):
+
+class ReportingScoreboard(tinyalu_base.Scoreboard):
+    def report_missing_command(self, actual_result):
+        self.uvm_report.fatal(self.get_name(), f"result {actual_result} had no command")
+
+    def report_pass(self, A, B, op, actual_result):
+        self.uvm_report.info(
+            self.get_name(),
+            self.pass_message(A, B, op, actual_result),
+            UVM_LOW,
+        )
+
+    def report_mismatch(self, A, B, op, actual_result, predicted_result):
         try:
-            disable_errors = ConfigDB().get(self, "", "DISABLE_COVERAGE_ERRORS")
+            fatals = ConfigDB().get(self, "", "CREATE_FATALS")
         except UVMConfigItemNotFound:
-            disable_errors = False
-        if not disable_errors:
-            if len(set(Ops) - self.cvg) > 0:
-                self.uvm_report.error(
-                    self.get_name(),
-                    f"Functional coverage error. Missed: {set(Ops) - self.cvg}",
-                )
-            else:
-                self.uvm_report.info(self.get_name(), "Covered all operations", UVM_LOW)
+            fatals = False
 
+        mismatch_msg = self.mismatch_message(A, B, op, actual_result, predicted_result)
+        if fatals:
+            self.uvm_report.fatal(self.get_name(), mismatch_msg)
+        else:
+            self.uvm_report.error(self.get_name(), mismatch_msg)
 
-class Scoreboard(uvm_component):
-    def build_phase(self):
-        self.cmd_fifo = uvm_tlm_analysis_fifo("cmd_fifo", self)
-        self.result_fifo = uvm_tlm_analysis_fifo("result_fifo", self)
-        self.cmd_get_port = uvm_get_port("cmd_get_port", self)
-        self.result_get_port = uvm_get_port("result_get_port", self)
-        self.cmd_export = self.cmd_fifo.analysis_export
-        self.result_export = self.result_fifo.analysis_export
-
-    def connect_phase(self):
-        self.cmd_get_port.connect(self.cmd_fifo.get_export)
-        self.result_get_port.connect(self.result_fifo.get_export)
-
-    def _quit_count_reached(self):
+    def quit_count_reached(self):
         report_server = uvm_report_server.get_or_none()
         return report_server is not None and report_server.error_quit_count_reached()
 
-    def check_phase(self):
-        try:
-            self.errors = ConfigDB().get(self, "", "CREATE_ERRORS")
-        except UVMConfigItemNotFound:
-            self.errors = False
-        try:
-            self.fatals = ConfigDB().get(self, "", "CREATE_FATALS")
-        except UVMConfigItemNotFound:
-            self.fatals = False
-        while self.result_get_port.can_get():
-            _, actual_result = self.result_get_port.try_get()
-            cmd_success, cmd = self.cmd_get_port.try_get()
-            if not cmd_success:
-                self.uvm_report.fatal(
-                    self.get_name(), f"result {actual_result} had no command"
-                )
-            else:
-                (A, B, op_numb) = cmd
-                op = Ops(op_numb)
-                predicted_result = alu_prediction(A, B, op, self.errors)
-                if predicted_result == actual_result:
-                    self.uvm_report.info(
-                        self.get_name(),
-                        f"PASSED: 0x{A:02x} {op.name} 0x{B:02x} = 0x{actual_result:04x}",
-                        UVM_LOW,
-                    )
-                else:
-                    mismatch_msg = (
-                        f"FAILED: 0x{A:02x} {op.name} 0x{B:02x} "
-                        f"= 0x{actual_result:04x} "
-                        f"expected 0x{predicted_result:04x}"
-                    )
-                    if self.fatals:
-                        self.uvm_report.fatal(self.get_name(), mismatch_msg)
-                    else:
-                        self.uvm_report.error(self.get_name(), mismatch_msg)
-                    if self._quit_count_reached():
-                        break
-
-
-class Monitor(uvm_component):
-    def __init__(self, name, parent, method_name):
-        super().__init__(name, parent)
-        self.method_name = method_name
-
-    def build_phase(self):
-        self.ap = uvm_analysis_port("ap", self)
-        self.bfm = TinyAluBfm()
-        self.get_method = getattr(self.bfm, self.method_name)
-
-    async def run_phase(self):
-        while True:
-            datum = await self.get_method()
-            self.uvm_report.info(self.get_name(), f"MONITORED {datum}", UVM_DEBUG)
-            self.ap.write(datum)
-
-
-class AluEnv(uvm_env):
-    def build_phase(self):
-        self.clk_drv = Clock(cocotb.top.clk, 2, "us")
-        cocotb.start_soon(self.clk_drv.start())
-        self.seqr = uvm_sequencer("seqr", self)
-        ConfigDB().set(None, "*", "SEQR", self.seqr)
-        self.driver = Driver.create("driver", self)
-        self.cmd_mon = Monitor("cmd_mon", self, "get_cmd")
-        self.coverage = Coverage("coverage", self)
-        self.scoreboard = Scoreboard("scoreboard", self)
-
-    def connect_phase(self):
-        self.driver.seq_item_port.connect(self.seqr.seq_item_export)
-        self.cmd_mon.ap.connect(self.scoreboard.cmd_export)
-        self.cmd_mon.ap.connect(self.coverage.analysis_export)
-        self.driver.ap.connect(self.scoreboard.result_export)
+    def finish_check(self, passed):
+        pass
 
 
 @pyuvm.test()
-class AluTest(uvm_test):
-    """Test ALU with random and max values"""
+class AluTest(tinyalu_base.AluTest):
+    """Test ALU with random and max values using UVM-style reporting."""
 
     def build_phase(self):
-        self.env = AluEnv("env", self)
-
-    def end_of_elaboration_phase(self):
-        self.test_all = TestAllSeq.create("test_all")
-
-    async def run_phase(self):
-        self.raise_objection("Keep simulation alive")
-        await self.test_all.start()
-        self.drop_objection("Simulation may end now")
+        factory = uvm_factory()
+        factory.set_type_override_by_type(
+            tinyalu_base.CommandMonitor, ReportingCommandMonitor
+        )
+        factory.set_type_override_by_type(tinyalu_base.Coverage, ReportingCoverage)
+        factory.set_type_override_by_type(tinyalu_base.Scoreboard, ReportingScoreboard)
+        super().build_phase()
 
     def final_phase(self):
         report_server = getattr(self, "report_server", None)
@@ -314,26 +114,30 @@ class AluTest(uvm_test):
 
 @pyuvm.test()
 class ParallelTest(AluTest):
-    """Test ALU random and max forked"""
+    """Test ALU random and max forked with UVM style reporting."""
 
     def build_phase(self):
-        uvm_factory().set_type_override_by_type(TestAllSeq, TestAllForkSeq)
+        uvm_factory().set_type_override_by_type(
+            tinyalu_base.TestAllSeq, tinyalu_base.TestAllForkSeq
+        )
         super().build_phase()
 
 
 @pyuvm.test()
 class FibonacciTest(AluTest):
-    """Run Fibonacci program"""
+    """Run Fibonacci program with UVM style reporting."""
 
     def build_phase(self):
         ConfigDB().set(None, "*", "DISABLE_COVERAGE_ERRORS", True)
-        uvm_factory().set_type_override_by_type(TestAllSeq, FibonacciSeq)
+        uvm_factory().set_type_override_by_type(
+            tinyalu_base.TestAllSeq, ReportingFibonacciSeq
+        )
         return super().build_phase()
 
 
 @pyuvm.test(expect_error=(AssertionError,))
 class AluTestErrors(AluTest):
-    """Test ALU with errors on all operations"""
+    """Test ALU with errors on all operations with UVM style reporting."""
 
     def start_of_simulation_phase(self):
         ConfigDB().set(None, "*", "CREATE_ERRORS", True)

--- a/pyuvm/_s06_reporting_classes.py
+++ b/pyuvm/_s06_reporting_classes.py
@@ -110,8 +110,7 @@ class uvm_report_object(uvm_object):
             configure_uvm_root_logger()
             self.logger.propagate = True
             for handler in list(self.logger.handlers):
-                if getattr(handler, "_pyuvm_object_default_handler", False):
-                    self.logger.removeHandler(handler)
+                self.logger.removeHandler(handler)
             self._streaming_handler = None
         else:
             self.logger.propagate = False

--- a/pyuvm/_s13_predefined_component_classes.py
+++ b/pyuvm/_s13_predefined_component_classes.py
@@ -4,6 +4,7 @@ from pyuvm._error_classes import UVMConfigItemNotFound, UVMFatalError
 from pyuvm._s12_uvm_tlm_interfaces import uvm_analysis_export, uvm_analysis_port
 from pyuvm._s13_uvm_component import uvm_component
 from pyuvm._s14_15_python_sequences import uvm_seq_item_port
+from pyuvm.uvm_reporting.uvm_test_reporting import configure_uvm_test_reporting
 
 # This section and sequences are the crux of pyuvm.
 # The classes here allow us to build classic UVM
@@ -39,6 +40,18 @@ class uvm_test(uvm_component):
     """
     The base class for all tests
     """
+
+    def __init__(self, name, parent=None):
+        super().__init__(name, parent)
+        report_server = self.configure_uvm_reporting()
+        if report_server is not None:
+            self.report_server = report_server
+
+    def configure_uvm_reporting(self):
+        return configure_uvm_test_reporting(self)
+
+    def add_message_demotes(self, catcher):
+        del catcher
 
 
 # 13.3

--- a/pyuvm/_s13_uvm_component.py
+++ b/pyuvm/_s13_uvm_component.py
@@ -20,6 +20,7 @@ from pyuvm._utility_classes import (
     uvm_is_match,
 )
 from pyuvm._utils import cocotb_version_info
+from pyuvm.uvm_reporting.uvm_test_reporting import configure_uvm_test_reporting
 
 if cocotb_version_info < (2, 0):
     from cocotb.log import SimColourLogFormatter, SimLogFormatter, SimTimeContextFilter
@@ -437,6 +438,18 @@ class uvm_test(uvm_component):
     """
     The base class for all tests
     """
+
+    def __init__(self, name, parent=None):
+        super().__init__(name, parent)
+        report_server = self.configure_uvm_reporting()
+        if report_server is not None:
+            self.report_server = report_server
+
+    def configure_uvm_reporting(self):
+        return configure_uvm_test_reporting(self)
+
+    def add_message_demotes(self, catcher):
+        del catcher
 
 
 class uvm_root(uvm_component, metaclass=UVM_ROOT_Singleton):

--- a/pyuvm/uvm_reporting/__init__.py
+++ b/pyuvm/uvm_reporting/__init__.py
@@ -7,6 +7,8 @@
 import os
 from typing import Any
 
+from pyuvm.uvm_reporting.uvm_runtime_options import get_plusarg
+
 
 _ENV_VAR = "PYUVM_ENABLE_SV_UVM_STYLE_REPORTING"
 _TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
@@ -33,6 +35,9 @@ def set_sv_uvm_style_reporting_enabled(enabled: bool) -> None:
 
 def get_sv_uvm_style_reporting_enabled() -> bool:
     """Return whether SV-UVM-style centralized reporting behavior is enabled."""
+    plusarg_value = get_plusarg(_ENV_VAR)
+    if plusarg_value is not None:
+        return _parse_bool(plusarg_value)
     return _sv_uvm_style_reporting_enabled
 
 

--- a/pyuvm/uvm_reporting/uvm_base_core_report.py
+++ b/pyuvm/uvm_reporting/uvm_base_core_report.py
@@ -28,7 +28,8 @@ class uvm_base_core_report:
         self.logger = getattr(owner, "logger")
         inherited = getattr(parent, "uvm_verbosity", default_verbosity)
         self.verbosity: int = int(inherited)
-        self.uvm_report = uvm_reporter(self.logger, self.verbosity)
+        self.full_name = self._owner_full_name(owner)
+        self.uvm_report = uvm_reporter(self.logger, self.verbosity, self.full_name)
 
     def apply_cfg(self, cfg: Any | None = None) -> int:
         """Resolve effective verbosity with an optional cfg override."""
@@ -45,3 +46,12 @@ class uvm_base_core_report:
     def set_logger(self, logger: Any) -> None:
         self.logger = logger
         self.uvm_report.set_logger(logger)
+
+    def _owner_full_name(self, owner: Any) -> str:
+        get_full_name = getattr(owner, "get_full_name", None)
+        if callable(get_full_name):
+            return str(get_full_name())
+        get_name = getattr(owner, "get_name", None)
+        if callable(get_name):
+            return str(get_name())
+        return ""

--- a/pyuvm/uvm_reporting/uvm_report_server.py
+++ b/pyuvm/uvm_reporting/uvm_report_server.py
@@ -522,10 +522,7 @@ class uvm_report_server:
             return "uvm"
         if not name.startswith("uvm."):
             return ""
-        full_name = name[4:]
-        if full_name and full_name[-1].isdigit():
-            full_name = full_name.rstrip("0123456789")
-        return full_name
+        return name[4:]
 
     def _max_quit_count_text(self) -> str:
         if int(self._policy.max_quit_count) == 0:

--- a/pyuvm/uvm_reporting/uvm_report_server.py
+++ b/pyuvm/uvm_reporting/uvm_report_server.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import textwrap
-import weakref
 from dataclasses import dataclass
 from typing import Any
 
@@ -31,6 +30,7 @@ class uvm_report_policy:
     fail_on_error: bool = True
     fail_on_fatal: bool = True
     max_quit_count: int = 1
+    test_status_label: str = "TEST_STATUS"
 
 
 @dataclass
@@ -66,20 +66,6 @@ class uvm_report_stats:
         )
 
 
-class _uvm_report_filter(logging.Filter):
-    """Filter that normalizes severities and updates global counters."""
-
-    def __init__(self, manager: uvm_report_server) -> None:
-        super().__init__("uvm_report_filter")
-        self._manager_ref = weakref.ref(manager)
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        manager = self._manager_ref()
-        if manager is not None:
-            manager.process_record(record)
-        return True
-
-
 class _uvm_wrapped_formatter(logging.Formatter):
     """Wrap rendered log lines without changing the underlying formatter layout."""
 
@@ -92,11 +78,30 @@ class _uvm_wrapped_formatter(logging.Formatter):
     def base_formatter(self) -> logging.Formatter:
         return self._base_formatter
 
+    def _is_uvm_report_record(self, record: logging.LogRecord) -> bool:
+        return bool(getattr(record, "_uvm_report_record", False))
+
+    def _source_name(self, record: logging.LogRecord) -> str:
+        pathname = str(getattr(record, "pathname", "") or "")
+        lineno = getattr(record, "lineno", 0)
+        if pathname and lineno:
+            return f"{pathname}({lineno})"
+        return record.name
+
     def _display_message(self, record: logging.LogRecord) -> str:
         message = record.getMessage()
+        if not self._is_uvm_report_record(record):
+            return message
+
+        full_name = str(getattr(record, "uvm_full_name", "") or "")
         report_id = str(getattr(record, "report_id", "") or "")
+        prefix = ""
+        if full_name:
+            prefix = f"[{full_name}]: "
         if report_id:
-            return f"[{report_id}] {message}"
+            return f"{prefix}[{report_id}] {message}"
+        if prefix:
+            return f"{prefix}{message}"
         return message
 
     def format(self, record: logging.LogRecord) -> str:
@@ -104,6 +109,8 @@ class _uvm_wrapped_formatter(logging.Formatter):
         clone = logging.makeLogRecord(record.__dict__.copy())
         clone.msg = display_message
         clone.args = ()
+        if self._is_uvm_report_record(record):
+            clone.name = self._source_name(record)
 
         rendered = self._base_formatter.format(clone)
         if self._max_chars <= 0 or len(rendered) <= self._max_chars:
@@ -152,9 +159,10 @@ class uvm_report_server:
         self._policy = uvm_report_policy()
         self._stats = uvm_report_stats()
         self._catcher = uvm_report_catcher("uvm_report_catcher")
-        self._filter = _uvm_report_filter(self)
-        self._attached: list[tuple[Any, bool, logging.Formatter | None]] = []
-        self._attached_keys: set[tuple[str, int]] = set()
+        self._attached: list[tuple[logging.Handler, logging.Formatter | None]] = []
+        self._attached_keys: set[int] = set()
+        self._logger_full_names: dict[int, str] = {}
+        self._quit_count_message_emitted = False
         self._initialized = False
 
     @classmethod
@@ -203,6 +211,7 @@ class uvm_report_server:
 
     def clear_counts(self) -> None:
         self._stats.clear()
+        self._quit_count_message_emitted = False
 
     def initialize(
         self,
@@ -219,24 +228,21 @@ class uvm_report_server:
         self._print_char_len = int(print_char_len)
         self._policy = policy if policy is not None else uvm_report_policy()
         self._stats.clear()
+        self._quit_count_message_emitted = False
+        self._logger_full_names.clear()
         self._catcher = uvm_report_catcher("uvm_report_catcher")
-        self._filter = _uvm_report_filter(self)
-        self._attach_filters()
+        self._attach_formatters()
         self._initialized = True
 
     def shutdown(self) -> None:
-        for target, is_handler, formatter in self._attached:
+        for handler, formatter in self._attached:
             try:
-                target.removeFilter(self._filter)
+                handler.setFormatter(formatter)
             except Exception:
                 pass
-            if is_handler:
-                try:
-                    target.setFormatter(formatter)
-                except Exception:
-                    pass
         self._attached.clear()
         self._attached_keys.clear()
+        self._logger_full_names.clear()
         self._initialized = False
 
     def set_verbosity(self, verbosity: int) -> None:
@@ -259,6 +265,7 @@ class uvm_report_server:
         verbosity: int = 100,
         logger: logging.Logger | None = None,
         stacklevel: int = 2,
+        uvm_full_name: str = "",
     ) -> None:
         sev = self._normalize_severity(severity)
         log = logger if logger is not None else self._root_logger
@@ -268,57 +275,34 @@ class uvm_report_server:
             if int(verbosity) > eff:
                 return
 
+        original_sev = sev
         sev = self._apply_catcher(msg, sev, report_id)
+        if self._should_suppress_for_quit_count(sev):
+            return
+        if sev != original_sev:
+            self._log_severity_change(
+                log,
+                original_sev,
+                sev,
+                report_id,
+                stacklevel + 1,
+                uvm_full_name,
+            )
         level = self._severity_to_level(sev)
 
-        # Count directly at emission time so fail-on-error is deterministic even if
-        # the logging filter chain changes underneath us.
-        if sev == UVM_INFO:
-            self._stats.info_count += 1
-        elif sev == UVM_WARNING:
-            self._stats.warning_count += 1
-        elif sev == UVM_ERROR:
-            self._stats.error_count += 1
-            self._stats.error_quit_count += 1
-        elif sev == UVM_FATAL:
-            self._stats.fatal_count += 1
+        self._count_severity(sev)
 
-        extra = {"_uvm_counted_by_emit": True}
-        if report_id:
-            extra["report_id"] = report_id
+        extra = self._uvm_record_extra(report_id, uvm_full_name)
         try:
             log.log(level, msg, extra=extra, stacklevel=stacklevel)
         except TypeError:
             log.log(level, msg, extra=extra)
 
+        if sev == UVM_ERROR:
+            self._maybe_log_quit_count_reached(log, stacklevel + 1, uvm_full_name)
+
         if sev == UVM_FATAL:
             raise RuntimeError(f"UVM_FATAL: {msg}")
-
-    def process_record(self, record: logging.LogRecord) -> None:
-        if getattr(record, "_uvm_report_processed", False):
-            return
-        setattr(record, "_uvm_report_processed", True)
-
-        if getattr(record, "_uvm_counted_by_emit", False):
-            return
-
-        severity = self._severity_from_level(record.levelno)
-        report_id = str(getattr(record, "report_id", "") or "")
-        message = record.getMessage()
-        new_severity = self._apply_catcher(message, severity, report_id)
-
-        if new_severity != severity:
-            self._set_record_level(record, self._severity_to_level(new_severity))
-
-        if new_severity == UVM_INFO:
-            self._stats.info_count += 1
-        elif new_severity == UVM_WARNING:
-            self._stats.warning_count += 1
-        elif new_severity == UVM_ERROR:
-            self._stats.error_count += 1
-            self._stats.error_quit_count += 1
-        elif new_severity == UVM_FATAL:
-            self._stats.fatal_count += 1
 
     def assert_no_failures(self, context: str = "") -> None:
         msg = self.failure_message(context)
@@ -345,41 +329,51 @@ class uvm_report_server:
             )
         return f"{prefix}Detected report failures at termination ({summary})"
 
-    def log_summary(self, logger: logging.Logger) -> None:
+    def log_summary(self, logger: logging.Logger, uvm_full_name: str = "") -> None:
         stats = self._stats
-        logger.info("")
-        logger.info("--- UVM Report Summary ---")
-        logger.info("")
-        logger.info("** Report counts by severity")
-        logger.info(f"UVM_INFO    : {stats.info_count:4d}")
-        logger.info(f"UVM_WARNING : {stats.warning_count:4d}")
-        logger.info(f"UVM_ERROR   : {stats.error_count:4d}")
-        logger.info(f"UVM_FATAL   : {stats.fatal_count:4d}")
-        logger.info(
-            f"Quit count : {stats.error_quit_count:5d} of {self._policy.max_quit_count:5d} "
-            "(UVM_ERROR)"
+        full_name = str(uvm_full_name).strip() or self._logger_uvm_full_name(logger)
+        self._log_uvm_info(logger, "--- UVM Report Summary ---", full_name)
+        self._log_uvm_info(logger, "** Report counts by severity", full_name)
+        self._log_uvm_info(logger, f"UVM_INFO    : {stats.info_count:4d}", full_name)
+        self._log_uvm_info(
+            logger, f"UVM_WARNING : {stats.warning_count:4d}", full_name
         )
-        logger.info("")
+        self._log_uvm_info(logger, f"UVM_ERROR   : {stats.error_count:4d}", full_name)
+        self._log_uvm_info(logger, f"UVM_FATAL   : {stats.fatal_count:4d}", full_name)
+        max_quit_count = self._max_quit_count_text()
+        self._log_uvm_info(
+            logger,
+            f"Quit count : {stats.error_quit_count:5d} of {max_quit_count} "
+            "(UVM_ERROR)",
+            full_name,
+        )
+
+    def error_quit_count_reached(self) -> bool:
+        return self._stats.error_quit_reached(self._policy)
 
     def log_final_status(
         self,
         logger: logging.Logger,
         context: str = "",
         prior_failure_msg: str | None = None,
+        test_status_label: str | None = None,
+        uvm_full_name: str = "",
     ) -> str | None:
-        """Log DV_TEST_STATUS and return terminal failure message if present."""
+        """Log final test status and return terminal failure message if present."""
         fail_msg = (
             prior_failure_msg
             if prior_failure_msg is not None
             else self.failure_message(context)
         )
+        label = self._final_status_label(test_status_label)
+        full_name = str(uvm_full_name).strip() or self._logger_uvm_full_name(logger)
         if fail_msg is not None:
-            logger.info("DV_TEST_STATUS: FAILED")
+            self._log_uvm_info(logger, f"{label}: FAILED", full_name)
             return fail_msg
-        logger.info("DV_TEST_STATUS: PASSED")
+        self._log_uvm_info(logger, f"{label}: PASSED", full_name)
         return None
 
-    def _attach_filters(self) -> None:
+    def _attach_formatters(self) -> None:
         loggers: list[logging.Logger] = []
 
         loggers.append(logging.getLogger())
@@ -396,21 +390,20 @@ class uvm_report_server:
         for log in loggers:
             self.register_logger(log)
 
-    def register_logger(self, log: logging.Logger | None) -> None:
+    def register_logger(
+        self, log: logging.Logger | None, uvm_full_name: str = ""
+    ) -> None:
         if log is None:
             return
 
-        key = ("logger", id(log))
-        if key not in self._attached_keys:
-            log.addFilter(self._filter)
-            self._attached.append((log, False, None))
-            self._attached_keys.add(key)
+        full_name = str(uvm_full_name).strip()
+        if full_name:
+            self._logger_full_names[id(log)] = full_name
 
         for handler in log.handlers:
-            hkey = ("handler", id(handler))
+            hkey = id(handler)
             if hkey in self._attached_keys:
                 continue
-            handler.addFilter(self._filter)
             original_formatter = handler.formatter
             base_formatter = original_formatter or logging.Formatter("%(message)s")
             if self._print_char_len > 0:
@@ -425,7 +418,7 @@ class uvm_report_server:
                         base_formatter, self._print_char_len
                     )
                 handler.setFormatter(wrapped)
-            self._attached.append((handler, True, original_formatter))
+            self._attached.append((handler, original_formatter))
             self._attached_keys.add(hkey)
 
     def _effective_verbosity(self, logger_name: str) -> int:
@@ -441,6 +434,114 @@ class uvm_report_server:
         report = uvm_report_message(report_id=report_id, message=msg, severity=severity)
         self._catcher.catch(report)
         return self._normalize_severity(report.severity)
+
+    def _count_severity(self, severity: str) -> None:
+        if severity == UVM_INFO:
+            self._stats.info_count += 1
+        elif severity == UVM_WARNING:
+            self._stats.warning_count += 1
+        elif severity == UVM_ERROR:
+            self._stats.error_count += 1
+            self._stats.error_quit_count += 1
+        elif severity == UVM_FATAL:
+            self._stats.fatal_count += 1
+
+    def _should_suppress_for_quit_count(self, severity: str) -> bool:
+        return self._normalize_severity(severity) == UVM_ERROR and (
+            self.error_quit_count_reached()
+        )
+
+    def _maybe_log_quit_count_reached(
+        self,
+        logger: logging.Logger,
+        stacklevel: int = 2,
+        uvm_full_name: str = "",
+    ) -> None:
+        if self._quit_count_message_emitted:
+            return
+        if not self._stats.error_quit_reached(self._policy):
+            return
+
+        self._quit_count_message_emitted = True
+        msg = (
+            f"Quit count reached: {self._stats.error_quit_count} "
+            f"of {self._policy.max_quit_count} (UVM_ERROR)"
+        )
+        extra = self._uvm_record_extra("MAXQUIT", uvm_full_name)
+        try:
+            logger.warning(msg, extra=extra, stacklevel=stacklevel)
+        except TypeError:
+            logger.warning(msg, extra=extra)
+
+    def _log_severity_change(
+        self,
+        logger: logging.Logger,
+        original_severity: str,
+        new_severity: str,
+        report_id: str = "",
+        stacklevel: int = 2,
+        uvm_full_name: str = "",
+    ) -> None:
+        msg = (
+            f"Severity changed from UVM_{original_severity} "
+            f"to UVM_{new_severity}"
+        )
+        if report_id:
+            msg = f"{msg} for report ID '{report_id}'"
+        extra = self._uvm_record_extra("SEVCHG", uvm_full_name)
+        try:
+            logger.info(msg, extra=extra, stacklevel=stacklevel)
+        except TypeError:
+            logger.info(msg, extra=extra)
+
+    def _uvm_record_extra(
+        self, report_id: str = "", uvm_full_name: str = ""
+    ) -> dict[str, str | bool]:
+        extra: dict[str, str | bool] = {"_uvm_report_record": True}
+        if report_id:
+            extra["report_id"] = str(report_id)
+        full_name = str(uvm_full_name).strip()
+        if full_name:
+            extra["uvm_full_name"] = full_name
+        return extra
+
+    def _log_uvm_info(
+        self,
+        logger: logging.Logger,
+        msg: str,
+        uvm_full_name: str = "",
+        stacklevel: int = 2,
+    ) -> None:
+        extra = self._uvm_record_extra(uvm_full_name=uvm_full_name)
+        try:
+            logger.info(msg, extra=extra, stacklevel=stacklevel)
+        except TypeError:
+            logger.info(msg, extra=extra)
+
+    def _logger_uvm_full_name(self, logger: logging.Logger) -> str:
+        registered = self._logger_full_names.get(id(logger))
+        if registered:
+            return registered
+
+        name = str(getattr(logger, "name", "") or "")
+        if name == "uvm":
+            return "uvm"
+        if not name.startswith("uvm."):
+            return ""
+        full_name = name[4:]
+        if full_name and full_name[-1].isdigit():
+            full_name = full_name.rstrip("0123456789")
+        return full_name
+
+    def _max_quit_count_text(self) -> str:
+        if int(self._policy.max_quit_count) == 0:
+            return "UNLIMITED"
+        return f"{self._policy.max_quit_count:5d}"
+
+    def _final_status_label(self, override: str | None = None) -> str:
+        label = self._policy.test_status_label if override is None else override
+        label = str(label).strip()
+        return label if label else "TEST_STATUS"
 
     def _normalize_severity(self, severity: Any) -> str:
         text = str(severity).strip().upper()
@@ -465,16 +566,3 @@ class uvm_report_server:
         if sev == UVM_ERROR:
             return logging.ERROR
         return logging.CRITICAL
-
-    def _severity_from_level(self, level: int) -> str:
-        if level >= logging.CRITICAL:
-            return UVM_FATAL
-        if level >= logging.ERROR:
-            return UVM_ERROR
-        if level >= logging.WARNING:
-            return UVM_WARNING
-        return UVM_INFO
-
-    def _set_record_level(self, record: logging.LogRecord, level: int) -> None:
-        record.levelno = int(level)
-        record.levelname = logging.getLevelName(level)

--- a/pyuvm/uvm_reporting/uvm_report_server.py
+++ b/pyuvm/uvm_reporting/uvm_report_server.py
@@ -106,14 +106,22 @@ class _uvm_wrapped_formatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         display_message = self._display_message(record)
+        is_uvm_report = self._is_uvm_report_record(record)
         clone = logging.makeLogRecord(record.__dict__.copy())
         clone.msg = display_message
         clone.args = ()
-        if self._is_uvm_report_record(record):
+        if is_uvm_report:
             clone.name = self._source_name(record)
 
         rendered = self._base_formatter.format(clone)
-        if self._max_chars <= 0 or len(rendered) <= self._max_chars:
+        has_multiline_message = is_uvm_report and (
+            "\n" in display_message or "\r" in display_message
+        )
+        # Multiline UVM reports still need continuation indentation even when
+        # the rendered message is shorter than the wrapping limit.
+        if self._max_chars <= 0 or (
+            len(rendered) <= self._max_chars and not has_multiline_message
+        ):
             return rendered
 
         if not display_message:

--- a/pyuvm/uvm_reporting/uvm_report_server.py
+++ b/pyuvm/uvm_reporting/uvm_report_server.py
@@ -335,16 +335,13 @@ class uvm_report_server:
         self._log_uvm_info(logger, "--- UVM Report Summary ---", full_name)
         self._log_uvm_info(logger, "** Report counts by severity", full_name)
         self._log_uvm_info(logger, f"UVM_INFO    : {stats.info_count:4d}", full_name)
-        self._log_uvm_info(
-            logger, f"UVM_WARNING : {stats.warning_count:4d}", full_name
-        )
+        self._log_uvm_info(logger, f"UVM_WARNING : {stats.warning_count:4d}", full_name)
         self._log_uvm_info(logger, f"UVM_ERROR   : {stats.error_count:4d}", full_name)
         self._log_uvm_info(logger, f"UVM_FATAL   : {stats.fatal_count:4d}", full_name)
         max_quit_count = self._max_quit_count_text()
         self._log_uvm_info(
             logger,
-            f"Quit count : {stats.error_quit_count:5d} of {max_quit_count} "
-            "(UVM_ERROR)",
+            f"Quit count : {stats.error_quit_count:5d} of {max_quit_count} (UVM_ERROR)",
             full_name,
         )
 
@@ -482,10 +479,7 @@ class uvm_report_server:
         stacklevel: int = 2,
         uvm_full_name: str = "",
     ) -> None:
-        msg = (
-            f"Severity changed from UVM_{original_severity} "
-            f"to UVM_{new_severity}"
-        )
+        msg = f"Severity changed from UVM_{original_severity} to UVM_{new_severity}"
         if report_id:
             msg = f"{msg} for report ID '{report_id}'"
         extra = self._uvm_record_extra("SEVCHG", uvm_full_name)

--- a/pyuvm/uvm_reporting/uvm_runtime_options.py
+++ b/pyuvm/uvm_reporting/uvm_runtime_options.py
@@ -10,6 +10,8 @@ import os
 from collections.abc import Iterable
 from typing import Any
 
+import cocotb
+
 _TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
 _FALSE_VALUES = {"0", "false", "f", "no", "n", "off", ""}
 
@@ -22,11 +24,6 @@ def _as_names(names: str | Iterable[str]) -> tuple[str, ...]:
 
 def get_plusarg(name: str) -> str | None:
     """Return a cocotb plusarg value when cocotb exposes plusargs."""
-    try:
-        import cocotb
-    except Exception:
-        return None
-
     plusargs = getattr(cocotb, "plusargs", None)
     if plusargs is None:
         return None

--- a/pyuvm/uvm_reporting/uvm_runtime_options.py
+++ b/pyuvm/uvm_reporting/uvm_runtime_options.py
@@ -1,0 +1,80 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime option helpers for SV-UVM-style reporting."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+_TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "f", "no", "n", "off", ""}
+
+
+def _as_names(names: str | Iterable[str]) -> tuple[str, ...]:
+    if isinstance(names, str):
+        return (names,)
+    return tuple(str(name) for name in names)
+
+
+def get_plusarg(name: str) -> str | None:
+    """Return a cocotb plusarg value when cocotb exposes plusargs."""
+    try:
+        import cocotb
+    except Exception:
+        return None
+
+    plusargs = getattr(cocotb, "plusargs", None)
+    if plusargs is None:
+        return None
+
+    value = plusargs.get(name)
+    if value in (None, False):
+        return None
+    if value is True:
+        return "1"
+    return str(value)
+
+
+def get_runtime_option(names: str | Iterable[str], default: Any = None) -> Any:
+    """Return the first matching plusarg/env value for ``names``."""
+    for name in _as_names(names):
+        value = get_plusarg(name)
+        if value is not None:
+            return value
+
+    for name in _as_names(names):
+        value = os.getenv(name)
+        if value is not None:
+            return value
+
+    return default
+
+
+def parse_bool_text(value: Any, default: bool = False) -> bool:
+    """Parse common textual boolean forms."""
+    if value is None:
+        return bool(default)
+    text = str(value).strip().lower()
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return bool(default)
+
+
+def get_runtime_bool(names: str | Iterable[str], default: bool = False) -> bool:
+    return parse_bool_text(get_runtime_option(names, None), default)
+
+
+def get_runtime_int(names: str | Iterable[str], default: int = 0) -> int:
+    value = get_runtime_option(names, None)
+    if value is None:
+        return int(default)
+    try:
+        return int(str(value), 0)
+    except (TypeError, ValueError):
+        return int(default)

--- a/pyuvm/uvm_reporting/uvm_test_reporting.py
+++ b/pyuvm/uvm_reporting/uvm_test_reporting.py
@@ -1,0 +1,76 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Automatic SV-UVM-style reporting setup for ``uvm_test``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting.uvm_report_server import (
+    uvm_report_policy,
+    uvm_report_server,
+)
+from pyuvm.uvm_reporting.uvm_runtime_options import (
+    get_runtime_bool,
+    get_runtime_int,
+    get_runtime_option,
+)
+from pyuvm.uvm_reporting.uvm_verbosity import UVM_LOW, parse_uvm_verbosity
+
+
+@dataclass(frozen=True)
+class uvm_test_reporting_config:
+    """Runtime reporting configuration resolved for a ``uvm_test``."""
+
+    verbosity: int
+    policy: uvm_report_policy
+    print_char_len: int
+
+
+def get_uvm_test_reporting_config() -> uvm_test_reporting_config:
+    """Resolve report-server configuration from plusargs, env vars, defaults."""
+    verbosity = parse_uvm_verbosity(
+        get_runtime_option("UVM_VERBOSITY", None), UVM_LOW
+    )
+    policy = uvm_report_policy(
+        fail_on_warning=get_runtime_bool("UVM_FAIL_ON_WARNING", False),
+        fail_on_error=get_runtime_bool("UVM_FAIL_ON_ERROR", True),
+        fail_on_fatal=get_runtime_bool("UVM_FAIL_ON_FATAL", True),
+        max_quit_count=get_runtime_int(
+            ("max_quit_count", "MAX_QUIT_COUNT", "UVM_MAX_QUIT_COUNT"), 1
+        ),
+        test_status_label=str(
+            get_runtime_option(
+                ("test_status_label", "TEST_STATUS_LABEL"), "TEST_STATUS"
+            )
+        ),
+    )
+    return uvm_test_reporting_config(
+        verbosity=verbosity,
+        policy=policy,
+        print_char_len=get_runtime_int(
+            ("print_char_len", "PRINT_CHAR_LEN", "UVM_PRINT_CHAR_LEN"), 300
+        ),
+    )
+
+
+def configure_uvm_test_reporting(test_obj: Any) -> uvm_report_server | None:
+    """Create and configure the shared report server for an opted-in test."""
+    if not get_sv_uvm_style_reporting_enabled():
+        return None
+
+    config = get_uvm_test_reporting_config()
+    manager = uvm_report_server.create(
+        root_logger=test_obj.logger,
+        verbosity=config.verbosity,
+        policy=config.policy,
+        print_char_len=config.print_char_len,
+    )
+    test_obj.set_report_verbosity(config.verbosity)
+    manager.register_logger(test_obj.logger, test_obj.get_full_name())
+    test_obj.add_message_demotes(manager.catcher)
+    return manager

--- a/pyuvm/uvm_reporting/uvm_test_reporting.py
+++ b/pyuvm/uvm_reporting/uvm_test_reporting.py
@@ -33,9 +33,7 @@ class uvm_test_reporting_config:
 
 def get_uvm_test_reporting_config() -> uvm_test_reporting_config:
     """Resolve report-server configuration from plusargs, env vars, defaults."""
-    verbosity = parse_uvm_verbosity(
-        get_runtime_option("UVM_VERBOSITY", None), UVM_LOW
-    )
+    verbosity = parse_uvm_verbosity(get_runtime_option("UVM_VERBOSITY", None), UVM_LOW)
     policy = uvm_report_policy(
         fail_on_warning=get_runtime_bool("UVM_FAIL_ON_WARNING", False),
         fail_on_error=get_runtime_bool("UVM_FAIL_ON_ERROR", True),

--- a/pyuvm/uvm_reporting/uvm_verbosity.py
+++ b/pyuvm/uvm_reporting/uvm_verbosity.py
@@ -66,9 +66,15 @@ def resolve_uvm_verbosity(inherited: int, cfg: Any | None = None) -> int:
 class uvm_reporter:
     """Centralized UVM-style reporter."""
 
-    def __init__(self, logger: logging.Logger, verbosity: int = UVM_LOW) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger,
+        verbosity: int = UVM_LOW,
+        full_name: str = "",
+    ) -> None:
         self._logger = logger
         self._verbosity = int(verbosity)
+        self._full_name = str(full_name)
         self._local_catcher = uvm_report_catcher("uvm_report_catcher")
         self._sync_with_manager()
 
@@ -87,16 +93,20 @@ class uvm_reporter:
         self._logger = logger
         self._sync_with_manager()
 
+    def set_full_name(self, full_name: str) -> None:
+        self._full_name = str(full_name)
+        self._sync_with_manager()
+
     def _sync_with_manager(self) -> None:
         manager = uvm_report_server.get_or_none()
         if manager is not None:
-            manager.register_logger(self._logger)
+            manager.register_logger(self._logger, self._full_name)
 
     def set_verbosity(self, verbosity: int) -> None:
         self._verbosity = int(verbosity)
         manager = uvm_report_server.get_or_none()
         if manager is not None:
-            manager.register_logger(self._logger)
+            manager.register_logger(self._logger, self._full_name)
             manager.set_verbosity(self._verbosity)
 
     def should_log(self, msg_verbosity: int = UVM_LOW) -> bool:
@@ -174,6 +184,7 @@ class uvm_reporter:
             verbosity=verbosity,
             logger=self._logger,
             stacklevel=3,
+            uvm_full_name=self._full_name,
         )
 
     def warning(self, report_id: str, msg: str) -> None:
@@ -193,7 +204,12 @@ class uvm_reporter:
             return
         self._sync_with_manager()
         manager.emit_uvm(
-            UVM_WARNING, msg, report_id=report_id, logger=self._logger, stacklevel=3
+            UVM_WARNING,
+            msg,
+            report_id=report_id,
+            logger=self._logger,
+            stacklevel=3,
+            uvm_full_name=self._full_name,
         )
 
     def error(self, report_id: str, msg: str) -> None:
@@ -213,7 +229,12 @@ class uvm_reporter:
             return
         self._sync_with_manager()
         manager.emit_uvm(
-            UVM_ERROR, msg, report_id=report_id, logger=self._logger, stacklevel=3
+            UVM_ERROR,
+            msg,
+            report_id=report_id,
+            logger=self._logger,
+            stacklevel=3,
+            uvm_full_name=self._full_name,
         )
 
     def fatal(self, report_id: str, msg: str) -> None:
@@ -233,5 +254,10 @@ class uvm_reporter:
             return
         self._sync_with_manager()
         manager.emit_uvm(
-            UVM_FATAL, msg, report_id=report_id, logger=self._logger, stacklevel=3
+            UVM_FATAL,
+            msg,
+            report_id=report_id,
+            logger=self._logger,
+            stacklevel=3,
+            uvm_full_name=self._full_name,
         )

--- a/tests/pytests/test_uvm_reporting.py
+++ b/tests/pytests/test_uvm_reporting.py
@@ -458,6 +458,48 @@ def test_uvm_report_formatter_uses_source_location_and_full_name(reporting_logge
     assert "[uvm_test_top.env.scoreboard]: [SRC_ID] source-tagged message" in output
 
 
+@pytest.mark.parametrize(
+    ("method_name", "expected_level", "expect_exception"),
+    [
+        ("info", "INFO", False),
+        ("warning", "WARNING", False),
+        ("error", "ERROR", False),
+        ("fatal", "CRITICAL", True),
+    ],
+)
+def test_uvm_report_formatter_indents_multiline_messages(
+    reporting_logger, method_name, expected_level, expect_exception
+):
+    _manager, logger, stream = reporting_logger(fmt="%(levelname)s:%(message)s")
+    reporter = uvm_reporter(logger, full_name="uvm_test_top.env.agent1")
+    report_method = getattr(reporter, method_name)
+
+    if expect_exception:
+        with pytest.raises(RuntimeError):
+            report_method("MULTI_ID", "first line\nsecond line")
+    elif method_name == "info":
+        report_method("MULTI_ID", "first line\nsecond line", UVM_LOW)
+    else:
+        report_method("MULTI_ID", "first line\nsecond line")
+
+    prefix = f"{expected_level}:"
+    expected = (
+        f"{prefix}[uvm_test_top.env.agent1]: [MULTI_ID] first line\n"
+        f"{' ' * len(prefix)}second line"
+    )
+    assert expected in stream.getvalue()
+
+
+def test_direct_logger_multiline_messages_are_not_uvm_reformatted(reporting_logger):
+    _manager, logger, stream = reporting_logger(fmt="%(levelname)s:%(message)s")
+
+    logger.error("first line\nsecond line")
+
+    output = stream.getvalue()
+    assert "ERROR:first line\nsecond line" in output
+    assert "     second line" not in output
+
+
 def test_object_uvm_report_formatter_uses_owner_full_name(reporting_logger):
     _manager, logger, stream = reporting_logger(
         fmt="%(levelname)s:%(name)s:%(message)s"

--- a/tests/pytests/test_uvm_reporting.py
+++ b/tests/pytests/test_uvm_reporting.py
@@ -2,9 +2,12 @@ import io
 import logging
 import uuid
 
+import cocotb
 import pytest
 
 from pyuvm import (
+    UVM_ERROR,
+    UVM_FULL,
     UVM_HIGH,
     UVM_INFO,
     UVM_LOW,
@@ -14,12 +17,15 @@ from pyuvm import (
     set_sv_uvm_style_reporting_enabled,
     uvm_component,
     uvm_report_object,
+    uvm_report_policy,
     uvm_report_server,
     uvm_reporter,
     uvm_sequence,
     uvm_sequence_item,
+    uvm_test,
     uvm_transaction,
 )
+from pyuvm._s13_uvm_component import uvm_test as internal_uvm_test
 
 
 @pytest.fixture(autouse=True)
@@ -43,7 +49,12 @@ def clean_report_server():
 def reporting_logger():
     created = []
 
-    def make(verbosity=UVM_LOW, print_char_len=300):
+    def make(
+        verbosity=UVM_LOW,
+        print_char_len=300,
+        policy=None,
+        fmt="%(levelname)s:%(message)s",
+    ):
         name = f"uvm_reporting_test.{uuid.uuid4().hex}"
         logger = logging.getLogger(name)
         logger.handlers.clear()
@@ -53,12 +64,13 @@ def reporting_logger():
         stream = io.StringIO()
         handler = logging.StreamHandler(stream)
         handler.setLevel(logging.NOTSET)
-        handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+        handler.setFormatter(logging.Formatter(fmt))
         logger.addHandler(handler)
 
         manager = uvm_report_server.create(
             root_logger=logger,
             verbosity=verbosity,
+            policy=policy,
             print_char_len=print_char_len,
         )
         manager.register_logger(logger)
@@ -154,6 +166,110 @@ def test_severity_counts_match_reports(reporting_logger):
     assert stats.error_quit_count == 1
 
 
+def test_max_quit_count_suppresses_later_report_errors(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(max_quit_count=1)
+    )
+    reporter = uvm_reporter(logger)
+
+    reporter.error("ERR_ONE", "first counted error")
+    reporter.error("ERR_TWO", "suppressed after quit count")
+
+    output = stream.getvalue()
+    assert "[ERR_ONE] first counted error" in output
+    assert "[MAXQUIT] Quit count reached: 1 of 1 (UVM_ERROR)" in output
+    assert output.index("[ERR_ONE] first counted error") < output.index("[MAXQUIT]")
+    assert "suppressed after quit count" not in output
+    stats = manager.get_stats()
+    assert stats.error_count == 1
+    assert stats.error_quit_count == 1
+    assert stats.warning_count == 0
+
+
+def test_direct_logger_errors_do_not_affect_max_quit_count(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(max_quit_count=1)
+    )
+    reporter = uvm_reporter(logger)
+
+    reporter.error("ERR_ID", "counted UVM error")
+    logger.error("plain direct error after quit count")
+
+    output = stream.getvalue()
+    assert "[ERR_ID] counted UVM error" in output
+    assert "[MAXQUIT] Quit count reached: 1 of 1 (UVM_ERROR)" in output
+    assert "plain direct error after quit count" in output
+    stats = manager.get_stats()
+    assert stats.error_count == 1
+    assert stats.error_quit_count == 1
+    assert stats.warning_count == 0
+
+
+def test_max_quit_count_two_suppresses_third_report_error(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(max_quit_count=2)
+    )
+    reporter = uvm_reporter(logger)
+
+    reporter.error("ERR_ID", "first counted error")
+    reporter.error("ERR_ID", "second counted error")
+    reporter.error("ERR_ID", "suppressed third error")
+
+    output = stream.getvalue()
+    assert "[ERR_ID] first counted error" in output
+    assert "[ERR_ID] second counted error" in output
+    assert "[MAXQUIT] Quit count reached: 2 of 2 (UVM_ERROR)" in output
+    assert output.index("[ERR_ID] second counted error") < output.index("[MAXQUIT]")
+    assert "suppressed third error" not in output
+    stats = manager.get_stats()
+    assert stats.error_count == 2
+    assert stats.error_quit_count == 2
+    assert stats.warning_count == 0
+    assert "Quit count reached: 2 of 2" in manager.failure_message("count two")
+
+
+def test_large_max_quit_count_allows_errors_below_limit(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(max_quit_count=25)
+    )
+    reporter = uvm_reporter(logger)
+
+    for idx in range(8):
+        reporter.error("ERR_ID", f"counted error {idx}")
+
+    output = stream.getvalue()
+    for idx in range(8):
+        assert f"[ERR_ID] counted error {idx}" in output
+    assert "[MAXQUIT]" not in output
+    stats = manager.get_stats()
+    assert stats.error_count == 8
+    assert stats.error_quit_count == 8
+    assert "Quit count reached" not in manager.failure_message("large count")
+
+
+def test_zero_max_quit_count_allows_all_report_errors(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(max_quit_count=0)
+    )
+    reporter = uvm_reporter(logger)
+
+    for idx in range(8):
+        reporter.error("ERR_ID", f"counted error {idx}")
+
+    output = stream.getvalue()
+    for idx in range(8):
+        assert f"[ERR_ID] counted error {idx}" in output
+    assert "[MAXQUIT]" not in output
+    stats = manager.get_stats()
+    assert stats.error_count == 8
+    assert stats.error_quit_count == 8
+    manager.log_summary(logger)
+    output = stream.getvalue()
+    assert "Quit count :     8 of UNLIMITED (UVM_ERROR)" in output
+    assert "Quit count :     8 of     0 (UVM_ERROR)" not in output
+    assert "Quit count reached" not in manager.failure_message("unlimited")
+
+
 def test_demotion_changes_emitted_severity_and_counts(reporting_logger):
     manager, logger, stream = reporting_logger()
     reporter = uvm_reporter(logger)
@@ -162,10 +278,77 @@ def test_demotion_changes_emitted_severity_and_counts(reporting_logger):
     reporter.error("DEMOTE_ID", "please downgrade this")
 
     output = stream.getvalue()
+    assert (
+        "INFO:[SEVCHG] Severity changed from UVM_ERROR to UVM_WARNING "
+        "for report ID 'DEMOTE_ID'"
+    ) in output
     assert "WARNING:[DEMOTE_ID] please downgrade this" in output
     stats = manager.get_stats()
+    assert stats.info_count == 0
     assert stats.warning_count == 1
     assert stats.error_count == 0
+
+
+def test_fatal_demotion_to_error_does_not_raise(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(max_quit_count=0)
+    )
+    reporter = uvm_reporter(logger)
+
+    reporter.add_change_sev("DEMOTE_FATAL", "known fatal", UVM_ERROR)
+    reporter.fatal("DEMOTE_FATAL", "known fatal downgraded")
+
+    output = stream.getvalue()
+    assert (
+        "INFO:[SEVCHG] Severity changed from UVM_FATAL to UVM_ERROR "
+        "for report ID 'DEMOTE_FATAL'"
+    ) in output
+    assert "ERROR:[DEMOTE_FATAL] known fatal downgraded" in output
+    stats = manager.get_stats()
+    assert stats.info_count == 0
+    assert stats.error_count == 1
+    assert stats.error_quit_count == 1
+    assert stats.fatal_count == 0
+
+
+def test_fatal_demotion_to_info_does_not_raise(reporting_logger):
+    manager, logger, stream = reporting_logger()
+    reporter = uvm_reporter(logger)
+
+    reporter.add_change_sev("DEMOTE_FATAL_INFO", "known fatal", UVM_INFO)
+    reporter.fatal("DEMOTE_FATAL_INFO", "known fatal waived")
+
+    output = stream.getvalue()
+    assert (
+        "INFO:[SEVCHG] Severity changed from UVM_FATAL to UVM_INFO "
+        "for report ID 'DEMOTE_FATAL_INFO'"
+    ) in output
+    assert "INFO:[DEMOTE_FATAL_INFO] known fatal waived" in output
+    stats = manager.get_stats()
+    assert stats.info_count == 1
+    assert stats.error_count == 0
+    assert stats.error_quit_count == 0
+    assert stats.fatal_count == 0
+
+
+def test_error_demotion_to_info_clears_error_count(reporting_logger):
+    manager, logger, stream = reporting_logger()
+    reporter = uvm_reporter(logger)
+
+    reporter.add_change_sev("DEMOTE_ERROR_INFO", "known error", UVM_INFO)
+    reporter.error("DEMOTE_ERROR_INFO", "known error waived")
+
+    output = stream.getvalue()
+    assert (
+        "INFO:[SEVCHG] Severity changed from UVM_ERROR to UVM_INFO "
+        "for report ID 'DEMOTE_ERROR_INFO'"
+    ) in output
+    assert "INFO:[DEMOTE_ERROR_INFO] known error waived" in output
+    stats = manager.get_stats()
+    assert stats.info_count == 1
+    assert stats.error_count == 0
+    assert stats.error_quit_count == 0
+    assert stats.fatal_count == 0
 
 
 def test_wildcard_report_id_demotion(reporting_logger):
@@ -188,6 +371,14 @@ def test_summary_text_contains_key_lines(reporting_logger):
 
     reporter.info("INFO_ID", "info", UVM_LOW)
     reporter.warning("WARN_ID", "warning")
+    stats = manager.get_stats()
+    expected_counts = (
+        stats.info_count,
+        stats.warning_count,
+        stats.error_count,
+        stats.fatal_count,
+        stats.error_quit_count,
+    )
     manager.log_summary(logger)
 
     output = stream.getvalue()
@@ -196,6 +387,52 @@ def test_summary_text_contains_key_lines(reporting_logger):
     assert "UVM_INFO" in output
     assert "UVM_WARNING" in output
     assert "Quit count" in output
+    assert (
+        stats.info_count,
+        stats.warning_count,
+        stats.error_count,
+        stats.fatal_count,
+        stats.error_quit_count,
+    ) == expected_counts
+
+
+def test_final_status_defaults_to_test_status(reporting_logger):
+    manager, logger, stream = reporting_logger()
+
+    fail_msg = manager.log_final_status(logger, "status default")
+
+    assert fail_msg is None
+    output = stream.getvalue()
+    assert "INFO:TEST_STATUS: PASSED" in output
+    assert "DV_TEST_STATUS" not in output
+    assert manager.get_stats().info_count == 0
+
+
+def test_final_status_label_can_be_customized_by_policy(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(test_status_label="DV_TEST_STATUS")
+    )
+
+    fail_msg = manager.log_final_status(
+        logger, "status policy", prior_failure_msg="expected failure"
+    )
+
+    assert fail_msg == "expected failure"
+    output = stream.getvalue()
+    assert "INFO:DV_TEST_STATUS: FAILED" in output
+    assert "INFO:TEST_STATUS: FAILED" not in output
+
+
+def test_final_status_label_can_be_overridden_for_one_call(reporting_logger):
+    manager, logger, stream = reporting_logger(
+        policy=uvm_report_policy(test_status_label="POLICY_STATUS")
+    )
+
+    manager.log_final_status(logger, test_status_label="CALL_STATUS")
+
+    output = stream.getvalue()
+    assert "INFO:CALL_STATUS: PASSED" in output
+    assert "POLICY_STATUS" not in output
 
 
 def test_wrapped_formatter_includes_report_id(reporting_logger):
@@ -207,17 +444,92 @@ def test_wrapped_formatter_includes_report_id(reporting_logger):
     assert "[WRAP_ID] wrapped message" in stream.getvalue()
 
 
-def test_direct_logger_error_is_counted_when_report_server_is_active(reporting_logger):
-    manager, logger, _stream = reporting_logger()
+def test_uvm_report_formatter_uses_source_location_and_full_name(reporting_logger):
+    _manager, logger, stream = reporting_logger(
+        fmt="%(levelname)s:%(name)s:%(message)s"
+    )
+    reporter = uvm_reporter(logger, full_name="uvm_test_top.env.scoreboard")
+
+    reporter.info("SRC_ID", "source-tagged message", UVM_LOW)
+
+    output = stream.getvalue()
+    assert "INFO:" in output
+    assert "test_uvm_reporting.py(" in output
+    assert (
+        "[uvm_test_top.env.scoreboard]: [SRC_ID] source-tagged message" in output
+    )
+
+
+def test_object_uvm_report_formatter_uses_owner_full_name(reporting_logger):
+    _manager, logger, stream = reporting_logger(
+        fmt="%(levelname)s:%(name)s:%(message)s"
+    )
+    transaction = uvm_transaction("txn")
+    transaction.set_report_logger(logger)
+
+    transaction.uvm_report.info("OBJ_ID", "object report", UVM_LOW)
+
+    output = stream.getvalue()
+    assert "test_uvm_reporting.py(" in output
+    assert "[txn]: [OBJ_ID] object report" in output
+
+
+def test_report_summary_uses_uvm_source_location_without_counting(
+    reporting_logger,
+):
+    manager, logger, stream = reporting_logger(
+        fmt="%(levelname)s:%(name)s:%(message)s"
+    )
+    reporter = uvm_reporter(logger, full_name="uvm_test_top")
+    reporter.info("INFO_ID", "counted info", UVM_LOW)
+    expected_counts = manager.get_stats().info_count
+
+    manager.log_summary(logger)
+
+    output = stream.getvalue()
+    assert "uvm_report_server.py(" in output
+    assert "[uvm_test_top]: --- UVM Report Summary ---" in output
+    assert manager.get_stats().info_count == expected_counts
+
+
+def test_direct_logger_keeps_logger_name_with_report_formatter(reporting_logger):
+    _manager, logger, stream = reporting_logger(
+        fmt="%(levelname)s:%(name)s:%(message)s"
+    )
 
     logger.error("direct logger error")
 
+    output = stream.getvalue()
+    assert f"ERROR:{logger.name}:direct logger error" in output
+    assert "test_uvm_reporting.py(" not in output
+
+
+def test_direct_logger_error_is_not_counted_when_report_server_is_active(
+    reporting_logger,
+):
+    manager, logger, stream = reporting_logger()
+
+    logger.error("direct logger error")
+
+    assert "ERROR:direct logger error" in stream.getvalue()
     stats = manager.get_stats()
-    assert stats.error_count == 1
-    assert stats.error_quit_count == 1
+    assert stats.error_count == 0
+    assert stats.error_quit_count == 0
 
 
-def test_direct_logger_error_is_counted_once_through_uvm_propagation(
+def test_direct_logger_error_is_not_rewritten_by_report_catcher(reporting_logger):
+    manager, logger, stream = reporting_logger()
+
+    manager.add_change_sev("*", "direct logger error", UVM_INFO)
+    logger.error("direct logger error")
+
+    assert "ERROR:direct logger error" in stream.getvalue()
+    stats = manager.get_stats()
+    assert stats.info_count == 0
+    assert stats.error_count == 0
+
+
+def test_direct_logger_error_is_not_counted_through_uvm_propagation(
     uvm_root_reporting,
 ):
     manager, stream = uvm_root_reporting
@@ -230,7 +542,7 @@ def test_direct_logger_error_is_counted_once_through_uvm_propagation(
     child_logger.error("propagated error")
 
     assert stream.getvalue().count("ERROR:propagated error") == 1
-    assert manager.get_stats().error_count == 1
+    assert manager.get_stats().error_count == 0
 
 
 def test_report_server_shutdown_makes_get_or_none_inactive(reporting_logger):
@@ -264,6 +576,149 @@ def test_reporter_local_catcher_applies_without_report_server():
 
 def test_sv_uvm_style_reporting_mode_defaults_to_disabled():
     assert not get_sv_uvm_style_reporting_enabled()
+
+
+def test_sv_uvm_style_reporting_can_be_enabled_by_plusarg(
+    initialize_pyuvm, monkeypatch
+):
+    monkeypatch.setattr(
+        cocotb,
+        "plusargs",
+        {"PYUVM_ENABLE_SV_UVM_STYLE_REPORTING": "1"},
+        raising=False,
+    )
+
+    assert get_sv_uvm_style_reporting_enabled()
+    test = uvm_test("plusarg_enabled")
+
+    assert test.report_server is uvm_report_server.get_or_none()
+
+
+@pytest.mark.parametrize("test_cls", [uvm_test, internal_uvm_test])
+def test_uvm_test_does_not_auto_create_report_server_when_disabled(
+    initialize_pyuvm, test_cls
+):
+    test_cls("disabled_test")
+
+    assert uvm_report_server.get_or_none() is None
+
+
+@pytest.mark.parametrize("test_cls", [uvm_test, internal_uvm_test])
+def test_uvm_test_auto_creates_report_server_when_enabled(
+    initialize_pyuvm, test_cls
+):
+    set_sv_uvm_style_reporting_enabled(True)
+
+    test = test_cls("enabled_test")
+    manager = uvm_report_server.get_or_none()
+
+    assert manager is not None
+    assert test.report_server is manager
+    assert manager.policy.max_quit_count == 1
+    assert manager.policy.test_status_label == "TEST_STATUS"
+
+
+def test_uvm_test_report_server_uses_env_runtime_options(
+    initialize_pyuvm, monkeypatch
+):
+    monkeypatch.setenv("UVM_VERBOSITY", "HIGH")
+    monkeypatch.setenv("UVM_FAIL_ON_WARNING", "1")
+    monkeypatch.setenv("UVM_FAIL_ON_ERROR", "0")
+    monkeypatch.setenv("UVM_FAIL_ON_FATAL", "0")
+    monkeypatch.setenv("max_quit_count", "9")
+    monkeypatch.setenv("TEST_STATUS_LABEL", "ENV_STATUS")
+    monkeypatch.setenv("print_char_len", "64")
+    set_sv_uvm_style_reporting_enabled(True)
+
+    uvm_test("env_options_test")
+    manager = uvm_report_server.get_or_none()
+
+    assert manager is not None
+    assert manager.verbosity == UVM_HIGH
+    assert manager.policy.fail_on_warning
+    assert not manager.policy.fail_on_error
+    assert not manager.policy.fail_on_fatal
+    assert manager.policy.max_quit_count == 9
+    assert manager.policy.test_status_label == "ENV_STATUS"
+    assert manager._print_char_len == 64
+
+
+def test_uvm_test_report_server_plusargs_override_env_options(
+    initialize_pyuvm, monkeypatch
+):
+    monkeypatch.setenv("UVM_VERBOSITY", "LOW")
+    monkeypatch.setenv("max_quit_count", "3")
+    monkeypatch.setenv("TEST_STATUS_LABEL", "ENV_STATUS")
+    monkeypatch.setattr(
+        cocotb,
+        "plusargs",
+        {
+            "UVM_VERBOSITY": "FULL",
+            "max_quit_count": "7",
+            "test_status_label": "PLUS_STATUS",
+            "print_char_len": "42",
+        },
+        raising=False,
+    )
+    set_sv_uvm_style_reporting_enabled(True)
+
+    uvm_test("plusarg_options_test")
+    manager = uvm_report_server.get_or_none()
+
+    assert manager is not None
+    assert manager.verbosity == UVM_FULL
+    assert manager.policy.max_quit_count == 7
+    assert manager.policy.test_status_label == "PLUS_STATUS"
+    assert manager._print_char_len == 42
+
+
+def test_uvm_test_add_message_demotes_hook_is_called(initialize_pyuvm):
+    class HookTest(uvm_test):
+        def add_message_demotes(self, catcher):
+            super().add_message_demotes(catcher)
+            self.hook_catcher = catcher
+            catcher.add_change_sev("HOOK_ID", "known issue", UVM_INFO)
+
+    set_sv_uvm_style_reporting_enabled(True)
+
+    test = HookTest("hook_test")
+    manager = uvm_report_server.get_or_none()
+    test.uvm_report.error("HOOK_ID", "known issue is waived")
+
+    assert manager is not None
+    assert test.hook_catcher is manager.catcher
+    stats = manager.get_stats()
+    assert stats.info_count == 1
+    assert stats.error_count == 0
+
+
+@pytest.mark.parametrize(
+    ("method_name", "new_severity", "expected_info", "expected_error"),
+    [
+        ("fatal", UVM_ERROR, 0, 1),
+        ("fatal", UVM_INFO, 1, 0),
+        ("error", UVM_INFO, 1, 0),
+    ],
+)
+def test_uvm_test_hook_installed_demotions_rewrite_reports(
+    initialize_pyuvm, method_name, new_severity, expected_info, expected_error
+):
+    class DemoteTest(uvm_test):
+        def add_message_demotes(self, catcher):
+            super().add_message_demotes(catcher)
+            catcher.add_change_sev("DEMOTE_ID", "known mismatch", new_severity)
+
+    set_sv_uvm_style_reporting_enabled(True)
+
+    test = DemoteTest("demote_test")
+    manager = uvm_report_server.get_or_none()
+    getattr(test.uvm_report, method_name)("DEMOTE_ID", "known mismatch")
+
+    assert manager is not None
+    stats = manager.get_stats()
+    assert stats.info_count == expected_info
+    assert stats.error_count == expected_error
+    assert stats.fatal_count == 0
 
 
 def test_legacy_report_object_creates_default_stream_handler():
@@ -302,10 +757,14 @@ def test_legacy_custom_handler_receives_logger_messages():
     stream = io.StringIO()
     handler = logging.StreamHandler(stream)
 
-    report_object.add_logging_handler(handler)
-    report_object.logger.info("custom logger message")
+    try:
+        report_object.add_logging_handler(handler)
+        report_object.logger.info("custom logger message")
 
-    assert "custom logger message" in stream.getvalue()
+        assert "custom logger message" in stream.getvalue()
+    finally:
+        report_object.remove_logging_handler(handler)
+        handler.close()
 
 
 def test_sv_uvm_style_report_object_does_not_create_default_stream_handler():

--- a/tests/pytests/test_uvm_reporting.py
+++ b/tests/pytests/test_uvm_reporting.py
@@ -455,9 +455,7 @@ def test_uvm_report_formatter_uses_source_location_and_full_name(reporting_logge
     output = stream.getvalue()
     assert "INFO:" in output
     assert "test_uvm_reporting.py(" in output
-    assert (
-        "[uvm_test_top.env.scoreboard]: [SRC_ID] source-tagged message" in output
-    )
+    assert "[uvm_test_top.env.scoreboard]: [SRC_ID] source-tagged message" in output
 
 
 def test_object_uvm_report_formatter_uses_owner_full_name(reporting_logger):
@@ -477,9 +475,7 @@ def test_object_uvm_report_formatter_uses_owner_full_name(reporting_logger):
 def test_report_summary_uses_uvm_source_location_without_counting(
     reporting_logger,
 ):
-    manager, logger, stream = reporting_logger(
-        fmt="%(levelname)s:%(name)s:%(message)s"
-    )
+    manager, logger, stream = reporting_logger(fmt="%(levelname)s:%(name)s:%(message)s")
     reporter = uvm_reporter(logger, full_name="uvm_test_top")
     reporter.info("INFO_ID", "counted info", UVM_LOW)
     expected_counts = manager.get_stats().info_count
@@ -604,9 +600,7 @@ def test_uvm_test_does_not_auto_create_report_server_when_disabled(
 
 
 @pytest.mark.parametrize("test_cls", [uvm_test, internal_uvm_test])
-def test_uvm_test_auto_creates_report_server_when_enabled(
-    initialize_pyuvm, test_cls
-):
+def test_uvm_test_auto_creates_report_server_when_enabled(initialize_pyuvm, test_cls):
     set_sv_uvm_style_reporting_enabled(True)
 
     test = test_cls("enabled_test")
@@ -618,9 +612,7 @@ def test_uvm_test_auto_creates_report_server_when_enabled(
     assert manager.policy.test_status_label == "TEST_STATUS"
 
 
-def test_uvm_test_report_server_uses_env_runtime_options(
-    initialize_pyuvm, monkeypatch
-):
+def test_uvm_test_report_server_uses_env_runtime_options(initialize_pyuvm, monkeypatch):
     monkeypatch.setenv("UVM_VERBOSITY", "HIGH")
     monkeypatch.setenv("UVM_FAIL_ON_WARNING", "1")
     monkeypatch.setenv("UVM_FAIL_ON_ERROR", "0")
@@ -777,6 +769,34 @@ def test_sv_uvm_style_report_object_does_not_create_default_stream_handler():
         isinstance(handler, logging.StreamHandler)
         for handler in report_object.logger.handlers
     )
+
+
+def test_sv_uvm_style_report_object_removes_reused_logger_stream_handler():
+    logger_name = f"reused_report_object.{uuid.uuid4().hex}"
+    logger = logging.getLogger(f"uvm.{logger_name}")
+
+    class ReusedLoggerReportObject(uvm_report_object):
+        def get_initial_logger_name(self):
+            return logger_name
+
+    try:
+        legacy_report_object = ReusedLoggerReportObject("legacy_report_object")
+        assert any(
+            isinstance(handler, logging.StreamHandler)
+            for handler in legacy_report_object.logger.handlers
+        )
+
+        set_sv_uvm_style_reporting_enabled(True)
+        report_object = ReusedLoggerReportObject("report_object")
+
+        assert report_object.logger is logger
+        assert report_object.logger.propagate
+        assert report_object._streaming_handler is None
+        assert not report_object.logger.handlers
+    finally:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
 
 
 def test_uvm_report_uses_existing_object_verbosity():


### PR DESCRIPTION
# TL;DR

Adds a TinyALU example for pyuvm's opt-in SV-UVM-style reporting path. The
example demonstrates report IDs, source file/line output, UVM hierarchy,
verbosity, report summaries, `TEST_STATUS`, max quit count handling, fatal
reports, and severity demotion using real TinyALU scoreboard traffic.

The pyuvm reporting changes in this PR are the support needed to make that
example work cleanly from a cocotb regression: centralized report-server setup
from `uvm_test`, runtime options from plusargs/env vars, graceful max-quit
termination, customizable test-status labels, and test-specific message
demotions.

# Summary

This PR adds `examples/TinyALU_uvm_reporting`, a TinyALU regression focused on
SV-UVM-style reporting behavior.

The existing `examples/TinyALU` remains the direct Python logging walkthrough.
The new example uses the same TinyALU RTL/BFM flow, but reports through
`self.uvm_report`.

The example demonstrates:

- passing ALU traffic with UVM report summaries
- source file and line output on UVM-style report records
- report IDs and UVM hierarchy in log output
- sequence reporting through `self.uvm_report`
- scoreboard mismatch reports
- fatal reports from the same mismatch path
- max quit count handling at `0`, `1`, `2`, and `25`
- `+max_quit_count=0` as unlimited, reported as `UNLIMITED`
- graceful summary and final status output after max quit count is reached
- default `TEST_STATUS` output with a customizable label
- severity demotion from fatal/error reports to lower severities
- `[SEVCHG]` diagnostics when a report is demoted

# RFC Alignment

This builds on the SV-UVM-style reporting direction from #396 and the RFC #374 

The main goal here is not to replace pyuvm's Python logging model. It is to give
users a concrete example showing how the new reporting layer behaves in a real
verification-style testbench.

The TinyALU example exercises the pieces that teams commonly need in regression logs:
- report IDs
- source locations
- UVM hierarchy
- per-test pass/fail status
- max quit count behavior
- severity demotion hooks
- report summaries at test end

# Deliberate Differences from SystemVerilog UVM

This remains a Python-native pyuvm example, not a complete SystemVerilog UVM
reporting clone.

Important differences:

- Python logging remains the backend.
- Direct Python logger records are still ordinary logging records.
- UVM-style report behavior applies to `self.uvm_report.*` calls.
- Fatal reports use Python exception behavior.
- Max quit count exits gracefully through pyuvm/cocotb test flow.
- Severity demotion is intentionally focused on report ID/message matching.

# Compatibility

The new TinyALU reporting example enables SV-UVM-style reporting for itself.
Existing examples and tests using `self.logger.*` continue to work as before.

Runtime reporting options can be supplied through cocotb plusargs or matching
environment variables.

For example:

```sh
make SIM=verilator TOPLEVEL_LANG=verilog \
    COCOTB_PLUSARGS="+UVM_VERBOSITY=DEBUG +max_quit_count=25 +test_status_label=MY_TEST_STATUS +print_char_len=80" \
    sim checkclean
```

The example also adds a `maxquit-demo` make target to show the same error test
at multiple quit-count settings:

```sh
make SIM=verilator TOPLEVEL_LANG=verilog maxquit-demo
```
# Implementation Notes

- `examples/TinyALU_uvm_reporting` adds the new example, Makefile, README, and
  cocotb/pyuvm testbench.
- `uvm_test` now creates centralized reporting support when SV-UVM-style
  reporting is enabled.
- Runtime reporting options are resolved from plusargs first, then environment
  variables.
- `uvm_report_policy` defaults the final status label to `TEST_STATUS`, while
  allowing teams to customize it.
- Max quit count now supports unlimited mode with `0`.
- Max quit count emits the triggering report, emits the `[MAXQUIT]` message, and
  still prints the report summary/final status.
- `add_message_demotes(self, catcher)` lets a test register report demotions.
- Severity demotions emit a `[SEVCHG]` diagnostic at the report call site.
- UVM-style report records include useful source file/line information.

# Tests Added

The TinyALU reporting regression includes:

- `AluTest`
- `ParallelTest`
- `FibonacciTest`
- `AluTestErrors`
- `FatalReportTest`
- `FatalDowngradeToErrorTest`
- `FatalDowngradeToInfoTest`
- `ErrorDowngradeToInfoTest`

The pyuvm unit tests cover:

- report-server setup from `uvm_test`
- plusarg/env runtime option parsing
- plusarg override behavior
- default and customized `TEST_STATUS` labels
- max quit count at `0`, `1`, `2`, and larger values
- unlimited quit-count summary formatting
- graceful max-quit summary/final-status behavior
- severity demotion diagnostics
- fatal-to-error, fatal-to-info, and error-to-info demotions
- the `add_message_demotes()` hook
```