### PR TITLE
[pyral, core] Add foundational RAL register and frontdoor access APIs

### DIFF
--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -627,7 +627,9 @@ class uvm_reg(uvm_object):
         lineno: int = 0,
     ) -> uvm_status_e:
         expected = self.get_mirrored_value(fname, lineno)
-        status, value = await self.read(path, map, parent, prior, extension, fname, lineno)
+        status, value = await self.read(
+            path, map, parent, prior, extension, fname, lineno
+        )
         if status == uvm_status_e.UVM_NOT_OK:
             return status
         if check == uvm_check_e.UVM_CHECK:

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -19,6 +19,7 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_status_e,
 )
 from pyuvm._s05_base_classes import uvm_object
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_reg_backdoor import uvm_reg_backdoor
@@ -38,6 +39,20 @@ if TYPE_CHECKING:
 
 __all__ = ["uvm_reg"]
 logger = logging.getLogger("RegModel")
+
+
+def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.warning(report_id, msg)
+    else:
+        logger.warning(msg)
+
+
+def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.error(report_id, msg)
+    else:
+        logger.error(msg)
 
 
 class uvm_reg(uvm_object):
@@ -318,7 +333,16 @@ class uvm_reg(uvm_object):
         return self._fields
 
     def get_field_by_name(self, name: str) -> uvm_reg_field:
-        raise NotImplementedError
+        for field in self._fields:
+            if field.get_name() == name:
+                return field
+        _report_warning(
+            self,
+            "REG_FIELD_LOOKUP",
+            f"Unable to locate field {repr(name)} in register "
+            f"{repr(self.get_full_name())}",
+        )
+        return None
 
     def _get_fields_access(self, map: uvm_reg_map) -> str:
         readable = False
@@ -339,8 +363,14 @@ class uvm_reg(uvm_object):
             return "RO"
         return "RW"
 
-    def get_offset(self, map: uvm_reg_map) -> uvm_reg_addr_t:
-        raise NotImplementedError
+    def get_offset(self, map: uvm_reg_map = None) -> uvm_reg_addr_t:
+        local_map = self.get_local_map(map)
+        if local_map is None:
+            return -1
+        map_info = local_map.get_reg_map_info(self)
+        if map_info is None:
+            return -1
+        return map_info.offset
 
     def get_address(self, map: uvm_reg_map = None) -> uvm_reg_addr_t:
         # TODO: remove backward compatibility
@@ -394,8 +424,11 @@ class uvm_reg(uvm_object):
             value |= field.get_mirrored_value() << field.get_lsb_pos()
         return value
 
-    def needs_update() -> bool:
-        raise NotImplementedError
+    def get_mask(self) -> uvm_reg_data_t:
+        return (1 << self.get_n_bits()) - 1
+
+    def needs_update(self) -> bool:
+        return any(field.needs_update() for field in self._fields)
 
     def reset(self, kind: str = "HARD") -> None:
         for field in self._fields:
@@ -412,13 +445,22 @@ class uvm_reg(uvm_object):
         self._set_is_busy(False)
 
     def get_reset(self, kind: str = "HARD") -> int:
-        raise NotImplementedError
+        value = 0
+        for field in self._fields:
+            value |= field.get_reset(kind) << field.get_lsb_pos()
+        return value & self.get_mask()
 
     def has_reset(self, kind: str = "HARD", delete: bool = False) -> bool:
-        raise NotImplementedError
+        has_reset = False
+        for field in self._fields:
+            has_reset |= field.has_reset(kind, delete)
+        return has_reset
 
     def set_reset(self, value: uvm_reg_data_t, kind: str = "HARD") -> None:
-        raise NotImplementedError
+        for field in self._fields:
+            field_mask = (1 << field.get_n_bits()) - 1
+            field_value = (value >> field.get_lsb_pos()) & field_mask
+            field.set_reset(field_value, kind)
 
     async def write(
         self,
@@ -503,7 +545,22 @@ class uvm_reg(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        async with self._atomic:
+            rw = uvm_reg_item("poke_item")
+            rw.set_element(self)
+            rw.set_element_kind(uvm_elem_kind_e.UVM_REG)
+            rw.set_kind(uvm_access_e.UVM_WRITE)
+            rw.set_value(value & self.get_mask())
+            rw.set_door(uvm_door_e.UVM_BACKDOOR)
+            rw.set_parent_sequence(parent)
+            rw.set_extension(extension)
+            rw.set_bd_kind(kind)
+            rw.set_fname(fname)
+            rw.set_line(lineno)
+            await self.do_write(rw)
+            if rw.get_status() != uvm_status_e.UVM_NOT_OK:
+                self.do_predict(rw, uvm_predict_e.UVM_PREDICT_DIRECT)
+        return rw.get_status()
 
     async def peek(
         self,
@@ -513,7 +570,23 @@ class uvm_reg(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        async with self._atomic:
+            rw = uvm_reg_item("peek_item")
+            rw.set_element(self)
+            rw.set_element_kind(uvm_elem_kind_e.UVM_REG)
+            rw.set_kind(uvm_access_e.UVM_READ)
+            rw.set_value(0)
+            rw.set_door(uvm_door_e.UVM_BACKDOOR)
+            rw.set_parent_sequence(parent)
+            rw.set_extension(extension)
+            rw.set_bd_kind(kind)
+            rw.set_fname(fname)
+            rw.set_line(lineno)
+            await self.do_read(rw)
+            rw.set_value(rw.get_value() & self.get_mask())
+            if rw.get_status() != uvm_status_e.UVM_NOT_OK:
+                self.do_predict(rw, uvm_predict_e.UVM_PREDICT_DIRECT)
+        return rw.get_status(), rw.get_value()
 
     async def update(
         self,
@@ -525,7 +598,18 @@ class uvm_reg(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        if not self.needs_update():
+            return uvm_status_e.UVM_IS_OK
+        return await self.write(
+            self.get(fname, lineno),
+            path,
+            map,
+            parent,
+            prior,
+            extension,
+            fname,
+            lineno,
+        )
 
     async def mirror(
         self,
@@ -538,7 +622,27 @@ class uvm_reg(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        expected = self.get_mirrored_value(fname, lineno)
+        status, value = await self.read(path, map, parent, prior, extension, fname, lineno)
+        if status == uvm_status_e.UVM_NOT_OK:
+            return status
+        if check == uvm_check_e.UVM_CHECK:
+            self.do_check(expected, value, map)
+        predict_path = path
+        if predict_path == uvm_door_e.UVM_DEFAULT_DOOR:
+            if self._parent is not None:
+                predict_path = self._parent.get_default_door()
+            else:
+                predict_path = uvm_door_e.UVM_FRONTDOOR
+        self.predict(
+            value,
+            kind=uvm_predict_e.UVM_PREDICT_READ,
+            path=predict_path,
+            map=map,
+            fname=fname,
+            lineno=lineno,
+        )
+        return status
 
     def predict(
         self,
@@ -580,6 +684,7 @@ class uvm_reg(uvm_object):
         rw = uvm_reg_item("read_item")
         rw.set_element(self)
         rw.set_element_kind(uvm_elem_kind_e.UVM_REG)
+        rw.set_kind(uvm_access_e.UVM_READ)
         rw.set_value(0)
         rw.set_door(path)
         rw.set_map(map)
@@ -617,7 +722,22 @@ class uvm_reg(uvm_object):
     def do_check(
         self, expected: uvm_reg_data_t, actual: uvm_reg_data_t, map: uvm_reg_map
     ) -> bool:
-        raise NotImplementedError
+        valid_bits_mask = 0
+        for field in self.get_fields():
+            if field.get_compare() == uvm_check_e.UVM_CHECK and not field.is_volatile():
+                field_mask = (1 << field.get_n_bits()) - 1
+                valid_bits_mask |= field_mask << field.get_lsb_pos()
+        valid_bits_mask &= self.get_mask()
+        if ((expected ^ actual) & valid_bits_mask) == 0:
+            return True
+        _report_error(
+            self,
+            "REG_COMPARE",
+            f"Register {repr(self.get_full_name())} value read from DUT "
+            f"(0x{actual & valid_bits_mask:X}) does not match mirrored value "
+            f"(0x{expected & valid_bits_mask:X})",
+        )
+        return False
 
     async def do_write(self, rw: uvm_reg_item) -> None:
         self.fname = rw.get_fname()
@@ -665,8 +785,8 @@ class uvm_reg(uvm_object):
         else:
             await local_map.do_write(rw)
         self._set_is_busy(False)
-        if system_map.get_auto_predict():
-            if rw.get_status() != uvm_status_e.UVM_NOT_OK:
+        if system_map.get_auto_predict() and rw.get_status() == uvm_status_e.UVM_IS_OK:
+            if self._cover_on:
                 self.sample(rw.get_value(), -1, False, rw.get_map())
                 self._parent._sample(map_info.offset, False, rw.get_map())
             status = rw.get_status()
@@ -760,18 +880,38 @@ class uvm_reg(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> None:
-        raise NotImplementedError
+        self._fname = fname
+        self._lineno = lineno
+        local_map = self.get_local_map(map)
+        if local_map is None:
+            return
+        map_info = local_map.get_reg_map_info(self)
+        if map_info is not None:
+            map_info.frontdoor = ftdr
 
     def get_frontdoor(self, map: uvm_reg_map = None) -> uvm_reg_frontdoor:
-        raise NotImplementedError
+        local_map = self.get_local_map(map)
+        if local_map is None:
+            return None
+        map_info = local_map.get_reg_map_info(self)
+        if map_info is None:
+            return None
+        return map_info.frontdoor
 
     def set_backdoor(
         self, bkdr: uvm_reg_backdoor, fname: str = "", lineno: int = 0
     ) -> None:
-        raise NotImplementedError
+        self._fname = fname
+        self._lineno = lineno
+        if bkdr is not None:
+            bkdr.fname = fname
+            bkdr.lineno = lineno
+        self._backdoor = bkdr
 
     def get_backdoor(self, inherited: bool = True) -> uvm_reg_backdoor:
-        raise NotImplementedError
+        if self._backdoor is None and inherited and self._parent is not None:
+            self._backdoor = self._parent.get_backdoor()
+        return self._backdoor
 
     def clear_hdl_path(self, kind: str = "RTL") -> None:
         raise NotImplementedError

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -600,8 +600,11 @@ class uvm_reg(uvm_object):
     ) -> uvm_status_e:
         if not self.needs_update():
             return uvm_status_e.UVM_IS_OK
+        value = 0
+        for field in self._fields:
+            value |= field.get_update_value() << field.get_lsb_pos()
         return await self.write(
-            self.get(fname, lineno),
+            value,
             path,
             map,
             parent,

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -366,10 +366,16 @@ class uvm_reg(uvm_object):
     def get_offset(self, map: uvm_reg_map = None) -> uvm_reg_addr_t:
         local_map = self.get_local_map(map)
         if local_map is None:
-            return -1
+            raise UVMFatalError(
+                f"Register {repr(self.get_full_name())} is not mapped in "
+                "the requested address map"
+            )
         map_info = local_map.get_reg_map_info(self)
         if map_info is None:
-            return -1
+            raise UVMFatalError(
+                f"Register {repr(self.get_full_name())} has no map info in "
+                f"address map {repr(local_map.get_full_name())}"
+            )
         return map_info.offset
 
     def get_address(self, map: uvm_reg_map = None) -> uvm_reg_addr_t:
@@ -899,7 +905,7 @@ class uvm_reg(uvm_object):
         return map_info.frontdoor
 
     def set_backdoor(
-        self, bkdr: uvm_reg_backdoor, fname: str = "", lineno: int = 0
+        self, bkdr: uvm_reg_backdoor | None, fname: str = "", lineno: int = 0
     ) -> None:
         self._fname = fname
         self._lineno = lineno
@@ -908,7 +914,7 @@ class uvm_reg(uvm_object):
             bkdr.lineno = lineno
         self._backdoor = bkdr
 
-    def get_backdoor(self, inherited: bool = True) -> uvm_reg_backdoor:
+    def get_backdoor(self, inherited: bool = True) -> uvm_reg_backdoor | None:
         if self._backdoor is None and inherited and self._parent is not None:
             self._backdoor = self._parent.get_backdoor()
         return self._backdoor

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -493,6 +493,7 @@ class uvm_reg(uvm_object):
             self.set(value)
             rw = uvm_reg_item("write_item")
             rw.set_element(self)
+            rw.set_element_kind(uvm_elem_kind_e.UVM_REG)
             rw.set_kind(uvm_access_e.UVM_WRITE)
             rw.set_value(value)
             rw.set_door(path)
@@ -840,15 +841,9 @@ class uvm_reg(uvm_object):
         else:  # Built-in frontdoor
             await local_map.do_read(rw)
         self._set_is_busy(False)
-        if system_map.get_auto_predict():
-            if (
-                local_map.get_check_on_read()
-                and rw.get_status() != uvm_status_e.UVM_NOT_OK
-            ):
+        if system_map.get_auto_predict() and rw.get_status() == uvm_status_e.UVM_IS_OK:
+            if local_map.get_check_on_read():
                 self.do_check(exp_value, rw.get_value(), system_map)
-            if rw.get_status() != uvm_status_e.UVM_NOT_OK:
-                # TODO: sample
-                pass
             status = rw.get_status()
             self.do_predict(rw, uvm_predict_e.UVM_PREDICT_READ)
             rw.set_status(status)

--- a/pyuvm/_reg/uvm_reg_adapter.py
+++ b/pyuvm/_reg/uvm_reg_adapter.py
@@ -12,10 +12,19 @@ __all__ = ["uvm_reg_adapter", "uvm_reg_tlm_adapter"]
 
 class uvm_reg_adapter(uvm_object):
     def __init__(self, name: str = ""):
+        super().__init__(name)
         self.supports_byte_enable: bool = False
-        self.provides_response: bool = False
+        self.provides_responses: bool = False
         self.parent_sequence: uvm_sequence_base = None
         self._item: uvm_reg_item = None
+
+    @property
+    def provides_response(self) -> bool:
+        return self.provides_responses
+
+    @provides_response.setter
+    def provides_response(self, value: bool) -> None:
+        self.provides_responses = value
 
     def get_item(self) -> uvm_reg_item:
         return self._item

--- a/pyuvm/_reg/uvm_reg_backdoor.py
+++ b/pyuvm/_reg/uvm_reg_backdoor.py
@@ -37,7 +37,7 @@ class uvm_reg_backdoor(uvm_object):
         raise NotImplementedError
 
     def is_auto_updated(self, field: uvm_reg_field) -> bool:
-        raise NotImplementedError
+        return False
 
     async def wait_for_change(element: uvm_object) -> None:
         raise NotImplementedError

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -485,7 +485,7 @@ class uvm_reg_block(uvm_object):
     async def writememh(filename: str) -> None:
         raise NotImplementedError
 
-    def get_backdoor(self, inherited: bool = True) -> uvm_reg_backdoor:
+    def get_backdoor(self, inherited: bool = True) -> uvm_reg_backdoor | None:
         if self._backdoor is not None or not inherited:
             return self._backdoor
         if self._parent is not None:
@@ -493,7 +493,7 @@ class uvm_reg_block(uvm_object):
         return None
 
     def set_backdoor(
-        self, bkdr: uvm_reg_backdoor, fname: str = "", lineno: int = 0
+        self, bkdr: uvm_reg_backdoor | None, fname: str = "", lineno: int = 0
     ) -> None:
         if bkdr is not None:
             bkdr.fname = fname

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -61,6 +61,7 @@ class uvm_reg_block(uvm_object):
         self._lock_model_complete: Event = Event()
         self._default_hdl_path = "RTL"
         self._hdl_paths_pool: dict[str, list[str]] = dict()
+        self._backdoor: uvm_reg_backdoor = None
 
     def configure(self, parent: uvm_reg_block = None, hdl_path: str = "") -> None:
         self._parent = parent
@@ -368,7 +369,7 @@ class uvm_reg_block(uvm_object):
         raise NotImplementedError
 
     def _sample(self, addr: uvm_reg_addr_t, is_read: bool, map: uvm_reg_map) -> None:
-        raise NotImplementedError
+        self.sample(addr, is_read, map)
 
     def get_default_door(self) -> uvm_door_e:
         if self.default_path is not uvm_door_e.UVM_DEFAULT_DOOR:
@@ -479,12 +480,19 @@ class uvm_reg_block(uvm_object):
         raise NotImplementedError
 
     def get_backdoor(self, inherited: bool = True) -> uvm_reg_backdoor:
-        raise NotImplementedError
+        if self._backdoor is not None or not inherited:
+            return self._backdoor
+        if self._parent is not None:
+            return self._parent.get_backdoor()
+        return None
 
     def set_backdoor(
         self, bkdr: uvm_reg_backdoor, fname: str = "", lineno: int = 0
     ) -> None:
-        raise NotImplementedError
+        if bkdr is not None:
+            bkdr.fname = fname
+            bkdr.lineno = lineno
+        self._backdoor = bkdr
 
     def clear_hdl_path(self, kind: str = "RTL") -> None:
         raise NotImplementedError

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import warnings
-from asyncio import Event
 from typing import TYPE_CHECKING, ClassVar
+
+from cocotb.triggers import Event
 
 from pyuvm._error_classes import UVMFatalError
 from pyuvm._reg.uvm_mem import uvm_mem
@@ -58,7 +59,6 @@ class uvm_reg_block(uvm_object):
         self._maps: list[uvm_reg_map] = list()
         self._locked: bool = False
         self._default_map: uvm_reg_map = None
-        # Python 3.9 binds asyncio.Event to the current loop at construction.
         self._lock_model_complete: Event | None = None
         self._default_hdl_path = "RTL"
         self._hdl_paths_pool: dict[str, list[str]] = dict()

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -58,7 +58,8 @@ class uvm_reg_block(uvm_object):
         self._maps: list[uvm_reg_map] = list()
         self._locked: bool = False
         self._default_map: uvm_reg_map = None
-        self._lock_model_complete: Event = Event()
+        # Python 3.9 binds asyncio.Event to the current loop at construction.
+        self._lock_model_complete: Event | None = None
         self._default_hdl_path = "RTL"
         self._hdl_paths_pool: dict[str, list[str]] = dict()
         self._backdoor: uvm_reg_backdoor = None
@@ -184,12 +185,17 @@ class uvm_reg_block(uvm_object):
                         "models have to be unique"
                     )
             # NOTE: Trigger event
-            self._lock_model_complete.set()
+            if self._lock_model_complete is not None:
+                self._lock_model_complete.set()
 
     def unlock_model(self) -> None:
         raise NotImplementedError
 
     async def wait_for_lock(self) -> None:
+        if self.is_locked():
+            return
+        if self._lock_model_complete is None:
+            self._lock_model_complete = Event()
         await self._lock_model_complete.wait()
         self._lock_model_complete.clear()
 

--- a/pyuvm/_reg/uvm_reg_field.py
+++ b/pyuvm/_reg/uvm_reg_field.py
@@ -109,6 +109,7 @@ class uvm_reg_field(uvm_object):
         self._lsb_pos = lsb_pos
         self._access = access
         self._volatile = volatile
+        self._check = uvm_check_e.UVM_NO_CHECK if volatile else uvm_check_e.UVM_CHECK
 
         # TODO: Remove backward compatibility check
         if has_reset is None:
@@ -587,11 +588,11 @@ class uvm_reg_field(uvm_object):
             #                           rw.get_door(), rw.get_map())
             field_value &= (1 << self.get_n_bits()) - 1
         elif kind == uvm_predict_e.UVM_PREDICT_DIRECT:
-            if self.parent.is_busy():
+            if self._parent.is_busy():
                 logger.warning(
                     "Trying to predict value of field "
                     f"{repr(self.get_name())} while register "
-                    f"{repr(self.parent.get_name())} is being "
+                    f"{repr(self._parent.get_name())} is being "
                     "accessed."
                 )
                 rw.set_status(uvm_status_e.UVM_NOT_OK)

--- a/pyuvm/_reg/uvm_reg_field.py
+++ b/pyuvm/_reg/uvm_reg_field.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, ClassVar
 from pyuvm._reg.uvm_reg_item import uvm_reg_item
 from pyuvm._reg.uvm_reg_map import uvm_reg_map
 from pyuvm._reg.uvm_reg_model import (
+    uvm_access_e,
     uvm_check_e,
     uvm_coverage_model_e,
     uvm_door_e,
+    uvm_elem_kind_e,
     uvm_predict_e,
     uvm_status_e,
 )
@@ -326,7 +328,12 @@ class uvm_reg_field(uvm_object):
         # Define an all 1 values
         _mask = (1 << self._size) - 1
 
-        # TODO: check if value given is bigger than the size of field
+        if value >> self._size:
+            logger.warning(
+                f"Specified value (0x{value:X}) greater than field "
+                f"{repr(self.get_name())} size ({self._size} bits)"
+            )
+            value &= _mask
 
         # Ideally the set value should be checked against the parent
         # register being accessed.
@@ -356,10 +363,11 @@ class uvm_reg_field(uvm_object):
         elif access == "W0T":
             self._desired = self._desired ^ (~value & _mask)
         elif access in ("W1", "WO1"):
-            if self._has_been_writ is False:
+            if self._written is False:
                 self._desired = value
         else:
             self._desired = value
+        self.value = self._desired
 
     def get(self, fname: str = "", lineno: int = 0) -> uvm_reg_data_t:
         self._fname = fname
@@ -407,6 +415,86 @@ class uvm_reg_field(uvm_object):
             return False
         return (self._desired != self._mirrored) | self._volatile
 
+    def get_mask(self) -> uvm_reg_data_t:
+        return (1 << self.get_n_bits()) - 1
+
+    def get_register_mask(self) -> uvm_reg_data_t:
+        return self.get_mask() << self.get_lsb_pos()
+
+    def extract_from_register(self, value: uvm_reg_data_t) -> uvm_reg_data_t:
+        return (value >> self.get_lsb_pos()) & self.get_mask()
+
+    def insert_into_register(
+        self, reg_value: uvm_reg_data_t, field_value: uvm_reg_data_t
+    ) -> uvm_reg_data_t:
+        register_mask = self.get_register_mask()
+        field_bits = (field_value & self.get_mask()) << self.get_lsb_pos()
+        return (reg_value & ~register_mask) | field_bits
+
+    def _get_parent_write_value(
+        self, value: uvm_reg_data_t, map: uvm_reg_map = None
+    ) -> uvm_reg_data_t:
+        value_adjust = 0
+        for field in self._parent.get_fields():
+            if field is self:
+                value_adjust |= (value & field.get_mask()) << field.get_lsb_pos()
+                continue
+
+            access = field.get_access(map)
+            if access in (
+                "RO",
+                "RC",
+                "RS",
+                "W1C",
+                "W1S",
+                "W1T",
+                "W1SRC",
+                "W1CRS",
+            ):
+                continue
+            if access in ("W0C", "W0S", "W0T", "W0SRC", "W0CRS"):
+                value_adjust |= field.get_register_mask()
+                continue
+            value_adjust |= field.get_mirrored_value() << field.get_lsb_pos()
+        return value_adjust & self._parent.get_mask()
+
+    def get_update_value(self) -> uvm_reg_data_t:
+        mask = self.get_mask()
+        access = self._access
+        if access in (
+            "RO",
+            "RW",
+            "RC",
+            "RS",
+            "WRC",
+            "WRS",
+            "WC",
+            "WS",
+            "WSRC",
+            "WCRS",
+            "WO",
+            "WOC",
+            "WOS",
+            "W1",
+            "WO1",
+        ):
+            update = self._desired
+        elif access in ("W1C", "W1CRS"):
+            update = ~self._desired
+        elif access in ("W1S", "W1SRC"):
+            update = self._desired
+        elif access == "W1T":
+            update = self._desired ^ self._mirrored
+        elif access in ("W0C", "W0CRS"):
+            update = self._desired
+        elif access in ("W0S", "W0SRC"):
+            update = ~self._desired
+        elif access == "W0T":
+            update = ~(self._desired ^ self._mirrored)
+        else:
+            update = self._desired
+        return update & mask
+
     async def write(
         self,
         value: uvm_reg_data_t,
@@ -418,7 +506,22 @@ class uvm_reg_field(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        async with self._parent._atomic:
+            self.set(value, fname, lineno)
+            rw = uvm_reg_item("field_write_item")
+            rw.set_element(self)
+            rw.set_element_kind(uvm_elem_kind_e.UVM_FIELD)
+            rw.set_kind(uvm_access_e.UVM_WRITE)
+            rw.set_value(value)
+            rw.set_door(path)
+            rw.set_map(map)
+            rw.set_parent_sequence(parent)
+            rw.set_priority(prior)
+            rw.set_extension(extension)
+            rw.set_fname(fname)
+            rw.set_line(lineno)
+            await self.do_write(rw)
+        return rw.get_status()
 
     async def read(
         self,
@@ -430,7 +533,21 @@ class uvm_reg_field(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        async with self._parent._atomic:
+            rw = uvm_reg_item("field_read_item")
+            rw.set_element(self)
+            rw.set_element_kind(uvm_elem_kind_e.UVM_FIELD)
+            rw.set_kind(uvm_access_e.UVM_READ)
+            rw.set_value(0)
+            rw.set_door(path)
+            rw.set_map(map)
+            rw.set_parent_sequence(parent)
+            rw.set_priority(prior)
+            rw.set_extension(extension)
+            rw.set_fname(fname)
+            rw.set_line(lineno)
+            await self.do_read(rw)
+        return rw.get_status(), rw.get_value()
 
     async def poke(
         self,
@@ -441,7 +558,30 @@ class uvm_reg_field(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        self._fname = fname
+        self._lineno = lineno
+        status, reg_value = await self._parent.peek(
+            kind,
+            parent,
+            extension,
+            fname,
+            lineno,
+        )
+        if status == uvm_status_e.UVM_NOT_OK:
+            logger.error(
+                f"uvm_reg_field::poke(): Peek of register "
+                f"{repr(self._parent.get_full_name())} returned status {status}"
+            )
+            return status
+        reg_value = self.insert_into_register(reg_value, value)
+        return await self._parent.poke(
+            reg_value,
+            kind,
+            parent,
+            extension,
+            fname,
+            lineno,
+        )
 
     async def peek(
         self,
@@ -451,7 +591,16 @@ class uvm_reg_field(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        self._fname = fname
+        self._lineno = lineno
+        status, reg_value = await self._parent.peek(
+            kind,
+            parent,
+            extension,
+            fname,
+            lineno,
+        )
+        return status, self.extract_from_register(reg_value)
 
     async def mirror(
         self,
@@ -464,7 +613,18 @@ class uvm_reg_field(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        self._fname = fname
+        self._lineno = lineno
+        return await self._parent.mirror(
+            check,
+            path,
+            map,
+            parent,
+            prior,
+            extension,
+            fname,
+            lineno,
+        )
 
     def set_compare(self, check: uvm_check_e) -> None:
         self._check = check
@@ -473,7 +633,7 @@ class uvm_reg_field(uvm_object):
         return self._check
 
     def is_indv_accessible(self, path: uvm_door_e, local_map: uvm_reg_map) -> bool:
-        raise NotImplementedError
+        return False
 
     def predict(
         self,
@@ -500,6 +660,8 @@ class uvm_reg_field(uvm_object):
         self, cur_val: uvm_reg_data_t, wr_val: uvm_reg_data_t, map: uvm_reg_map
     ) -> uvm_reg_data_t:
         mask = (1 << self.get_n_bits()) - 1
+        cur_val &= mask
+        wr_val &= mask
         access = self.get_access(map)
         if access in ["RO", "RC", "RS", "NOACCESS"]:
             return cur_val
@@ -510,10 +672,10 @@ class uvm_reg_field(uvm_object):
         elif access in ["WS", "WSRC", "WOS"]:
             return mask
         elif access in ["W1C", "W1CRS"]:
-            return cur_val & ~mask
+            return cur_val & (~wr_val & mask)
         elif access in ["W1S", "W1SRC"]:
             return cur_val | wr_val
-        elif access in ["WT"]:
+        elif access in ["W1T"]:
             return cur_val ^ wr_val
         elif access in ["W0C", "W0CRS"]:
             return cur_val & wr_val
@@ -530,16 +692,23 @@ class uvm_reg_field(uvm_object):
             return wr_val
 
     def _update(self) -> uvm_reg_data_t:
-        raise NotImplementedError
+        return self.get_update_value()
 
     def _check_access(self, rw: uvm_reg_item, map_info: uvm_reg_map_info) -> bool:
         raise NotImplementedError
 
     async def do_write(self, rw: uvm_reg_item) -> None:
-        raise NotImplementedError
+        reg_value = self._get_parent_write_value(rw.get_value(0), rw.get_map())
+        rw.set_element_kind(uvm_elem_kind_e.UVM_REG)
+        rw.set_element(self._parent)
+        rw.set_value(reg_value)
+        await self._parent.do_write(rw)
 
     async def do_read(self, rw: uvm_reg_item) -> None:
-        raise NotImplementedError
+        rw.set_element_kind(uvm_elem_kind_e.UVM_REG)
+        rw.set_element(self._parent)
+        await self._parent.do_read(rw)
+        rw.set_value(self.extract_from_register(rw.get_value(0)))
 
     def do_predict(
         self,
@@ -560,7 +729,7 @@ class uvm_reg_field(uvm_object):
                 or rw.get_door() == uvm_door_e.UVM_PREDICT
             ):
                 field_value = self._predict(self._mirrored, field_value, rw.get_map())
-            self.written = True
+            self._written = True
             # TODDO: implement callbacks
             # callbacks = uvm_reg_field_cb_iter(self)
             # for callback in self._callbacks:

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -591,9 +591,7 @@ class uvm_reg_map(uvm_object):
         sequence = adapter.parent_sequence
         if sequence is None:
             sequence = uvm_sequence("base_seq")
-        if not hasattr(sequence, "start_item") or not hasattr(
-            sequence, "finish_item"
-        ):
+        if not hasattr(sequence, "start_item") or not hasattr(sequence, "finish_item"):
             raise UVMFatalError(
                 f"Adapter {repr(adapter.get_full_name())} parent_sequence must "
                 "provide start_item() and finish_item()."

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -556,87 +556,129 @@ class uvm_reg_map(uvm_object):
     def get_check_on_read(self) -> bool:
         return self._check_on_read
 
-    async def do_bus_write(
-        self, rw: uvm_reg_item, sequencer: uvm_sequencer_base, adapter: uvm_reg_adapter
-    ) -> None:
+    def _get_bus_access_config(
+        self, rw: uvm_reg_item
+    ) -> tuple[uvm_sequencer_base, uvm_reg_adapter]:
+        system_map = self.get_root_map()
+        adapter = system_map.get_adapter()
+        sequencer = system_map.get_sequencer()
+        element = rw.get_element()
+        element_name = (
+            element.get_full_name()
+            if element is not None and hasattr(element, "get_full_name")
+            else rw.get_name()
+        )
+        map_name = system_map.get_full_name()
+        if adapter is None:
+            raise UVMFatalError(
+                f"Register map {repr(map_name)} has no adapter configured for "
+                f"frontdoor access to {repr(element_name)}. Call "
+                "set_sequencer(sequencer, adapter) before using register "
+                "frontdoor reads or writes."
+            )
+        if sequencer is None:
+            raise UVMFatalError(
+                f"Register map {repr(map_name)} has no sequencer configured for "
+                f"frontdoor access to {repr(element_name)}. Call "
+                "set_sequencer(sequencer, adapter) before using register "
+                "frontdoor reads or writes."
+            )
+        return sequencer, adapter
+
+    def _get_bus_sequence(
+        self, rw: uvm_reg_item, adapter: uvm_reg_adapter
+    ) -> uvm_sequence:
+        sequence = adapter.parent_sequence
+        if sequence is None:
+            sequence = uvm_sequence("base_seq")
+        if not hasattr(sequence, "start_item") or not hasattr(
+            sequence, "finish_item"
+        ):
+            raise UVMFatalError(
+                f"Adapter {repr(adapter.get_full_name())} parent_sequence must "
+                "provide start_item() and finish_item()."
+            )
+        rw.set_parent_sequence(sequence)
+        return sequence
+
+    def _make_bus_op(
+        self,
+        rw: uvm_reg_item,
+        access_kind: uvm_access_e,
+        adapter: uvm_reg_adapter,
+    ) -> uvm_reg_bus_op:
         reg = rw.get_element()
-        bus_width, addrs, _ = self._get_physical_addresses_to_map(
+        bus_width, addrs, byte_offset = self._get_physical_addresses_to_map(
             self._regs_info[reg].offset, 0x0, reg.get_n_bytes(), None, None
         )
         bus_op = uvm_reg_bus_op()
-        bus_op.kind = uvm_access_e.UVM_WRITE
+        bus_op.kind = access_kind
         bus_op.addr = addrs[0]
         bus_op.data = rw.get_value()
-        bus_op.n_bits = bus_width * 8
-        # TODO: Support byte enable
-        bus_op.byte_en = (1 << bus_width) - 1
+        bus_op.n_bits = min(reg.get_n_bits(), bus_width * 8)
+        bus_op.status = rw.get_status()
+        if adapter.supports_byte_enable:
+            byte_offset = int(byte_offset)
+            available_bytes = max(bus_width - byte_offset, 0)
+            enabled_bytes = min(ceildiv(bus_op.n_bits, 8), available_bytes)
+            bus_op.byte_en = ((1 << enabled_bytes) - 1) << byte_offset
+        else:
+            bus_op.byte_en = -1
+        return bus_op
+
+    async def _send_bus_op(
+        self,
+        rw: uvm_reg_item,
+        bus_op: uvm_reg_bus_op,
+        sequencer: uvm_sequencer_base,
+        adapter: uvm_reg_adapter,
+    ) -> None:
+        sequence = self._get_bus_sequence(rw, adapter)
         adapter.set_item(rw)
-        bus_seq_item = adapter.reg2bus(bus_op)
-        adapter.set_item(None)
-        sequence: uvm_sequence = adapter.parent_sequence
+        try:
+            bus_seq_item = adapter.reg2bus(bus_op)
+        finally:
+            adapter.set_item(None)
+        if bus_seq_item is None:
+            raise UVMFatalError(
+                f"Adapter {repr(adapter.get_full_name())} reg2bus() returned None"
+            )
+
         sequence.sequencer = sequencer
         await sequence.start_item(bus_seq_item)
         await sequence.finish_item(bus_seq_item)
-        adapter.bus2reg(bus_seq_item, bus_op)
+
+        bus_rsp_item = bus_seq_item
+        if adapter.provides_responses:
+            bus_rsp_item = await sequence.get_response()
+            if bus_rsp_item is None:
+                raise UVMFatalError(
+                    f"Adapter {repr(adapter.get_full_name())} expects bus "
+                    "responses, but the sequencer returned None"
+                )
+
+        adapter.bus2reg(bus_rsp_item, bus_op)
         rw.set_value(bus_op.data)
         rw.set_status(bus_op.status)
+
+    async def do_bus_write(
+        self, rw: uvm_reg_item, sequencer: uvm_sequencer_base, adapter: uvm_reg_adapter
+    ) -> None:
+        bus_op = self._make_bus_op(rw, uvm_access_e.UVM_WRITE, adapter)
+        await self._send_bus_op(rw, bus_op, sequencer, adapter)
 
     async def do_bus_read(
         self, rw: uvm_reg_item, sequencer: uvm_sequencer_base, adapter: uvm_reg_adapter
     ) -> None:
-        reg = rw.get_element()
-        bus_width, addrs, _ = self._get_physical_addresses_to_map(
-            self._regs_info[reg].offset, 0x0, reg.get_n_bytes(), None, None
-        )
-        bus_op = uvm_reg_bus_op()
-        bus_op.kind = uvm_access_e.UVM_READ
-        bus_op.addr = addrs[0]
-        bus_op.data = rw.get_value()
-        bus_op.n_bits = bus_width * 8
-        bus_op.byte_en = (1 << bus_width) - 1
-        adapter.set_item(rw)
-        bus_seq_item = adapter.reg2bus(bus_op)
-        adapter.set_item(None)
-        sequence: uvm_sequence = adapter.parent_sequence
-        sequence.sequencer = sequencer
-        await sequence.start_item(bus_seq_item)
-        await sequence.finish_item(bus_seq_item)
-        adapter.bus2reg(bus_seq_item, bus_op)
-        rw.set_value(bus_op.data)
-        rw.set_status(bus_op.status)
+        bus_op = self._make_bus_op(rw, uvm_access_e.UVM_READ, adapter)
+        await self._send_bus_op(rw, bus_op, sequencer, adapter)
 
     async def do_write(self, rw: uvm_reg_item) -> None:
-        system_map = self.get_root_map()
-        adapter = system_map.get_adapter()
-        sequencer = system_map.get_sequencer()
-        # TODO: See official UVM implementation for special cases
-        if adapter and adapter.parent_sequence:
-            rw.set_parent_sequence(adapter.parent_sequence)
-        else:
-            base_seq = uvm_sequence("base_seq")
-            rw.set_parent_sequence(base_seq)
-            adapter.parent_sequence = base_seq
-        # if not rw.get_parent_sequence():
-        #     raise NotImplementedError
-        if not adapter:
-            raise NotImplementedError
+        sequencer, adapter = self._get_bus_access_config(rw)
         await self.do_bus_write(rw, sequencer, adapter)
 
     async def do_read(self, rw: uvm_reg_item) -> None:
-        system_map = self.get_root_map()
-        adapter = system_map.get_adapter()
-        sequencer = system_map.get_sequencer()
-        # TODO: See official UVM implementation for special cases
-        if adapter and adapter.parent_sequence:
-            rw.set_parent_sequence(adapter.parent_sequence)
-        else:
-            base_seq = uvm_sequence("base_seq")
-            rw.set_parent_sequence(base_seq)
-            adapter.parent_sequence = base_seq
-        # if not rw.get_parent_sequence():
-        #     raise NotImplementedError
-        if not adapter:
-            raise NotImplementedError
+        sequencer, adapter = self._get_bus_access_config(rw)
         await self.do_bus_read(rw, sequencer, adapter)
 
     def _get_bus_info(self, rw: uvm_reg_item) -> tuple[uvm_reg_map_info, int, int, int]:

--- a/pyuvm/_reg/uvm_reg_sequence.py
+++ b/pyuvm/_reg/uvm_reg_sequence.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import logging
-
-try:
-    from cocotb.triggers import Lock
-except ModuleNotFoundError:
-    from asyncio import Semaphore as Lock
-
 from typing import TYPE_CHECKING
+
+from cocotb.triggers import Lock
 
 from pyuvm._reg.uvm_reg_model import (
     uvm_check_e,

--- a/tests/pytests/reg/async_helpers.py
+++ b/tests/pytests/reg/async_helpers.py
@@ -1,0 +1,10 @@
+import asyncio
+
+
+def run_pytest_coro(coro):
+    """Run an isolated Python coroutine from a pure pytest unit test.
+
+    cocotb tests run on the cocotb scheduler. These RAL unit tests use local
+    fakes and no simulator triggers, so asyncio is only the pytest harness.
+    """
+    return asyncio.run(coro)

--- a/tests/pytests/reg/test_uvm_reg_core_api.py
+++ b/tests/pytests/reg/test_uvm_reg_core_api.py
@@ -1,0 +1,322 @@
+import asyncio
+import io
+import logging
+
+import pytest
+
+from pyuvm._reg.uvm_reg import uvm_reg
+from pyuvm._reg.uvm_reg_backdoor import uvm_reg_backdoor
+from pyuvm._reg.uvm_reg_block import uvm_reg_block
+from pyuvm._reg.uvm_reg_field import uvm_reg_field
+from pyuvm._reg.uvm_reg_item import uvm_reg_item
+from pyuvm._reg.uvm_reg_model import (
+    uvm_access_e,
+    uvm_check_e,
+    uvm_door_e,
+    uvm_endianness_e,
+    uvm_predict_e,
+    uvm_status_e,
+)
+from pyuvm.uvm_reporting import set_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting.uvm_report_server import uvm_report_server
+
+
+class AsyncNoopLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def locked(self):
+        return False
+
+    def release(self):
+        pass
+
+
+class CoreApiReg(uvm_reg):
+    def __init__(self, name="core_api_reg"):
+        super().__init__(name, 16)
+        self.low = uvm_reg_field("low")
+        self.high = uvm_reg_field("high")
+        self.low.configure(self, 8, 0, "RW", False, 0x12, True, False, False)
+        self.high.configure(self, 8, 8, "RW", False, 0x34, True, False, False)
+
+
+class SpyReg(CoreApiReg):
+    def __init__(self, name="spy_reg"):
+        super().__init__(name)
+        self.write_items = []
+        self.read_items = []
+        self.read_value = 0
+        self.next_status = uvm_status_e.UVM_IS_OK
+
+    async def do_write(self, rw):
+        self.write_items.append(rw)
+        rw.set_value(rw.get_value() & self.get_mask())
+        rw.set_status(self.next_status)
+        if rw.get_status() != uvm_status_e.UVM_NOT_OK:
+            self.do_predict(rw, uvm_predict_e.UVM_PREDICT_WRITE)
+
+    async def do_read(self, rw):
+        self.read_items.append(rw)
+        rw.set_value(self.read_value)
+        rw.set_status(self.next_status)
+
+
+def build_reg(reg=None):
+    block = uvm_reg_block("core_api_block")
+    reg_map = block.create_map(
+        "csr", 0x100, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    reg = reg or CoreApiReg()
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x20, "RW")
+    block.lock_model()
+    reg._atomic = AsyncNoopLock()
+    return block, reg_map, reg
+
+
+def test_register_helpers_reset_and_needs_update():
+    _, reg_map, reg = build_reg()
+
+    assert reg.get_field_by_name("low") is reg.low
+    assert reg.get_field_by_name("missing") is None
+    assert reg.get_offset() == 0x20
+    assert reg.get_offset(reg_map) == 0x20
+    assert reg.get_mask() == 0xFFFF
+
+    assert reg.get_reset() == 0x3412
+    reg.reset()
+    assert reg.get_mirrored_value() == 0x3412
+    assert not reg.needs_update()
+
+    reg.low.set(0x13)
+    assert reg.needs_update()
+
+    reg.set_reset(0xABCD, "SOFT")
+    assert reg.get_reset("SOFT") == 0xABCD
+    assert reg.has_reset("SOFT")
+    assert reg.has_reset("SOFT", delete=True)
+    assert not reg.has_reset("SOFT")
+
+
+def test_update_writes_desired_value_only_when_needed():
+    _, reg_map, reg = build_reg(SpyReg())
+    reg.reset()
+
+    status = asyncio.run(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert reg.write_items == []
+
+    reg.set(0x5678)
+    status = asyncio.run(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert len(reg.write_items) == 1
+    rw = reg.write_items[0]
+    assert rw.get_kind() == uvm_access_e.UVM_WRITE
+    assert rw.get_door() == uvm_door_e.UVM_FRONTDOOR
+    assert rw.get_map() is reg_map
+    assert rw.get_value() == 0x5678
+    assert reg.get_mirrored_value() == 0x5678
+    assert not reg.needs_update()
+
+
+def test_mirror_reads_predicts_and_compares(caplog):
+    _, reg_map, reg = build_reg(SpyReg())
+    reg.reset()
+    reg.read_value = 0x4567
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        status = asyncio.run(
+            reg.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
+        )
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert "does not match mirrored value" in caplog.text
+    assert reg.get_mirrored_value() == 0x4567
+    assert len(reg.read_items) == 1
+    assert reg.read_items[0].get_kind() == uvm_access_e.UVM_READ
+    assert reg.read_items[0].get_door() == uvm_door_e.UVM_FRONTDOOR
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        status = asyncio.run(
+            reg.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
+        )
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert "does not match mirrored value" not in caplog.text
+
+
+def test_do_check_uses_field_compare_mask(caplog):
+    _, _, reg = build_reg()
+    reg.reset()
+    reg.high.set_compare(uvm_check_e.UVM_NO_CHECK)
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        assert reg.do_check(0x3412, 0xAB12, None)
+
+    assert "does not match mirrored value" not in caplog.text
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        assert not reg.do_check(0x3412, 0x3413, None)
+
+    assert "does not match mirrored value" in caplog.text
+
+    caplog.clear()
+    reg.low.set_volatility(True)
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        assert reg.do_check(0x3412, 0x3413, None)
+
+    assert "does not match mirrored value" not in caplog.text
+
+
+def test_peek_and_poke_use_backdoor_items_and_predict():
+    _, _, reg = build_reg(SpyReg())
+    reg.reset()
+
+    status = asyncio.run(reg.poke(0x1A2B3, kind="RTL"))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert reg.write_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
+    assert reg.write_items[-1].get_bd_kind() == "RTL"
+    assert reg.write_items[-1].get_value() == 0xA2B3
+    assert reg.get_mirrored_value() == 0xA2B3
+
+    reg.read_value = 0x15555
+    status, value = asyncio.run(reg.peek(kind="RTL"))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert value == 0x5555
+    assert reg.read_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
+    assert reg.read_items[-1].get_bd_kind() == "RTL"
+    assert reg.get_mirrored_value() == 0x5555
+
+
+def test_frontdoor_and_backdoor_setters_getters():
+    block, reg_map, reg = build_reg()
+    frontdoor = object()
+    block_backdoor = uvm_reg_backdoor("block_bkdr")
+    reg_backdoor = uvm_reg_backdoor("reg_bkdr")
+
+    reg.set_frontdoor(frontdoor, reg_map)
+    block.set_backdoor(block_backdoor, fname="block.sv", lineno=42)
+
+    assert reg.get_frontdoor(reg_map) is frontdoor
+    assert reg.get_frontdoor() is frontdoor
+    assert block.get_backdoor() is block_backdoor
+    assert block_backdoor.fname == "block.sv"
+    assert block_backdoor.lineno == 42
+    assert reg.get_backdoor(inherited=False) is None
+    assert reg.get_backdoor() is block_backdoor
+
+    reg.set_backdoor(reg_backdoor, fname="reg.sv", lineno=84)
+
+    assert reg.get_backdoor() is reg_backdoor
+    assert reg.get_backdoor(inherited=False) is reg_backdoor
+    assert reg_backdoor.fname == "reg.sv"
+    assert reg_backdoor.lineno == 84
+
+
+def test_unimplemented_hooks_raise():
+    block, _, reg = build_reg()
+    item = uvm_reg_item()
+    backdoor = uvm_reg_backdoor("bkdr")
+
+    with pytest.raises(NotImplementedError):
+        reg.sample(0, 0, False, None)
+    with pytest.raises(NotImplementedError):
+        reg.sample_values()
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.pre_write(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.post_write(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.pre_read(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.post_read(item))
+
+    with pytest.raises(NotImplementedError):
+        reg.low.pre_randomize()
+    with pytest.raises(NotImplementedError):
+        reg.low.post_randomize()
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.low.pre_write(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.low.post_write(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.low.pre_read(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(reg.low.post_read(item))
+
+    with pytest.raises(NotImplementedError):
+        block.sample(0, False, None)
+    with pytest.raises(NotImplementedError):
+        block._sample(0, False, None)
+    with pytest.raises(NotImplementedError):
+        block.sample_values()
+
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.do_pre_read(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.do_post_read(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.do_pre_write(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.do_post_write(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.pre_read(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.post_read(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.pre_write(item))
+    with pytest.raises(NotImplementedError):
+        asyncio.run(backdoor.post_write(item))
+
+    assert not backdoor.is_auto_updated(reg.low)
+
+
+def test_new_diagnostics_use_sv_uvm_reporting_when_enabled():
+    root_logger = logging.getLogger("uvm")
+    old_level = root_logger.level
+    old_propagate = root_logger.propagate
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.NOTSET)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+
+    set_sv_uvm_style_reporting_enabled(True)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.propagate = False
+    manager = uvm_report_server.create(root_logger=root_logger)
+
+    try:
+        _, reg_map, reg = build_reg(SpyReg())
+        assert reg.get_field_by_name("missing") is None
+
+        reg.reset()
+        reg.read_value = 0x4567
+        status = asyncio.run(
+            reg.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
+        )
+
+        assert status == uvm_status_e.UVM_IS_OK
+        output = stream.getvalue()
+        assert "[REG_FIELD_LOOKUP] Unable to locate field 'missing'" in output
+        assert "[REG_COMPARE] Register 'core_api_block.spy_reg'" in output
+        assert manager.get_stats().warning_count == 1
+        assert manager.get_stats().error_count == 1
+    finally:
+        manager.shutdown()
+        manager.clear_counts()
+        manager.catcher.clear()
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(old_level)
+        root_logger.propagate = old_propagate
+        set_sv_uvm_style_reporting_enabled(False)

--- a/tests/pytests/reg/test_uvm_reg_core_api.py
+++ b/tests/pytests/reg/test_uvm_reg_core_api.py
@@ -1,9 +1,10 @@
-import asyncio
 import io
 import logging
 
 import pytest
+from async_helpers import run_pytest_coro
 
+from pyuvm._error_classes import UVMFatalError
 from pyuvm._reg.uvm_reg import uvm_reg
 from pyuvm._reg.uvm_reg_backdoor import uvm_reg_backdoor
 from pyuvm._reg.uvm_reg_block import uvm_reg_block
@@ -102,17 +103,38 @@ def test_register_helpers_reset_and_needs_update():
     assert not reg.has_reset("SOFT")
 
 
+def test_unmapped_register_helpers_raise_for_invalid_offsets():
+    loose_reg = CoreApiReg("loose")
+
+    with pytest.raises(UVMFatalError, match="not mapped"):
+        loose_reg.get_offset()
+    assert loose_reg.get_frontdoor() is None
+    loose_reg.set_frontdoor(object())
+
+    block = uvm_reg_block("unmapped_block")
+    reg_map = block.create_map("csr", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True)
+    mapped_without_info = CoreApiReg("mapped_without_info")
+    mapped_without_info.configure(block)
+    mapped_without_info.add_map(reg_map)
+
+    with pytest.raises(UVMFatalError, match="no map info"):
+        mapped_without_info.get_offset(reg_map)
+    assert mapped_without_info.get_frontdoor(reg_map) is None
+    mapped_without_info.set_frontdoor(object(), reg_map)
+    assert mapped_without_info.get_frontdoor(reg_map) is None
+
+
 def test_update_writes_desired_value_only_when_needed():
     _, reg_map, reg = build_reg(SpyReg())
     reg.reset()
 
-    status = asyncio.run(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status = run_pytest_coro(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert reg.write_items == []
 
     reg.set(0x5678)
-    status = asyncio.run(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status = run_pytest_coro(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert len(reg.write_items) == 1
@@ -131,7 +153,7 @@ def test_mirror_reads_predicts_and_compares(caplog):
     reg.read_value = 0x4567
 
     with caplog.at_level(logging.ERROR, logger="RegModel"):
-        status = asyncio.run(
+        status = run_pytest_coro(
             reg.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
         )
 
@@ -144,12 +166,40 @@ def test_mirror_reads_predicts_and_compares(caplog):
 
     caplog.clear()
     with caplog.at_level(logging.ERROR, logger="RegModel"):
-        status = asyncio.run(
+        status = run_pytest_coro(
             reg.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
         )
 
     assert status == uvm_status_e.UVM_IS_OK
     assert "does not match mirrored value" not in caplog.text
+
+
+def test_mirror_handles_not_ok_status_and_default_doors():
+    _, reg_map, reg = build_reg(SpyReg())
+    reg.reset()
+    reg.next_status = uvm_status_e.UVM_NOT_OK
+
+    status = run_pytest_coro(
+        reg.mirror(uvm_check_e.UVM_NO_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+
+    reg.next_status = uvm_status_e.UVM_IS_OK
+    reg.read_value = 0x1234
+    status = run_pytest_coro(reg.mirror(uvm_check_e.UVM_NO_CHECK))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert reg.get_mirrored_value() == 0x1234
+
+    loose_reg = SpyReg("loose_mirror")
+    loose_reg._atomic = AsyncNoopLock()
+    loose_reg.read_value = 0x4321
+
+    status = run_pytest_coro(loose_reg.mirror(uvm_check_e.UVM_NO_CHECK))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert loose_reg.get_mirrored_value() == 0x4321
 
 
 def test_do_check_uses_field_compare_mask(caplog):
@@ -180,7 +230,7 @@ def test_peek_and_poke_use_backdoor_items_and_predict():
     _, _, reg = build_reg(SpyReg())
     reg.reset()
 
-    status = asyncio.run(reg.poke(0x1A2B3, kind="RTL"))
+    status = run_pytest_coro(reg.poke(0x1A2B3, kind="RTL"))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert reg.write_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
@@ -189,12 +239,23 @@ def test_peek_and_poke_use_backdoor_items_and_predict():
     assert reg.get_mirrored_value() == 0xA2B3
 
     reg.read_value = 0x15555
-    status, value = asyncio.run(reg.peek(kind="RTL"))
+    status, value = run_pytest_coro(reg.peek(kind="RTL"))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert value == 0x5555
     assert reg.read_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
     assert reg.read_items[-1].get_bd_kind() == "RTL"
+    assert reg.get_mirrored_value() == 0x5555
+
+    reg.next_status = uvm_status_e.UVM_NOT_OK
+    status = run_pytest_coro(reg.poke(0xAAAA, kind="RTL"))
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert reg.get_mirrored_value() == 0x5555
+
+    reg.read_value = 0xBBBB
+    status, value = run_pytest_coro(reg.peek(kind="RTL"))
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert value == 0xBBBB
     assert reg.get_mirrored_value() == 0x5555
 
 
@@ -203,6 +264,8 @@ def test_frontdoor_and_backdoor_setters_getters():
     frontdoor = object()
     block_backdoor = uvm_reg_backdoor("block_bkdr")
     reg_backdoor = uvm_reg_backdoor("reg_bkdr")
+    child = uvm_reg_block("child")
+    child.configure(block)
 
     reg.set_frontdoor(frontdoor, reg_map)
     block.set_backdoor(block_backdoor, fname="block.sv", lineno=42)
@@ -212,6 +275,8 @@ def test_frontdoor_and_backdoor_setters_getters():
     assert block.get_backdoor() is block_backdoor
     assert block_backdoor.fname == "block.sv"
     assert block_backdoor.lineno == 42
+    assert child.get_backdoor(inherited=False) is None
+    assert child.get_backdoor() is block_backdoor
     assert reg.get_backdoor(inherited=False) is None
     assert reg.get_backdoor() is block_backdoor
 
@@ -221,6 +286,42 @@ def test_frontdoor_and_backdoor_setters_getters():
     assert reg.get_backdoor(inherited=False) is reg_backdoor
     assert reg_backdoor.fname == "reg.sv"
     assert reg_backdoor.lineno == 84
+
+    reg.set_backdoor(None)
+    block.set_backdoor(None)
+
+    assert reg.get_backdoor(inherited=False) is None
+    assert block.get_backdoor() is None
+    assert uvm_reg_block("root_without_backdoor").get_backdoor() is None
+
+
+def test_wait_for_lock_returns_when_model_is_already_locked():
+    block = uvm_reg_block("locked_block")
+
+    block.lock_model()
+
+    assert run_pytest_coro(block.wait_for_lock()) is None
+
+
+def test_wait_for_lock_awaits_completion_event_when_unlocked():
+    class AsyncEvent:
+        def __init__(self):
+            self.waited = False
+            self.cleared = False
+
+        async def wait(self):
+            self.waited = True
+
+        def clear(self):
+            self.cleared = True
+
+    block = uvm_reg_block("unlocked_block")
+    event = AsyncEvent()
+    block._lock_model_complete = event
+
+    assert run_pytest_coro(block.wait_for_lock()) is None
+    assert event.waited
+    assert event.cleared
 
 
 def test_unimplemented_hooks_raise():
@@ -233,26 +334,26 @@ def test_unimplemented_hooks_raise():
     with pytest.raises(NotImplementedError):
         reg.sample_values()
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.pre_write(item))
+        run_pytest_coro(reg.pre_write(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.post_write(item))
+        run_pytest_coro(reg.post_write(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.pre_read(item))
+        run_pytest_coro(reg.pre_read(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.post_read(item))
+        run_pytest_coro(reg.post_read(item))
 
     with pytest.raises(NotImplementedError):
         reg.low.pre_randomize()
     with pytest.raises(NotImplementedError):
         reg.low.post_randomize()
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.low.pre_write(item))
+        run_pytest_coro(reg.low.pre_write(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.low.post_write(item))
+        run_pytest_coro(reg.low.post_write(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.low.pre_read(item))
+        run_pytest_coro(reg.low.pre_read(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(reg.low.post_read(item))
+        run_pytest_coro(reg.low.post_read(item))
 
     with pytest.raises(NotImplementedError):
         block.sample(0, False, None)
@@ -262,21 +363,21 @@ def test_unimplemented_hooks_raise():
         block.sample_values()
 
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.do_pre_read(item))
+        run_pytest_coro(backdoor.do_pre_read(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.do_post_read(item))
+        run_pytest_coro(backdoor.do_post_read(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.do_pre_write(item))
+        run_pytest_coro(backdoor.do_pre_write(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.do_post_write(item))
+        run_pytest_coro(backdoor.do_post_write(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.pre_read(item))
+        run_pytest_coro(backdoor.pre_read(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.post_read(item))
+        run_pytest_coro(backdoor.post_read(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.pre_write(item))
+        run_pytest_coro(backdoor.pre_write(item))
     with pytest.raises(NotImplementedError):
-        asyncio.run(backdoor.post_write(item))
+        run_pytest_coro(backdoor.post_write(item))
 
     assert not backdoor.is_auto_updated(reg.low)
 
@@ -302,7 +403,7 @@ def test_new_diagnostics_use_sv_uvm_reporting_when_enabled():
 
         reg.reset()
         reg.read_value = 0x4567
-        status = asyncio.run(
+        status = run_pytest_coro(
             reg.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
         )
 

--- a/tests/pytests/reg/test_uvm_reg_field_access.py
+++ b/tests/pytests/reg/test_uvm_reg_field_access.py
@@ -1,8 +1,8 @@
-import asyncio
 import itertools
 import logging
 
 import pytest
+from async_helpers import run_pytest_coro
 
 from pyuvm._reg.uvm_reg import uvm_reg
 from pyuvm._reg.uvm_reg_block import uvm_reg_block
@@ -66,6 +66,19 @@ class PolicyReg(uvm_reg):
         super().__init__(name, 4)
         self.field = uvm_reg_field("field")
         self.field.configure(self, 4, 0, access, False, reset, True, False, False)
+
+
+class MixedAccessReg(uvm_reg):
+    def __init__(self, name="mixed_access_reg"):
+        super().__init__(name, 12)
+        self.target = uvm_reg_field("target")
+        self.read_only = uvm_reg_field("read_only")
+        self.write_zero_clear = uvm_reg_field("write_zero_clear")
+        self.target.configure(self, 4, 0, "RW", False, 0, True, False, False)
+        self.read_only.configure(self, 4, 4, "RO", False, 0xA, True, False, False)
+        self.write_zero_clear.configure(
+            self, 4, 8, "W0C", False, 0x5, True, False, False
+        )
 
 
 class SpyPolicyReg(PolicyReg):
@@ -137,7 +150,7 @@ def test_field_write_preserves_sibling_fields_from_mirror():
     reg.reset()
     reg.high.set(0x77)
 
-    status = asyncio.run(reg.low.write(0x1AB, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status = run_pytest_coro(reg.low.write(0x1AB, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert len(reg.write_items) == 1
@@ -154,7 +167,7 @@ def test_field_read_delegates_to_parent_and_extracts_field_value():
     _, reg_map, reg = build_reg(SpyFieldAccessReg())
     reg.read_value = 0xABCD
 
-    status, value = asyncio.run(reg.high.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status, value = run_pytest_coro(reg.high.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert value == 0xAB
@@ -169,7 +182,7 @@ def test_field_poke_and_peek_use_parent_backdoor_path():
     reg.reset()
     reg.read_value = 0x1234
 
-    status = asyncio.run(reg.low.poke(0x1FE, kind="RTL"))
+    status = run_pytest_coro(reg.low.poke(0x1FE, kind="RTL"))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert reg.read_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
@@ -180,7 +193,7 @@ def test_field_poke_and_peek_use_parent_backdoor_path():
     assert reg.get_mirrored_value() == 0x12FE
 
     reg.read_value = 0xAB89
-    status, value = asyncio.run(reg.low.peek(kind="RTL"))
+    status, value = run_pytest_coro(reg.low.peek(kind="RTL"))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert value == 0x89
@@ -196,7 +209,7 @@ def test_field_mirror_reads_compares_and_predicts(caplog):
     reg.read_value = 0x12AA
 
     with caplog.at_level(logging.ERROR, logger="RegModel"):
-        status = asyncio.run(
+        status = run_pytest_coro(
             reg.low.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
         )
 
@@ -214,6 +227,41 @@ def test_field_set_masks_oversized_values():
 
     assert reg.low.get() == 0xAB
     assert reg.low.value == 0xAB
+
+
+def test_field_set_honors_one_shot_write_policy():
+    _, field = build_policy_field("W1", reset=0)
+
+    field.set(0x5)
+    assert field.get() == 0x5
+
+    field._written = True
+    field.set(0xA)
+    assert field.get() == 0x5
+
+
+def test_field_parent_write_value_applies_sibling_access_policies():
+    _, reg_map, reg = build_reg(MixedAccessReg())
+
+    assert reg.target._get_parent_write_value(0x3, reg_map) == 0xF03
+
+
+def test_field_poke_returns_parent_peek_error_without_write():
+    _, _, reg = build_reg(SpyFieldAccessReg())
+    reg.reset()
+    reg.next_status = uvm_status_e.UVM_NOT_OK
+
+    status = run_pytest_coro(reg.low.poke(0x12, kind="RTL"))
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert len(reg.read_items) == 1
+    assert reg.write_items == []
+
+
+def test_field_individual_accessibility_defaults_to_false():
+    _, reg_map, reg = build_reg()
+
+    assert not reg.low.is_indv_accessible(uvm_door_e.UVM_FRONTDOOR, reg_map)
 
 
 @pytest.mark.parametrize(
@@ -299,11 +347,32 @@ def test_field_update_value_matches_sv_xupdate(access, mirrored, desired, expect
     assert field._update() == expected
 
 
+def test_field_update_value_uses_desired_value_for_custom_policy():
+    access = f"CUSTOM_{next(_policy_ids)}"
+    assert uvm_reg_field.define_access(access)
+    _, field = build_policy_field(access, reset=0)
+    field._desired = 0xB
+
+    assert field.get_update_value() == 0xB
+
+
+def test_field_direct_prediction_fails_when_parent_is_busy():
+    _, _, reg = build_reg()
+
+    reg._set_is_busy(True)
+
+    assert not reg.low.predict(
+        0x44,
+        kind=uvm_predict_e.UVM_PREDICT_DIRECT,
+        path=uvm_door_e.UVM_FRONTDOOR,
+    )
+
+
 def test_register_update_uses_field_update_value_for_w1c():
     reg_map, reg = build_spy_policy_reg("W1C", reset=0xF)
 
     reg.field.set(0x3)
-    status = asyncio.run(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status = run_pytest_coro(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert reg.write_items[-1].get_value() == 0x3

--- a/tests/pytests/reg/test_uvm_reg_field_access.py
+++ b/tests/pytests/reg/test_uvm_reg_field_access.py
@@ -1,0 +1,314 @@
+import asyncio
+import itertools
+import logging
+
+import pytest
+
+from pyuvm._reg.uvm_reg import uvm_reg
+from pyuvm._reg.uvm_reg_block import uvm_reg_block
+from pyuvm._reg.uvm_reg_field import uvm_reg_field
+from pyuvm._reg.uvm_reg_model import (
+    uvm_access_e,
+    uvm_check_e,
+    uvm_door_e,
+    uvm_endianness_e,
+    uvm_predict_e,
+    uvm_status_e,
+)
+
+
+class AsyncNoopLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def locked(self):
+        return False
+
+    def release(self):
+        pass
+
+
+class FieldAccessReg(uvm_reg):
+    def __init__(self, name="field_access_reg"):
+        super().__init__(name, 16)
+        self.low = uvm_reg_field("low")
+        self.high = uvm_reg_field("high")
+        self.low.configure(self, 8, 0, "RW", False, 0x34, True, False, False)
+        self.high.configure(self, 8, 8, "RW", False, 0x12, True, False, False)
+
+
+class SpyFieldAccessReg(FieldAccessReg):
+    def __init__(self, name="field_access_reg"):
+        super().__init__(name)
+        self.write_items = []
+        self.read_items = []
+        self.read_value = 0
+        self.next_status = uvm_status_e.UVM_IS_OK
+
+    async def do_write(self, rw):
+        self.write_items.append(rw)
+        rw.set_value(rw.get_value() & self.get_mask())
+        rw.set_status(self.next_status)
+        if rw.get_status() != uvm_status_e.UVM_NOT_OK:
+            self.do_predict(rw, uvm_predict_e.UVM_PREDICT_WRITE)
+
+    async def do_read(self, rw):
+        self.read_items.append(rw)
+        rw.set_value(self.read_value & self.get_mask())
+        rw.set_status(self.next_status)
+
+
+class PolicyReg(uvm_reg):
+    def __init__(self, name, access, reset):
+        super().__init__(name, 4)
+        self.field = uvm_reg_field("field")
+        self.field.configure(self, 4, 0, access, False, reset, True, False, False)
+
+
+class SpyPolicyReg(PolicyReg):
+    def __init__(self, name, access, reset):
+        super().__init__(name, access, reset)
+        self.write_items = []
+
+    async def do_write(self, rw):
+        self.write_items.append(rw)
+        rw.set_value(rw.get_value() & self.get_mask())
+        rw.set_status(uvm_status_e.UVM_IS_OK)
+        self.do_predict(rw, uvm_predict_e.UVM_PREDICT_WRITE)
+
+
+_policy_ids = itertools.count()
+
+
+def build_reg(reg=None):
+    block = uvm_reg_block("field_access_block")
+    reg_map = block.create_map(
+        "csr", 0x100, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    reg = reg or FieldAccessReg()
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x20, "RW")
+    block.lock_model()
+    reg._atomic = AsyncNoopLock()
+    return block, reg_map, reg
+
+
+def build_policy_field(access, reset=0xA):
+    idx = next(_policy_ids)
+    block = uvm_reg_block(f"policy_block_{idx}")
+    reg_map = block.create_map(
+        "csr", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    reg = PolicyReg(f"policy_reg_{idx}", access, reset)
+    reg.configure(block)
+    reg_map.add_reg(reg, 0, "RW")
+    block.lock_model()
+    reg.reset()
+    return reg_map, reg.field
+
+
+def build_spy_policy_reg(access, reset=0xA):
+    idx = next(_policy_ids)
+    block = uvm_reg_block(f"policy_block_{idx}")
+    reg_map = block.create_map(
+        "csr", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    reg = SpyPolicyReg(f"policy_reg_{idx}", access, reset)
+    reg.configure(block)
+    reg_map.add_reg(reg, 0, "RW")
+    block.lock_model()
+    reg._atomic = AsyncNoopLock()
+    reg.reset()
+    return reg_map, reg
+
+
+def test_field_mask_and_register_packing_helpers():
+    _, _, reg = build_reg()
+    high = reg.high
+
+    assert high.get_mask() == 0xFF
+    assert high.get_register_mask() == 0xFF00
+    assert high.extract_from_register(0xABCD) == 0xAB
+    assert high.insert_into_register(0x1234, 0xCD) == 0xCD34
+    assert high.insert_into_register(0x1234, 0x1AB) == 0xAB34
+
+
+def test_field_write_preserves_sibling_fields_from_mirror():
+    _, reg_map, reg = build_reg(SpyFieldAccessReg())
+    reg.reset()
+    reg.high.set(0x77)
+
+    status = asyncio.run(reg.low.write(0x1AB, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert len(reg.write_items) == 1
+    rw = reg.write_items[0]
+    assert rw.get_kind() == uvm_access_e.UVM_WRITE
+    assert rw.get_door() == uvm_door_e.UVM_FRONTDOOR
+    assert rw.get_map() is reg_map
+    assert rw.get_value() == 0x12AB
+    assert reg.low.get_mirrored_value() == 0xAB
+    assert reg.high.get_mirrored_value() == 0x12
+
+
+def test_field_read_delegates_to_parent_and_extracts_field_value():
+    _, reg_map, reg = build_reg(SpyFieldAccessReg())
+    reg.read_value = 0xABCD
+
+    status, value = asyncio.run(reg.high.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert value == 0xAB
+    assert len(reg.read_items) == 1
+    assert reg.read_items[0].get_kind() == uvm_access_e.UVM_READ
+    assert reg.read_items[0].get_door() == uvm_door_e.UVM_FRONTDOOR
+    assert reg.read_items[0].get_map() is reg_map
+
+
+def test_field_poke_and_peek_use_parent_backdoor_path():
+    _, _, reg = build_reg(SpyFieldAccessReg())
+    reg.reset()
+    reg.read_value = 0x1234
+
+    status = asyncio.run(reg.low.poke(0x1FE, kind="RTL"))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert reg.read_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
+    assert reg.read_items[-1].get_bd_kind() == "RTL"
+    assert reg.write_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
+    assert reg.write_items[-1].get_bd_kind() == "RTL"
+    assert reg.write_items[-1].get_value() == 0x12FE
+    assert reg.get_mirrored_value() == 0x12FE
+
+    reg.read_value = 0xAB89
+    status, value = asyncio.run(reg.low.peek(kind="RTL"))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert value == 0x89
+    assert reg.read_items[-1].get_door() == uvm_door_e.UVM_BACKDOOR
+    assert reg.read_items[-1].get_bd_kind() == "RTL"
+    assert reg.get_mirrored_value() == 0xAB89
+
+
+def test_field_mirror_reads_compares_and_predicts(caplog):
+    _, reg_map, reg = build_reg(SpyFieldAccessReg())
+    reg.reset()
+    reg.low.set_compare(uvm_check_e.UVM_CHECK)
+    reg.read_value = 0x12AA
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        status = asyncio.run(
+            reg.low.mirror(uvm_check_e.UVM_CHECK, uvm_door_e.UVM_FRONTDOOR, reg_map)
+        )
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert "Register 'field_access_block.field_access_reg'" in caplog.text
+    assert "does not match mirrored value" in caplog.text
+    assert reg.low.get_mirrored_value() == 0xAA
+    assert reg.high.get_mirrored_value() == 0x12
+
+
+def test_field_set_masks_oversized_values():
+    _, _, reg = build_reg()
+
+    reg.low.set(0x1AB)
+
+    assert reg.low.get() == 0xAB
+    assert reg.low.value == 0xAB
+
+
+@pytest.mark.parametrize(
+    "access",
+    ["W1C", "W1S", "W0C", "W0S", "W1T", "W0T", "RC", "RS"],
+)
+def test_field_direct_prediction_bypasses_access_policy(access):
+    reg_map, field = build_policy_field(access)
+
+    assert field.predict(
+        0x13,
+        kind=uvm_predict_e.UVM_PREDICT_DIRECT,
+        path=uvm_door_e.UVM_FRONTDOOR,
+        map=reg_map,
+    )
+    assert field.get_mirrored_value() == 0x3
+    assert field.get() == 0x3
+
+
+@pytest.mark.parametrize(
+    ("access", "write_value", "expected"),
+    [
+        ("W1C", 0x6, 0x8),
+        ("W1S", 0x5, 0xF),
+        ("W0C", 0x6, 0x2),
+        ("W0S", 0x6, 0xB),
+        ("W1T", 0x6, 0xC),
+        ("W0T", 0x6, 0x3),
+    ],
+)
+def test_field_write_prediction_applies_access_policy(access, write_value, expected):
+    reg_map, field = build_policy_field(access)
+
+    assert field.predict(
+        write_value,
+        kind=uvm_predict_e.UVM_PREDICT_WRITE,
+        path=uvm_door_e.UVM_FRONTDOOR,
+        map=reg_map,
+    )
+    assert field.get_mirrored_value() == expected
+    assert field.get() == expected
+
+
+@pytest.mark.parametrize(
+    ("access", "expected"),
+    [
+        ("RC", 0x0),
+        ("RS", 0xF),
+    ],
+)
+def test_field_read_prediction_applies_access_policy(access, expected):
+    reg_map, field = build_policy_field(access)
+
+    assert field.predict(
+        0x6,
+        kind=uvm_predict_e.UVM_PREDICT_READ,
+        path=uvm_door_e.UVM_FRONTDOOR,
+        map=reg_map,
+    )
+    assert field.get_mirrored_value() == expected
+    assert field.get() == expected
+
+
+@pytest.mark.parametrize(
+    ("access", "mirrored", "desired", "expected"),
+    [
+        ("RW", 0xA, 0x5, 0x5),
+        ("W1C", 0xF, 0xC, 0x3),
+        ("W1S", 0x0, 0x3, 0x3),
+        ("W1T", 0xA, 0x6, 0xC),
+        ("W0C", 0xF, 0xC, 0xC),
+        ("W0S", 0x0, 0x3, 0xC),
+        ("W0T", 0xA, 0x6, 0x3),
+        ("W1CRS", 0xF, 0xC, 0x3),
+        ("W0SRC", 0x0, 0x3, 0xC),
+    ],
+)
+def test_field_update_value_matches_sv_xupdate(access, mirrored, desired, expected):
+    _, field = build_policy_field(access, reset=mirrored)
+    field._desired = desired
+
+    assert field.get_update_value() == expected
+    assert field._update() == expected
+
+
+def test_register_update_uses_field_update_value_for_w1c():
+    reg_map, reg = build_spy_policy_reg("W1C", reset=0xF)
+
+    reg.field.set(0x3)
+    status = asyncio.run(reg.update(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert reg.write_items[-1].get_value() == 0x3
+    assert reg.field.get_mirrored_value() == 0xC

--- a/tests/pytests/reg/test_uvm_reg_field_access.py
+++ b/tests/pytests/reg/test_uvm_reg_field_access.py
@@ -99,9 +99,7 @@ def build_reg(reg=None):
 def build_policy_field(access, reset=0xA):
     idx = next(_policy_ids)
     block = uvm_reg_block(f"policy_block_{idx}")
-    reg_map = block.create_map(
-        "csr", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
-    )
+    reg_map = block.create_map("csr", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True)
     reg = PolicyReg(f"policy_reg_{idx}", access, reset)
     reg.configure(block)
     reg_map.add_reg(reg, 0, "RW")
@@ -113,9 +111,7 @@ def build_policy_field(access, reset=0xA):
 def build_spy_policy_reg(access, reset=0xA):
     idx = next(_policy_ids)
     block = uvm_reg_block(f"policy_block_{idx}")
-    reg_map = block.create_map(
-        "csr", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
-    )
+    reg_map = block.create_map("csr", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True)
     reg = SpyPolicyReg(f"policy_reg_{idx}", access, reset)
     reg.configure(block)
     reg_map.add_reg(reg, 0, "RW")

--- a/tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py
+++ b/tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py
@@ -1,7 +1,7 @@
-import asyncio
 from dataclasses import replace
 
 import pytest
+from async_helpers import run_pytest_coro
 
 from pyuvm._error_classes import UVMFatalError
 from pyuvm._reg.uvm_reg import uvm_reg
@@ -139,6 +139,39 @@ class RecordingAdapter(uvm_reg_adapter):
         rw.status = bus_item.status
 
 
+class NoneReg2BusAdapter(RecordingAdapter):
+    def reg2bus(self, rw):
+        self.reg2bus_ops.append(replace(rw))
+
+
+class InvalidParentSequence:
+    async def start_item(self, item):
+        pass
+
+
+class NoneResponseSequencer(MockSequencer):
+    async def get_response(self, txn_id=None):
+        self.response_txn_ids.append(txn_id)
+
+
+class SamplingBlock(uvm_reg_block):
+    def __init__(self, name="sampling_block"):
+        super().__init__(name)
+        self.samples = []
+
+    def sample(self, offset, is_read, map):
+        self.samples.append((offset, is_read, map))
+
+
+class SamplingReg(FrontdoorReg):
+    def __init__(self, name="sampling_reg"):
+        super().__init__(name)
+        self.samples = []
+
+    def sample(self, data, byte_en, is_read, map):
+        self.samples.append((data, byte_en, is_read, map))
+
+
 def build_model(adapter=None, sequencer=None, auto_predict=True):
     block = uvm_reg_block("phase4_block")
     reg_map = block.create_map(
@@ -161,10 +194,12 @@ def test_frontdoor_write_and_read_through_adapter():
     sequencer = MockSequencer(read_data=0xCAFE_BABE)
     _, reg_map, reg = build_model(adapter, sequencer)
 
-    write_status = asyncio.run(
+    write_status = run_pytest_coro(
         reg.write(0x1234_5678, uvm_door_e.UVM_FRONTDOOR, reg_map)
     )
-    read_status, read_data = asyncio.run(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+    read_status, read_data = run_pytest_coro(
+        reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
 
     assert write_status == uvm_status_e.UVM_IS_OK
     assert read_status == uvm_status_e.UVM_IS_OK
@@ -197,7 +232,7 @@ def test_frontdoor_status_controls_auto_prediction():
     sequencer = MockSequencer(write_status=uvm_status_e.UVM_NOT_OK)
     _, reg_map, reg = build_model(adapter, sequencer)
 
-    status = asyncio.run(reg.write(0x1111_2222, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status = run_pytest_coro(reg.write(0x1111_2222, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert reg.get_mirrored_value() == 0
@@ -208,7 +243,7 @@ def test_adapter_without_byte_enable_uses_all_bytes_sentinel():
     sequencer = MockSequencer()
     _, reg_map, reg = build_model(adapter, sequencer)
 
-    status = asyncio.run(reg.write(0xA5A5_A5A5, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status = run_pytest_coro(reg.write(0xA5A5_A5A5, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert adapter.reg2bus_ops[-1].byte_en == -1
@@ -221,7 +256,7 @@ def test_adapter_parent_sequence_and_responses_are_used():
     sequencer = MockSequencer(read_data=0x1357_9BDF, use_response=True)
     _, reg_map, reg = build_model(adapter, sequencer)
 
-    status, value = asyncio.run(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status, value = run_pytest_coro(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert value == 0x1357_9BDF
@@ -235,7 +270,7 @@ def test_map_creates_parent_sequence_when_adapter_does_not_supply_one():
     sequencer = MockSequencer()
     _, reg_map, reg = build_model(adapter, sequencer)
 
-    status = asyncio.run(reg.write(0x55AA_55AA, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    status = run_pytest_coro(reg.write(0x55AA_55AA, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_IS_OK
     assert adapter.parent_sequence is None
@@ -246,7 +281,7 @@ def test_missing_adapter_and_sequencer_raise_useful_errors():
     _, reg_map, reg = build_model()
 
     with pytest.raises(UVMFatalError, match="no adapter configured"):
-        asyncio.run(reg.write(0x1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+        run_pytest_coro(reg.write(0x1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     adapter = RecordingAdapter()
     _, reg_map, reg = build_model()
@@ -254,7 +289,72 @@ def test_missing_adapter_and_sequencer_raise_useful_errors():
         reg_map.set_adapter(adapter)
 
     with pytest.raises(UVMFatalError, match="no sequencer configured"):
-        asyncio.run(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+        run_pytest_coro(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+
+def test_adapter_parent_sequence_must_provide_bus_item_hooks():
+    adapter = RecordingAdapter()
+    adapter.parent_sequence = InvalidParentSequence()
+    sequencer = MockSequencer()
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    with pytest.raises(UVMFatalError, match="parent_sequence must"):
+        run_pytest_coro(reg.write(0x1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+
+def test_adapter_reg2bus_must_return_bus_item():
+    adapter = NoneReg2BusAdapter()
+    sequencer = MockSequencer()
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    with pytest.raises(UVMFatalError, match="reg2bus\\(\\) returned None"):
+        run_pytest_coro(reg.write(0x1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+
+def test_adapter_declared_response_must_return_response_item():
+    adapter = RecordingAdapter()
+    adapter.provides_responses = True
+    sequencer = NoneResponseSequencer()
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    with pytest.raises(UVMFatalError, match="sequencer returned None"):
+        run_pytest_coro(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+
+def test_frontdoor_auto_predict_samples_when_coverage_is_enabled():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    block = SamplingBlock()
+    reg_map = block.create_map(
+        "csr", 0x1000, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    reg = SamplingReg()
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x20, "RW")
+    block.lock_model()
+    reg._atomic = AsyncNoopLock()
+    reg.reset()
+    reg._cover_on = 1
+    reg_map.set_auto_predict(True)
+    reg_map.set_sequencer(sequencer, adapter)
+
+    status = run_pytest_coro(reg.write(0x1234_5678, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert reg.samples == [(0x1234_5678, -1, False, reg_map)]
+    assert block.samples == [(0x20, False, reg_map)]
+
+
+def test_frontdoor_read_checks_mirrored_value_when_enabled():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer(read_data=0)
+    _, reg_map, reg = build_model(adapter, sequencer)
+    reg_map.set_check_on_read(True)
+
+    status, value = run_pytest_coro(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert value == 0
 
 
 def test_legacy_response_spelling_updates_canonical_property():
@@ -262,4 +362,5 @@ def test_legacy_response_spelling_updates_canonical_property():
 
     adapter.provides_response = True
 
+    assert adapter.provides_response
     assert adapter.provides_responses

--- a/tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py
+++ b/tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py
@@ -1,0 +1,267 @@
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from pyuvm._error_classes import UVMFatalError
+from pyuvm._reg.uvm_reg import uvm_reg
+from pyuvm._reg.uvm_reg_adapter import uvm_reg_adapter
+from pyuvm._reg.uvm_reg_block import uvm_reg_block
+from pyuvm._reg.uvm_reg_field import uvm_reg_field
+from pyuvm._reg.uvm_reg_model import (
+    uvm_access_e,
+    uvm_door_e,
+    uvm_endianness_e,
+    uvm_status_e,
+)
+from pyuvm._s14_15_python_sequences import uvm_sequence, uvm_sequence_item
+
+
+class AsyncNoopLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def locked(self):
+        return False
+
+    def release(self):
+        pass
+
+
+class FrontdoorReg(uvm_reg):
+    def __init__(self, name="frontdoor_reg"):
+        super().__init__(name, 32)
+        self.data = uvm_reg_field("data")
+        self.data.configure(self, 32, 0, "RW", False, 0, True, False, False)
+
+
+class MockBusItem(uvm_sequence_item):
+    def __init__(
+        self,
+        name,
+        kind=None,
+        addr=0,
+        data=0,
+        n_bits=0,
+        byte_en=0,
+        status=uvm_status_e.UVM_IS_OK,
+    ):
+        super().__init__(name)
+        self.kind = kind
+        self.addr = addr
+        self.data = data
+        self.n_bits = n_bits
+        self.byte_en = byte_en
+        self.status = status
+
+
+class MockSequencer:
+    def __init__(
+        self,
+        read_data=0,
+        read_status=uvm_status_e.UVM_IS_OK,
+        write_status=uvm_status_e.UVM_IS_OK,
+        use_response=False,
+    ):
+        self.read_data = read_data
+        self.read_status = read_status
+        self.write_status = write_status
+        self.use_response = use_response
+        self.started = []
+        self.finished = []
+        self.responses = []
+        self.response_txn_ids = []
+
+    async def start_item(self, item):
+        self.started.append(item)
+
+    async def finish_item(self, item):
+        self.finished.append(item)
+        if item.kind == uvm_access_e.UVM_READ:
+            data = self.read_data
+            status = self.read_status
+        else:
+            data = item.data
+            status = self.write_status
+
+        if self.use_response:
+            self.responses.append(
+                MockBusItem(
+                    "bus_rsp",
+                    item.kind,
+                    item.addr,
+                    data,
+                    item.n_bits,
+                    item.byte_en,
+                    status,
+                )
+            )
+        else:
+            item.data = data
+            item.status = status
+
+    async def get_response(self, txn_id=None):
+        self.response_txn_ids.append(txn_id)
+        return self.responses.pop(0)
+
+
+class RecordingAdapter(uvm_reg_adapter):
+    def __init__(self, name="recording_adapter", supports_byte_enable=True):
+        super().__init__(name)
+        self.supports_byte_enable = supports_byte_enable
+        self.reg2bus_ops = []
+        self.reg2bus_parent_sequences = []
+        self.bus2reg_items = []
+
+    def reg2bus(self, rw):
+        self.reg2bus_ops.append(replace(rw))
+        self.reg2bus_parent_sequences.append(self.get_item().get_parent_sequence())
+        return MockBusItem(
+            "bus_req",
+            rw.kind,
+            rw.addr,
+            rw.data,
+            rw.n_bits,
+            rw.byte_en,
+            rw.status,
+        )
+
+    def bus2reg(self, bus_item, rw):
+        self.bus2reg_items.append(bus_item)
+        rw.kind = bus_item.kind
+        rw.addr = bus_item.addr
+        rw.data = bus_item.data
+        rw.n_bits = bus_item.n_bits
+        rw.byte_en = bus_item.byte_en
+        rw.status = bus_item.status
+
+
+def build_model(adapter=None, sequencer=None, auto_predict=True):
+    block = uvm_reg_block("phase4_block")
+    reg_map = block.create_map(
+        "csr", 0x1000, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    reg = FrontdoorReg()
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x20, "RW")
+    block.lock_model()
+    reg._atomic = AsyncNoopLock()
+    reg.reset()
+    reg_map.set_auto_predict(auto_predict)
+    if sequencer is not None:
+        reg_map.set_sequencer(sequencer, adapter)
+    return block, reg_map, reg
+
+
+def test_frontdoor_write_and_read_through_adapter():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer(read_data=0xCAFE_BABE)
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    write_status = asyncio.run(
+        reg.write(0x1234_5678, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+    read_status, read_data = asyncio.run(
+        reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert write_status == uvm_status_e.UVM_IS_OK
+    assert read_status == uvm_status_e.UVM_IS_OK
+    assert read_data == 0xCAFE_BABE
+
+    write_op, read_op = adapter.reg2bus_ops
+    assert write_op.kind == uvm_access_e.UVM_WRITE
+    assert write_op.addr == 0x1020
+    assert write_op.data == 0x1234_5678
+    assert write_op.n_bits == 32
+    assert write_op.byte_en == 0xF
+    assert write_op.status == uvm_status_e.UVM_IS_OK
+
+    assert read_op.kind == uvm_access_e.UVM_READ
+    assert read_op.addr == 0x1020
+    assert read_op.data == 0
+    assert read_op.n_bits == 32
+    assert read_op.byte_en == 0xF
+    assert read_op.status == uvm_status_e.UVM_IS_OK
+
+    assert [item.kind for item in sequencer.started] == [
+        uvm_access_e.UVM_WRITE,
+        uvm_access_e.UVM_READ,
+    ]
+    assert reg.get_mirrored_value() == 0xCAFE_BABE
+
+
+def test_frontdoor_status_controls_auto_prediction():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer(write_status=uvm_status_e.UVM_NOT_OK)
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    status = asyncio.run(reg.write(0x1111_2222, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert reg.get_mirrored_value() == 0
+
+
+def test_adapter_without_byte_enable_uses_all_bytes_sentinel():
+    adapter = RecordingAdapter(supports_byte_enable=False)
+    sequencer = MockSequencer()
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    status = asyncio.run(reg.write(0xA5A5_A5A5, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert adapter.reg2bus_ops[-1].byte_en == -1
+
+
+def test_adapter_parent_sequence_and_responses_are_used():
+    adapter = RecordingAdapter()
+    adapter.provides_responses = True
+    adapter.parent_sequence = uvm_sequence("adapter_parent_seq")
+    sequencer = MockSequencer(read_data=0x1357_9BDF, use_response=True)
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    status, value = asyncio.run(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert value == 0x1357_9BDF
+    assert adapter.reg2bus_parent_sequences[-1] is adapter.parent_sequence
+    assert adapter.bus2reg_items[-1].get_name() == "bus_rsp"
+    assert sequencer.response_txn_ids
+
+
+def test_map_creates_parent_sequence_when_adapter_does_not_supply_one():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    _, reg_map, reg = build_model(adapter, sequencer)
+
+    status = asyncio.run(reg.write(0x55AA_55AA, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert adapter.parent_sequence is None
+    assert adapter.reg2bus_parent_sequences[-1].get_name() == "base_seq"
+
+
+def test_missing_adapter_and_sequencer_raise_useful_errors():
+    _, reg_map, reg = build_model()
+
+    with pytest.raises(UVMFatalError, match="no adapter configured"):
+        asyncio.run(reg.write(0x1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    adapter = RecordingAdapter()
+    _, reg_map, reg = build_model()
+    with pytest.warns(DeprecationWarning):
+        reg_map.set_adapter(adapter)
+
+    with pytest.raises(UVMFatalError, match="no sequencer configured"):
+        asyncio.run(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+
+def test_legacy_response_spelling_updates_canonical_property():
+    adapter = RecordingAdapter()
+
+    adapter.provides_response = True
+
+    assert adapter.provides_responses

--- a/tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py
+++ b/tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py
@@ -164,9 +164,7 @@ def test_frontdoor_write_and_read_through_adapter():
     write_status = asyncio.run(
         reg.write(0x1234_5678, uvm_door_e.UVM_FRONTDOOR, reg_map)
     )
-    read_status, read_data = asyncio.run(
-        reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    read_status, read_data = asyncio.run(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert write_status == uvm_status_e.UVM_IS_OK
     assert read_status == uvm_status_e.UVM_IS_OK

--- a/tests/pytests/reg/test_uvm_reg_model_structure.py
+++ b/tests/pytests/reg/test_uvm_reg_model_structure.py
@@ -1,0 +1,141 @@
+import logging
+
+from pyuvm import (
+    uvm_endianness_e,
+    uvm_predict_e,
+    uvm_reg,
+    uvm_reg_block,
+    uvm_reg_field,
+)
+
+
+class BytePairReg(uvm_reg):
+    def __init__(self, name="byte_pair"):
+        super().__init__(name, 16)
+        self.high = uvm_reg_field("high")
+        self.low = uvm_reg_field("low")
+
+        # Configure out of order to prove the register stores fields by LSB.
+        self.high.configure(self, 8, 8, "RW", False, 0, True, False, False)
+        self.low.configure(self, 8, 0, "RW", False, 0, True, False, False)
+
+
+def make_block_with_map(name, base_addr=0):
+    block = uvm_reg_block(name)
+    reg_map = block.create_map(
+        "csr", base_addr, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    return block, reg_map
+
+
+def add_reg(block, reg_map, reg, offset, rights="RW"):
+    reg.configure(block)
+    reg_map.add_reg(reg, offset, rights)
+    return reg
+
+
+def test_block_map_construction_default_map_and_lock_model():
+    block = uvm_reg_block("reg_model_construct")
+    main_map = block.create_map(
+        "main", 0x1000, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    alias_map = block.create_map(
+        "alias", 0x2000, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+
+    assert block.get_maps() == [main_map, alias_map]
+    assert block.get_default_map() is main_map
+
+    block.set_default_map(alias_map)
+    assert block.get_default_map() is alias_map
+
+    control = BytePairReg("control")
+    control.configure(block)
+    main_map.add_reg(control, 0x10, "RW")
+    alias_map.add_reg(control, 0x4, "RO")
+
+    assert not block.is_locked()
+    block.lock_model()
+
+    assert block.is_locked()
+    assert control.get_default_map() is alias_map
+    assert control.get_address() == 0x2004
+    assert control.get_address(main_map) == 0x1010
+
+
+def test_map_add_reg_info_and_address_lookup_after_lock():
+    block, reg_map = make_block_with_map("reg_model_lookup", 0x80)
+    control = add_reg(block, reg_map, BytePairReg("control"), 0x0, "RW")
+    status = add_reg(block, reg_map, BytePairReg("status"), 0x8, "RO")
+
+    block.lock_model()
+
+    control_info = reg_map.get_reg_map_info(control)
+    status_info = reg_map.get_reg_map_info(status)
+
+    assert control_info.offset == 0x0
+    assert control_info.rights == "RW"
+    assert not control_info.unmapped
+    assert control_info.addr == [0x80]
+    assert control_info.is_initialized
+
+    assert status_info.offset == 0x8
+    assert status_info.rights == "RO"
+    assert status_info.addr == [0x88]
+
+    assert reg_map.get_reg_by_offset(0x80) is control
+    assert reg_map.get_reg_by_offset(0x88) is status
+    assert reg_map.get_reg_by_offset(0x84) is None
+
+    n_bytes, addresses = control.get_addresses(reg_map)
+    assert n_bytes == 4
+    assert addresses == [0x80]
+    assert control.get_address(reg_map) == 0x80
+
+
+def test_field_order_overlap_reporting_and_register_packing(caplog):
+    block, reg_map = make_block_with_map("reg_model_packing")
+    packed = add_reg(block, reg_map, BytePairReg("packed"), 0x0)
+    block.lock_model()
+
+    assert packed.get_fields() == [packed.low, packed.high]
+
+    packed.set(0xABCD)
+    assert packed.low.get() == 0xCD
+    assert packed.high.get() == 0xAB
+    assert packed.get() == 0xABCD
+
+    packed.low.set(0x12)
+    packed.high.set(0x34)
+    assert packed.get() == 0x3412
+
+    overlap = uvm_reg("overlap", 16)
+    first = uvm_reg_field("first")
+    second = uvm_reg_field("second")
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        first.configure(overlap, 8, 0, "RW", False, 0, True, False, False)
+        second.configure(overlap, 8, 4, "RW", False, 0, True, False, False)
+
+    assert "first overlaps field second in register overlap" in caplog.text
+    assert overlap.get_fields() == [first, second]
+
+
+def test_simple_rw_prediction_updates_field_and_register_mirrors():
+    block, reg_map = make_block_with_map("reg_model_prediction")
+    reg = add_reg(block, reg_map, BytePairReg("predictable"), 0x0)
+    block.lock_model()
+
+    reg.reset()
+    assert reg.get_mirrored_value() == 0
+
+    assert reg.predict(0xA55A, kind=uvm_predict_e.UVM_PREDICT_WRITE, map=reg_map)
+    assert reg.low.get_mirrored_value() == 0x5A
+    assert reg.high.get_mirrored_value() == 0xA5
+    assert reg.get_mirrored_value() == 0xA55A
+    assert reg.get() == 0xA55A
+
+    assert reg.predict(0x00FF, kind=uvm_predict_e.UVM_PREDICT_READ, map=reg_map)
+    assert reg.low.get_mirrored_value() == 0xFF
+    assert reg.high.get_mirrored_value() == 0x00
+    assert reg.get_mirrored_value() == 0x00FF

--- a/tests/pytests/reg/test_uvm_reg_model_structure.py
+++ b/tests/pytests/reg/test_uvm_reg_model_structure.py
@@ -1,5 +1,6 @@
-import asyncio
 import logging
+
+from async_helpers import run_pytest_coro
 
 from pyuvm import (
     uvm_endianness_e,
@@ -68,7 +69,7 @@ def test_block_construction_after_asyncio_run_clears_event_loop():
     async def noop():
         return None
 
-    asyncio.run(noop())
+    run_pytest_coro(noop())
 
     block = uvm_reg_block("reg_model_after_asyncio_run")
     block.lock_model()

--- a/tests/pytests/reg/test_uvm_reg_model_structure.py
+++ b/tests/pytests/reg/test_uvm_reg_model_structure.py
@@ -74,7 +74,7 @@ def test_block_construction_after_asyncio_run_clears_event_loop():
     block = uvm_reg_block("reg_model_after_asyncio_run")
     block.lock_model()
 
-    asyncio.run(block.wait_for_lock())
+    run_pytest_coro(block.wait_for_lock())
 
 
 def test_map_add_reg_info_and_address_lookup_after_lock():

--- a/tests/pytests/reg/test_uvm_reg_model_structure.py
+++ b/tests/pytests/reg/test_uvm_reg_model_structure.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from pyuvm import (
@@ -61,6 +62,18 @@ def test_block_map_construction_default_map_and_lock_model():
     assert control.get_default_map() is alias_map
     assert control.get_address() == 0x2004
     assert control.get_address(main_map) == 0x1010
+
+
+def test_block_construction_after_asyncio_run_clears_event_loop():
+    async def noop():
+        return None
+
+    asyncio.run(noop())
+
+    block = uvm_reg_block("reg_model_after_asyncio_run")
+    block.lock_model()
+
+    asyncio.run(block.wait_for_lock())
 
 
 def test_map_add_reg_info_and_address_lookup_after_lock():


### PR DESCRIPTION
# TL;DR

Implements the first four phases of the practical pyuvm RAL RFC: baseline register-model behavior tests, core `uvm_reg` APIs, field access helpers, and a working frontdoor register read/write path through `uvm_reg_map` and `uvm_reg_adapter`.

This makes simple pyuvm register models usable for construction, field packing, desired/mirrored/reset state, register update/mirror flows, field read/write delegation, and mock-adapter frontdoor access without hitting the previous core stubs.

# Summary

This PR adds the foundational RAL behavior needed before memory, full backdoor dispatch, register sequences/frontdoors, and predictor work can land.

It covers:

- register/block/map construction and address lookup behavior
- register field ordering, overlap reporting, packing, and prediction
- `uvm_reg` helpers for field lookup, offsets, masks, reset state, update, mirror, compare, peek/poke item flow, and frontdoor/backdoor setter/getter APIs
- `uvm_reg_field` helpers for masks, register insertion/extraction, direct field read/write, peek/poke, mirror, update values, and access-policy prediction
- register-map frontdoor read/write dispatch through a sequencer and adapter
- bus op propagation for kind, address, data, bit width, byte enables, and status
- auto-prediction only after successful frontdoor accesses
- useful fatal errors for missing adapter/sequencer setup
- canonical `provides_responses` adapter spelling, with `provides_response` kept as a compatibility property

# RFC Alignment

This follows the staged RAL direction from the RFC #399 

Covered in this PR (single commit per phase):

- Phase 1: lock down existing register model behavior
- Phase 2: complete practical core `uvm_reg` APIs
- Phase 3: complete practical `uvm_reg_field` access and packing helpers
- Phase 4: harden frontdoor register access through map and adapter

The intent is not to complete the entire IEEE register layer in one PR. This change establishes the tested register and adapter foundation that later RAL work can build on.

# Deliberate Scope Boundaries

This PR does not implement the remaining RAL phases:

- full base-class backdoor dispatch remains follow-on work
- `uvm_mem` construction, mapping, and memory access remain follow-on work (Should leverage what is done in #393)
- `uvm_reg_sequence` / `uvm_reg_frontdoor` usability remains follow-on work
- `uvm_reg_predictor` remains follow-on work
- HDL path behavior remains storage/introspection-oriented for now

`peek` and `poke` now create the correct register items and prediction flow, but concrete base backdoor read/write dispatch is still intentionally left for later where cocotb HDL integration is needed.

# Compatibility

The implementation keeps pyuvm's existing canonical enum style, including:

- `uvm_status_e`
- `uvm_door_e`
- `uvm_access_e`
- `uvm_predict_e`
- `uvm_check_e`

It does not add broad compatibility aliases for non-pyuvm enum naming schemes.

Existing deprecated register read/write argument handling is preserved. The adapter response-support spelling is normalized around `provides_responses`, while `provides_response` remains as a compatibility property.

# Implementation Notes

- `pyuvm/_reg/uvm_reg.py` now implements practical register helper APIs, reset aggregation, update/mirror behavior, compare masking, frontdoor/backdoor setter/getter behavior, and SV-UVM-style diagnostics for new register warnings/errors when that reporting mode is enabled.
- `pyuvm/_reg/uvm_reg_field.py` now implements field packing helpers, parent-register read/write delegation, field peek/poke delegation, access-policy prediction fixes, and update-value calculation.
- `pyuvm/_reg/uvm_reg_map.py` now centralizes adapter/sequencer validation, bus op creation, request/response handling, byte-enable behavior, and read/write dispatch.
- `pyuvm/_reg/uvm_reg_adapter.py` now initializes as a proper `uvm_object` and supports canonical plus legacy response-support spelling.
- `pyuvm/_reg/uvm_reg_block.py` and `pyuvm/_reg/uvm_reg_backdoor.py` now provide no-op hooks and basic backdoor storage needed by the practical register APIs.

# Tests Added

New focused RAL pytest coverage includes:

- `tests/pytests/reg/test_uvm_reg_model_structure.py`
- `tests/pytests/reg/test_uvm_reg_core_api.py`
- `tests/pytests/reg/test_uvm_reg_field_access.py`
- `tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py`

The tests cover construction, map locking, address lookup, field packing, reset/update/mirror behavior, compare masking, backdoor item flow, field read/write delegation, access-policy prediction, adapter bus op propagation, response handling, byte-enable behavior, auto-prediction, and missing adapter/sequencer diagnostics.

# Testing

```sh
~/.venv-3.12/bin/python -m pytest \
    tests/pytests/reg/test_uvm_reg_model_structure.py \
    tests/pytests/reg/test_uvm_reg_core_api.py \
    tests/pytests/reg/test_uvm_reg_field_access.py \
    tests/pytests/reg/test_uvm_reg_frontdoor_adapter.py