### PR TITLE
[pyral, core] Implement RAL memory mapping and frontdoor access

### DIFF
--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -40,6 +40,13 @@ __all__ = ["uvm_mem"]
 logger = logging.getLogger("RegModel")
 
 
+def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.warning(report_id, msg)
+    else:
+        logger.warning(msg)
+
+
 def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
     if get_sv_uvm_style_reporting_enabled():
         obj.uvm_report.error(report_id, msg)
@@ -179,15 +186,19 @@ class uvm_mem(uvm_object):
                 if parent_map == map:
                     return local_map
                 parent_map = parent_map.get_parent_map()
-        logger.warning(
+        _report_warning(
+            self,
+            "MEM_MAP_LOOKUP",
             f"Memory '{self.get_full_name()}' is not contained "
-            f"within map '{map.get_full_name()}'"
+            f"within map '{map.get_full_name()}'",
         )
 
     def get_default_map(self) -> uvm_reg_map | None:
         if not self._maps:
-            logger.warning(
-                f"Memory '{self.get_full_name()}' is not registered with any map"
+            _report_warning(
+                self,
+                "MEM_NO_MAP",
+                f"Memory '{self.get_full_name()}' is not registered with any map",
             )
             return
         if len(self._maps) == 1:
@@ -268,17 +279,21 @@ class uvm_mem(uvm_object):
         for vreg in self.get_virtual_registers():
             if vreg.get_name() == name:
                 return vreg
-        logger.warning(
+        _report_warning(
+            self,
+            "MEM_VREG_LOOKUP",
             f"Unable to find virtual register '{name}' in memory "
-            f"'{self.get_full_name()}'"
+            f"'{self.get_full_name()}'",
         )
 
     def get_vfield_by_name(self, name: str) -> uvm_vreg_field | None:
         for field in self.get_virtual_fields():
             if field.get_name() == name:
                 return field
-        logger.warning(
-            f"Unable to find virtual field '{name}' in memory '{self.get_full_name()}'"
+        _report_warning(
+            self,
+            "MEM_VFIELD_LOOKUP",
+            f"Unable to find virtual field '{name}' in memory '{self.get_full_name()}'",
         )
 
     def get_vreg_by_offset(
@@ -290,9 +305,11 @@ class uvm_mem(uvm_object):
         self, offset: uvm_reg_addr_t = 0, map: uvm_reg_map = None
     ) -> uvm_reg_addr_t:
         if offset < 0 or offset >= self._size:
-            logger.warning(
+            _report_warning(
+                self,
+                "MEM_OFFSET",
                 f"Offset 0x{offset:X} lies outside of memory "
-                f"'{self.get_name()}' which has size 0x{self._size:X}"
+                f"'{self.get_name()}' which has size 0x{self._size:X}",
             )
             return -1
         local_map = self.get_local_map(map)
@@ -307,33 +324,47 @@ class uvm_mem(uvm_object):
         self, offset: uvm_reg_addr_t = 0, map: uvm_reg_map = None
     ) -> uvm_reg_addr_t:
         _, addresses = self.get_addresses(offset, map)
-        return addresses[0]
+        # UVM address-introspection APIs use -1 as the recoverable failure
+        # sentinel when an offset is invalid or no mapped address is available.
+        # This is not an exception because a failed address query does not
+        # corrupt the model or prevent simulation from continuing; exceptions
+        # are reserved for fatal configuration and model-integrity failures.
+        return addresses[0] if addresses else -1
 
     def get_addresses(
         self,
         offset: uvm_reg_addr_t = 0,
         map: uvm_reg_map = None,
     ) -> tuple[int, list[uvm_reg_addr_t]]:
-        if offset >= self._size:
-            logger.warning(
+        if offset < 0 or offset >= self._size:
+            _report_warning(
+                self,
+                "MEM_OFFSET",
                 f"Offset 0x{offset:X} lies outside of memory "
-                f"'{self.get_name()}' which has size 0x{self._size:X}"
+                f"'{self.get_name()}' which has size 0x{self._size:X}",
             )
             return -1, list()
         local_map = self.get_local_map(map)
         if not local_map:
             map_name = "None" if not map else map.get_full_name()
-            logger.warning(f"Memory '{self.get_name()}' not found in map '{map_name}'")
+            _report_warning(
+                self,
+                "MEM_MAP_LOOKUP",
+                f"Memory '{self.get_name()}' not found in map '{map_name}'",
+            )
             return -1, list()
         map_info = local_map.get_mem_map_info(self)
         if map_info.unmapped:
             map_name = local_map.get_full_name() if not map else map.get_full_name()
-            logger.warning(
-                f"Memory '{self.get_name()}' is unmapped in map '{map_name}'"
+            _report_warning(
+                self,
+                "MEM_UNMAPPED",
+                f"Memory '{self.get_name()}' is unmapped in map '{map_name}'",
             )
             return -1, list()
         addresses = local_map._memory_element_addresses(self, map_info, offset)
-        return local_map.get_n_bytes(), addresses
+        bytes_per_access = min(self.get_n_bytes(), local_map.get_n_bytes())
+        return bytes_per_access, addresses
 
     async def write(
         self,

--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, ClassVar
 
+from cocotb.triggers import Lock
+
 from pyuvm._error_classes import UVMFatalError
+from pyuvm._reg.uvm_reg_item import uvm_reg_item
 from pyuvm._reg.uvm_reg_model import (
+    uvm_access_e,
     uvm_coverage_model_e,
     uvm_door_e,
+    uvm_elem_kind_e,
+    uvm_status_e,
 )
 from pyuvm._s05_base_classes import uvm_object
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_mem_mam import (
@@ -38,6 +45,13 @@ __all__ = ["uvm_mem"]
 logger = logging.getLogger("RegModel")
 
 
+def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.error(report_id, msg)
+    else:
+        logger.error(msg)
+
+
 class uvm_mem(uvm_object):
     _max_size: ClassVar[int] = 0
 
@@ -50,12 +64,36 @@ class uvm_mem(uvm_object):
         has_coverage: int = uvm_coverage_model_e.UVM_NO_COVERAGE,
     ) -> None:
         super().__init__(name)
+        self._parent = None
+        if size < 1:
+            _report_error(
+                self,
+                "MEM_SIZE",
+                f"Memory {repr(self.get_name())} cannot have fewer than 1 location",
+            )
+            size = 1
+        if n_bits < 1:
+            _report_error(
+                self,
+                "MEM_WIDTH",
+                f"Memory {repr(self.get_name())} cannot have fewer than 1 bit",
+            )
+            n_bits = 1
+        access = access.upper()
+        if access not in ("RW", "RO"):
+            _report_error(
+                self,
+                "MEM_ACCESS",
+                f"Memory {repr(self.get_name())} can only have 'RW' or 'RO' "
+                "access; using 'RW'",
+            )
+            access = "RW"
         self._locked: bool = False
         self._read_in_progress: bool = False
         self._write_in_progress: bool = False
+        self._atomic = Lock()
         self._access: str = access
         self._size: int = size
-        self._parent = None
         self._maps: list[uvm_reg_map] = list()
         self._n_bits: int = n_bits
         self._backdoor: uvm_reg_backdoor = None
@@ -67,37 +105,25 @@ class uvm_mem(uvm_object):
         self._vregs: list[uvm_vreg] = list()
         # self._hdl_paths_pool: uvm_object_string_pool = None
         self._mam: uvm_mem_mam = None
-        raise NotImplementedError
+        uvm_mem._max_size = max(uvm_mem._max_size, self._n_bits)
 
     def configure(self, parent: uvm_reg_block, hdl_path: str = "") -> None:
         if not parent:
             raise UVMFatalError("Configure: parent is None")
         self._parent = parent
-
-        if self._access not in ["RW", "RO"]:
-            logger.error(
-                f"Memory '{self.get_full_name()}' can only be 'RW' "
-                "and 'RO', setting access to 'RW'"
-            )
-            self._access = "RW"
-            cfg = uvm_mem_mam_cfg()
-            cfg.n_bytes = 0
-            cfg.start_offset = 0
-            cfg.end_offset = self._size - 1
-            cfg.mode = alloc_mode_e.GREEDY
-            cfg.locality = locality_e.BROAD
-            self.mam = uvm_mem_mam(self.get_full_name(), cfg, self)
-            self._parent.add_mem(self)
-            if hdl_path != "":
-                self.add_hdl_path_slice(hdl_path, -1, -1)
+        self._parent._add_memory(self)
+        # HDL paths and the memory allocation manager are intentionally
+        # deferred; basic frontdoor memory configuration must not create them.
 
     def set_offset(
         self, map: uvm_reg_map, offset: uvm_reg_addr_t, unmapped: bool = False
     ) -> None:
         if len(self._maps) > 1 and not map:
-            logger.error(
+            _report_error(
+                self,
+                "MEM_MAP_REQUIRED",
                 f"Set offset requires a map when memory "
-                f"'{self.get_full_name()}' belongs to more than one map"
+                f"'{self.get_full_name()}' belongs to more than one map",
             )
             return
         local_map = self.get_local_map(map)
@@ -111,7 +137,7 @@ class uvm_mem(uvm_object):
         self._maps.append(map)
 
     def _lock_model(self) -> None:
-        self._lock_model = True
+        self._locked = True
 
     def _add_vreg(self, vreg: uvm_vreg) -> None:
         raise NotImplementedError
@@ -181,9 +207,6 @@ class uvm_mem(uvm_object):
         return self._maps[0]
 
     def get_rights(self, map: uvm_reg_map = None) -> str:
-        # If memory is not shared
-        if len(self._maps) <= 1:
-            return "RW"
         local_map = self.get_local_map(map)
         if not local_map:
             return "RW"
@@ -191,8 +214,6 @@ class uvm_mem(uvm_object):
         return info.rights
 
     def get_access(self, map: uvm_reg_map = None) -> str:
-        if self.get_n_maps() == 1:
-            return self._access
         local_map = self.get_local_map(map)
         if not local_map:
             return self._access
@@ -206,14 +227,18 @@ class uvm_mem(uvm_object):
             if self._access in ["RW", "WO"]:
                 return "WO"
             elif self._access in ["RO"]:
-                logger.error(
+                _report_error(
+                    self,
+                    "MEM_RIGHTS",
                     f"RO memory '{self.get_full_name()}' restricted "
-                    f"to WO in map '{local_map.get_full_name()}'"
+                    f"to WO in map '{local_map.get_full_name()}'",
                 )
             else:
-                logger.error(
+                _report_error(
+                    self,
+                    "MEM_ACCESS",
                     f"Memory '{self.get_full_name()}' has invalid "
-                    f"access mode '{self._access}'"
+                    f"access mode '{self._access}'",
                 )
         return self._access
 
@@ -221,7 +246,7 @@ class uvm_mem(uvm_object):
         return self._size
 
     def get_n_bytes(self) -> int:
-        return int(self._n_bits - 1 / 8 + 1)
+        return (self._n_bits + 7) // 8
 
     def get_n_bits(self) -> int:
         return self._n_bits
@@ -269,7 +294,19 @@ class uvm_mem(uvm_object):
     def get_offset(
         self, offset: uvm_reg_addr_t = 0, map: uvm_reg_map = None
     ) -> uvm_reg_addr_t:
-        raise NotImplementedError
+        if offset < 0 or offset >= self._size:
+            logger.warning(
+                f"Offset 0x{offset:X} lies outside of memory "
+                f"'{self.get_name()}' which has size 0x{self._size:X}"
+            )
+            return -1
+        local_map = self.get_local_map(map)
+        if not local_map:
+            return -1
+        info = local_map.get_mem_map_info(self)
+        if info.unmapped:
+            return -1
+        return info.offset + offset * info.stride
 
     def get_address(
         self, offset: uvm_reg_addr_t = 0, map: uvm_reg_map = None
@@ -300,8 +337,7 @@ class uvm_mem(uvm_object):
                 f"Memory '{self.get_name()}' is unmapped in map '{map_name}'"
             )
             return -1, list()
-        stride = map_info.stride
-        addresses = [a + stride * offset for a in map_info.addr]
+        addresses = local_map._memory_element_addresses(self, map_info, offset)
         return local_map.get_n_bytes(), addresses
 
     async def write(
@@ -316,7 +352,22 @@ class uvm_mem(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        async with self._atomic:
+            rw = uvm_reg_item("mem_write_item")
+            rw.set_element(self)
+            rw.set_element_kind(uvm_elem_kind_e.UVM_MEM)
+            rw.set_kind(uvm_access_e.UVM_WRITE)
+            rw.set_offset(offset)
+            rw.set_value(value & ((1 << self._n_bits) - 1))
+            rw.set_door(path)
+            rw.set_map(map)
+            rw.set_parent_sequence(parent)
+            rw.set_priority(prior)
+            rw.set_extension(extension)
+            rw.set_fname(fname)
+            rw.set_line(lineno)
+            await self.do_write(rw)
+        return rw.get_status()
 
     async def read(
         self,
@@ -329,7 +380,22 @@ class uvm_mem(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        async with self._atomic:
+            rw = uvm_reg_item("mem_read_item")
+            rw.set_element(self)
+            rw.set_element_kind(uvm_elem_kind_e.UVM_MEM)
+            rw.set_kind(uvm_access_e.UVM_READ)
+            rw.set_offset(offset)
+            rw.set_value(0)
+            rw.set_door(path)
+            rw.set_map(map)
+            rw.set_parent_sequence(parent)
+            rw.set_priority(prior)
+            rw.set_extension(extension)
+            rw.set_fname(fname)
+            rw.set_line(lineno)
+            await self.do_read(rw)
+        return rw.get_status(), rw.get_value()
 
     async def burst_write(
         self,
@@ -383,13 +449,83 @@ class uvm_mem(uvm_object):
         raise NotImplementedError
 
     def _check_access(self, rw: uvm_reg_item) -> uvm_reg_map_info | None:
-        raise NotImplementedError
+        if rw.get_offset() < 0 or rw.get_offset() >= self._size:
+            _report_error(
+                self,
+                "MEM_BOUNDS",
+                f"Memory offset 0x{rw.get_offset():X} is outside "
+                f"{repr(self.get_full_name())}",
+            )
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return None
+        if rw.get_door() == uvm_door_e.UVM_DEFAULT_DOOR:
+            rw.set_door(self._parent.get_default_door())
+        if rw.get_door() != uvm_door_e.UVM_FRONTDOOR:
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return None
+        local_map = self.get_local_map(rw.get_map())
+        rw.set_local_map(local_map)
+        if local_map is None:
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return None
+        info = local_map.get_mem_map_info(self)
+        if info.unmapped or info.frontdoor is not None:
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return None
+        if self.get_n_bytes() > local_map.get_n_bytes():
+            _report_error(
+                self,
+                "MEM_MULTIBEAT",
+                f"Memory {repr(self.get_full_name())} element width "
+                f"({self.get_n_bytes()} bytes) exceeds map bus width "
+                f"({local_map.get_n_bytes()} bytes); multi-beat memory "
+                "access is not supported",
+            )
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return None
+        access = self.get_access(local_map)
+        if rw.get_kind() == uvm_access_e.UVM_WRITE and access == "RO":
+            _report_error(
+                self,
+                "MEM_WRITE_RO",
+                f"Cannot write read-only memory {repr(self.get_full_name())}",
+            )
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return None
+        if rw.get_kind() == uvm_access_e.UVM_READ and access == "WO":
+            _report_error(
+                self,
+                "MEM_READ_WO",
+                f"Cannot read write-only memory {repr(self.get_full_name())}",
+            )
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return None
+        if not rw.get_map():
+            rw.set_map(local_map)
+        return info
 
     async def do_write(self, rw: uvm_reg_item) -> None:
-        raise NotImplementedError
+        info = self._check_access(rw)
+        if info is None:
+            return
+        self._write_in_progress = True
+        rw.set_status(uvm_status_e.UVM_IS_OK)
+        try:
+            await rw.get_local_map().do_write(rw)
+        finally:
+            self._write_in_progress = False
 
     async def do_read(self, rw: uvm_reg_item) -> None:
-        raise NotImplementedError
+        info = self._check_access(rw)
+        if info is None:
+            return
+        self._read_in_progress = True
+        rw.set_status(uvm_status_e.UVM_IS_OK)
+        try:
+            await rw.get_local_map().do_read(rw)
+            rw.set_value(rw.get_value() & ((1 << self._n_bits) - 1))
+        finally:
+            self._read_in_progress = False
 
     def set_frontdoor(
         self,

--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -13,13 +13,13 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_elem_kind_e,
     uvm_status_e,
 )
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_error as _report_error,
+)
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_warning as _report_warning,
+)
 from pyuvm._s05_base_classes import uvm_object
-from pyuvm.uvm_reporting import (
-    uvm_report_error as _report_error,
-)
-from pyuvm.uvm_reporting import (
-    uvm_report_warning as _report_warning,
-)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_mem_mam import uvm_mem_mam

--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -18,12 +18,7 @@ from pyuvm._s05_base_classes import uvm_object
 from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
 
 if TYPE_CHECKING:
-    from pyuvm._reg.uvm_mem_mam import (
-        alloc_mode_e,
-        locality_e,
-        uvm_mem_mam,
-        uvm_mem_mam_cfg,
-    )
+    from pyuvm._reg.uvm_mem_mam import uvm_mem_mam
     from pyuvm._reg.uvm_reg_backdoor import uvm_reg_backdoor
     from pyuvm._reg.uvm_reg_block import uvm_reg_block
     from pyuvm._reg.uvm_reg_item import uvm_reg_item

--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, ClassVar
 
 from cocotb.triggers import Lock
@@ -15,7 +14,12 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_status_e,
 )
 from pyuvm._s05_base_classes import uvm_object
-from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting import (
+    uvm_report_error as _report_error,
+)
+from pyuvm.uvm_reporting import (
+    uvm_report_warning as _report_warning,
+)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_mem_mam import uvm_mem_mam
@@ -37,21 +41,6 @@ if TYPE_CHECKING:
     from pyuvm._s14_15_python_sequences import uvm_sequence_base
 
 __all__ = ["uvm_mem"]
-logger = logging.getLogger("RegModel")
-
-
-def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.warning(report_id, msg)
-    else:
-        logger.warning(msg)
-
-
-def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.error(report_id, msg)
-    else:
-        logger.error(msg)
 
 
 class uvm_mem(uvm_object):
@@ -303,7 +292,7 @@ class uvm_mem(uvm_object):
 
     def get_offset(
         self, offset: uvm_reg_addr_t = 0, map: uvm_reg_map = None
-    ) -> uvm_reg_addr_t:
+    ) -> uvm_reg_addr_t | None:
         if offset < 0 or offset >= self._size:
             _report_warning(
                 self,
@@ -311,31 +300,30 @@ class uvm_mem(uvm_object):
                 f"Offset 0x{offset:X} lies outside of memory "
                 f"'{self.get_name()}' which has size 0x{self._size:X}",
             )
-            return -1
+            return None
         local_map = self.get_local_map(map)
         if not local_map:
-            return -1
+            return None
         info = local_map.get_mem_map_info(self)
         if info.unmapped:
-            return -1
+            return None
         return info.offset + offset * info.stride
 
     def get_address(
         self, offset: uvm_reg_addr_t = 0, map: uvm_reg_map = None
-    ) -> uvm_reg_addr_t:
+    ) -> uvm_reg_addr_t | None:
         _, addresses = self.get_addresses(offset, map)
-        # UVM address-introspection APIs use -1 as the recoverable failure
-        # sentinel when an offset is invalid or no mapped address is available.
-        # This is not an exception because a failed address query does not
-        # corrupt the model or prevent simulation from continuing; exceptions
-        # are reserved for fatal configuration and model-integrity failures.
-        return addresses[0] if addresses else -1
+        # A failed address query is recoverable: it does not corrupt the model
+        # or prevent simulation from continuing.  None represents the absence
+        # of an address without inventing an out-of-domain integer sentinel;
+        # exceptions remain reserved for fatal model-integrity failures.
+        return addresses[0] if addresses else None
 
     def get_addresses(
         self,
         offset: uvm_reg_addr_t = 0,
         map: uvm_reg_map = None,
-    ) -> tuple[int, list[uvm_reg_addr_t]]:
+    ) -> tuple[uvm_reg_addr_t | None, list[uvm_reg_addr_t]]:
         if offset < 0 or offset >= self._size:
             _report_warning(
                 self,
@@ -343,7 +331,7 @@ class uvm_mem(uvm_object):
                 f"Offset 0x{offset:X} lies outside of memory "
                 f"'{self.get_name()}' which has size 0x{self._size:X}",
             )
-            return -1, list()
+            return None, list()
         local_map = self.get_local_map(map)
         if not local_map:
             map_name = "None" if not map else map.get_full_name()
@@ -352,7 +340,7 @@ class uvm_mem(uvm_object):
                 "MEM_MAP_LOOKUP",
                 f"Memory '{self.get_name()}' not found in map '{map_name}'",
             )
-            return -1, list()
+            return None, list()
         map_info = local_map.get_mem_map_info(self)
         if map_info.unmapped:
             map_name = local_map.get_full_name() if not map else map.get_full_name()
@@ -361,7 +349,7 @@ class uvm_mem(uvm_object):
                 "MEM_UNMAPPED",
                 f"Memory '{self.get_name()}' is unmapped in map '{map_name}'",
             )
-            return -1, list()
+            return None, list()
         addresses = local_map._memory_element_addresses(self, map_info, offset)
         bytes_per_access = min(self.get_n_bytes(), local_map.get_n_bytes())
         return bytes_per_access, addresses

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -19,7 +19,12 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_status_e,
 )
 from pyuvm._s05_base_classes import uvm_object
-from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting import (
+    uvm_report_error as _report_error,
+)
+from pyuvm.uvm_reporting import (
+    uvm_report_warning as _report_warning,
+)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_reg_backdoor import uvm_reg_backdoor
@@ -39,20 +44,6 @@ if TYPE_CHECKING:
 
 __all__ = ["uvm_reg"]
 logger = logging.getLogger("RegModel")
-
-
-def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.warning(report_id, msg)
-    else:
-        logger.warning(msg)
-
-
-def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.error(report_id, msg)
-    else:
-        logger.error(msg)
 
 
 class uvm_reg(uvm_object):

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -18,13 +18,13 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_predict_e,
     uvm_status_e,
 )
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_error as _report_error,
+)
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_warning as _report_warning,
+)
 from pyuvm._s05_base_classes import uvm_object
-from pyuvm.uvm_reporting import (
-    uvm_report_error as _report_error,
-)
-from pyuvm.uvm_reporting import (
-    uvm_report_warning as _report_warning,
-)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_reg_backdoor import uvm_reg_backdoor

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -19,6 +19,7 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_hier_e,
 )
 from pyuvm._s05_base_classes import uvm_object
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_mem import uvm_mem
@@ -37,6 +38,20 @@ if TYPE_CHECKING:
 
 __all__ = ["uvm_reg_block"]
 logger = logging.getLogger("RegModel")
+
+
+def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.warning(report_id, msg)
+    else:
+        logger.warning(msg)
+
+
+def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.error(report_id, msg)
+    else:
+        logger.error(msg)
 
 
 class uvm_reg_block(uvm_object):
@@ -88,7 +103,9 @@ class uvm_reg_block(uvm_object):
 
     def set_default_map(self, map: uvm_reg_map) -> None:
         if map not in self._maps:
-            logger.error(f"Map {repr(map.get_name())} does not exist in block")
+            _report_error(
+                self, "REG_BLOCK", f"Map {repr(map.get_name())} does not exist in block"
+            )
             return
         self._default_map = map
 
@@ -101,12 +118,16 @@ class uvm_reg_block(uvm_object):
     def _add_block(self, blk: uvm_reg_block) -> None:
         uid = blk.get_inst_id()
         if self.is_locked():
-            logger.error("Cannot add subblock to a locked block model")
+            _report_error(
+                self, "REG_BLOCK", "Cannot add subblock to a locked block model"
+            )
             return
         if uid in self._blks:
-            logger.error(
+            _report_error(
+                self,
+                "REG_BLOCK",
                 f"Subblock {repr(blk.get_name())} has already been "
-                f"registered with block {repr(self.get_name())}"
+                f"registered with block {repr(self.get_name())}",
             )
             return
         self._blks[uid] = blk
@@ -117,11 +138,13 @@ class uvm_reg_block(uvm_object):
 
     def _add_map(self, map: uvm_reg_map) -> None:
         if self.is_locked():
-            logger.error("Cannot add map to locked model")
+            _report_error(self, "REG_BLOCK", "Cannot add map to locked model")
             return
         if map in self._maps:
-            logger.error(
-                f"Map {repr(map.get_name())} already exists in {repr(self.get_full_name())}"
+            _report_error(
+                self,
+                "REG_BLOCK",
+                f"Map {repr(map.get_name())} already exists in {repr(self.get_full_name())}",
             )
             return
         self._maps.append(map)
@@ -131,12 +154,16 @@ class uvm_reg_block(uvm_object):
     def _add_register(self, reg: uvm_reg) -> None:
         uid = reg.get_inst_id()
         if self.is_locked():
-            logger.error("Cannot add register to a locked block model")
+            _report_error(
+                self, "REG_BLOCK", "Cannot add register to a locked block model"
+            )
             return
         if uid in self._regs:
-            logger.error(
+            _report_error(
+                self,
+                "REG_BLOCK",
                 f"Register {repr(reg.get_name())} has already been "
-                f"registered with block {self.get_full_name()}"
+                f"registered with block {self.get_full_name()}",
             )
             return
         self._regs[uid] = reg
@@ -144,12 +171,16 @@ class uvm_reg_block(uvm_object):
     def _add_memory(self, mem: uvm_mem) -> None:
         uid = mem.get_inst_id()
         if self.is_locked():
-            logger.error("Cannot add memory to a locked block model")
+            _report_error(
+                self, "REG_BLOCK", "Cannot add memory to a locked block model"
+            )
             return
         if uid in self._mems:
-            logger.error(
+            _report_error(
+                self,
+                "REG_BLOCK",
                 f"Memory {repr(mem.get_name())} has already been "
-                f"registered with block {self.get_full_name()}"
+                f"registered with block {self.get_full_name()}",
             )
             return
         self._mems[uid] = mem
@@ -192,10 +223,12 @@ class uvm_reg_block(uvm_object):
                 count = names.count(names[0])
                 _ = names.pop(0)
                 if count > 1:
-                    logger.error(
+                    _report_error(
+                        self,
+                        "REG_BLOCK",
                         f"There are {count} root register models "
                         "named {repr(name)}. The names of the root register "
-                        "models have to be unique"
+                        "models have to be unique",
                     )
             # NOTE: Trigger event
             if self._lock_model_complete is not None:
@@ -307,8 +340,10 @@ class uvm_reg_block(uvm_object):
             block = uvm_reg_block.get_block_by_name(f"{blk_name}.{name}")
             if block:
                 return block
-        logger.warning(
-            f"Unable to locate block {repr(name)} in block {repr(self.get_full_name())}"
+        _report_warning(
+            self,
+            "REG_BLOCK",
+            f"Unable to locate block {repr(name)} in block {repr(self.get_full_name())}",
         )
 
     @staticmethod
@@ -319,49 +354,61 @@ class uvm_reg_block(uvm_object):
         for map in self.get_maps():
             if map.get_name() == name:
                 return map
-        logger.warning(
-            f"Unable to locate map {repr(name)} in block {repr(self.get_full_name())}"
+        _report_warning(
+            self,
+            "REG_BLOCK",
+            f"Unable to locate map {repr(name)} in block {repr(self.get_full_name())}",
         )
 
     def get_reg_by_name(self, name: str) -> uvm_reg | None:
         for reg in self.get_registers(uvm_hier_e.UVM_HIER):
             if reg.get_name() == name:
                 return reg
-        logger.warning(
-            f"Unable to locate register {repr(name)} in block {repr(self.get_full_name())}"
+        _report_warning(
+            self,
+            "REG_BLOCK",
+            f"Unable to locate register {repr(name)} in block {repr(self.get_full_name())}",
         )
 
     def get_field_by_name(self, name: str) -> uvm_reg_field:
         for field in self.get_fields(uvm_hier_e.UVM_HIER):
             if field.get_name() == name:
                 return field
-        logger.warning(
-            f"Unable to locate field {repr(name)} in block {repr(self.get_full_name())}"
+        _report_warning(
+            self,
+            "REG_BLOCK",
+            f"Unable to locate field {repr(name)} in block {repr(self.get_full_name())}",
         )
 
     def get_mem_by_name(self, name: str) -> uvm_mem | None:
         for mem in self.get_memories(uvm_hier_e.UVM_HIER):
             if mem.get_name() == name:
                 return mem
-        logger.warning(
-            f"Unable to locate memory {repr(name)} in block {repr(self.get_full_name())}"
+        _report_warning(
+            self,
+            "REG_BLOCK",
+            f"Unable to locate memory {repr(name)} in block {repr(self.get_full_name())}",
         )
 
     def get_vreg_by_name(self, name: str) -> uvm_vreg | None:
         for vreg in self.get_virtual_registers(uvm_hier_e.UVM_HIER):
             if vreg.get_name() == name:
                 return vreg
-        logger.warning(
+        _report_warning(
+            self,
+            "REG_BLOCK",
             f"Unable to locate virtual register {repr(name)} in block "
-            f"{repr(self.get_full_name())}"
+            f"{repr(self.get_full_name())}",
         )
 
     def get_vfield_by_name(self, name: str) -> uvm_vreg_field:
         for vfield in self.get_virtual_fields(uvm_hier_e.UVM_HIER):
             if vfield.get_name() == name:
                 return vfield
-        logger.warning(
-            f"Unable to locate virtual field {repr(name)}' in block {repr(self.get_full_name())}"
+        _report_warning(
+            self,
+            "REG_BLOCK",
+            f"Unable to locate virtual field {repr(name)}' in block {repr(self.get_full_name())}",
         )
 
     def build_coverage(self, models: uvm_reg_cvr_t) -> uvm_reg_cvr_t:

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import warnings
 from typing import TYPE_CHECKING, ClassVar
 
@@ -19,7 +18,12 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_hier_e,
 )
 from pyuvm._s05_base_classes import uvm_object
-from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting import (
+    uvm_report_error as _report_error,
+)
+from pyuvm.uvm_reporting import (
+    uvm_report_warning as _report_warning,
+)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_mem import uvm_mem
@@ -37,21 +41,6 @@ if TYPE_CHECKING:
     from pyuvm._s14_15_python_sequences import uvm_sequence_base
 
 __all__ = ["uvm_reg_block"]
-logger = logging.getLogger("RegModel")
-
-
-def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.warning(report_id, msg)
-    else:
-        logger.warning(msg)
-
-
-def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.error(report_id, msg)
-    else:
-        logger.error(msg)
 
 
 class uvm_reg_block(uvm_object):

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -17,13 +17,13 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_door_e,
     uvm_hier_e,
 )
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_error as _report_error,
+)
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_warning as _report_warning,
+)
 from pyuvm._s05_base_classes import uvm_object
-from pyuvm.uvm_reporting import (
-    uvm_report_error as _report_error,
-)
-from pyuvm.uvm_reporting import (
-    uvm_report_warning as _report_warning,
-)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_mem import uvm_mem

--- a/pyuvm/_reg/uvm_reg_block.py
+++ b/pyuvm/_reg/uvm_reg_block.py
@@ -141,6 +141,19 @@ class uvm_reg_block(uvm_object):
             return
         self._regs[uid] = reg
 
+    def _add_memory(self, mem: uvm_mem) -> None:
+        uid = mem.get_inst_id()
+        if self.is_locked():
+            logger.error("Cannot add memory to a locked block model")
+            return
+        if uid in self._mems:
+            logger.error(
+                f"Memory {repr(mem.get_name())} has already been "
+                f"registered with block {self.get_full_name()}"
+            )
+            return
+        self._mems[uid] = mem
+
     def _add_virtual_register(self, vreg: uvm_vreg) -> None:
         raise NotImplementedError
 

--- a/pyuvm/_reg/uvm_reg_field.py
+++ b/pyuvm/_reg/uvm_reg_field.py
@@ -17,6 +17,12 @@ from pyuvm._reg.uvm_reg_model import (
 )
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._s24_uvm_reg_includes import uvm_resp_t
+from pyuvm.uvm_reporting import (
+    uvm_report_error as _report_error,
+)
+from pyuvm.uvm_reporting import (
+    uvm_report_warning as _report_warning,
+)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_reg import uvm_reg
@@ -329,9 +335,11 @@ class uvm_reg_field(uvm_object):
         _mask = (1 << self._size) - 1
 
         if value >> self._size:
-            logger.warning(
+            _report_warning(
+                self,
+                "FIELD_VALUE_WIDTH",
                 f"Specified value (0x{value:X}) greater than field "
-                f"{repr(self.get_name())} size ({self._size} bits)"
+                f"{repr(self.get_name())} size ({self._size} bits)",
             )
             value &= _mask
 
@@ -568,9 +576,11 @@ class uvm_reg_field(uvm_object):
             lineno,
         )
         if status == uvm_status_e.UVM_NOT_OK:
-            logger.error(
+            _report_error(
+                self,
+                "FIELD_POKE",
                 f"uvm_reg_field::poke(): Peek of register "
-                f"{repr(self._parent.get_full_name())} returned status {status}"
+                f"{repr(self._parent.get_full_name())} returned status {status}",
             )
             return status
         reg_value = self.insert_into_register(reg_value, value)

--- a/pyuvm/_reg/uvm_reg_field.py
+++ b/pyuvm/_reg/uvm_reg_field.py
@@ -15,14 +15,14 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_predict_e,
     uvm_status_e,
 )
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_error as _report_error,
+)
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_warning as _report_warning,
+)
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._s24_uvm_reg_includes import uvm_resp_t
-from pyuvm.uvm_reporting import (
-    uvm_report_error as _report_error,
-)
-from pyuvm.uvm_reporting import (
-    uvm_report_warning as _report_warning,
-)
 
 if TYPE_CHECKING:
     from pyuvm._reg.uvm_reg import uvm_reg

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -18,7 +18,12 @@ from pyuvm._reg.uvm_reg_model import (
 )
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._s14_15_python_sequences import uvm_sequence, uvm_sequence_base
-from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting import (
+    uvm_report_error as _report_error,
+)
+from pyuvm.uvm_reporting import (
+    uvm_report_warning as _report_warning,
+)
 
 if TYPE_CHECKING:
     from pyuvm import (
@@ -46,20 +51,6 @@ __all__ = [
     "uvm_reg_map",
 ]
 logger = logging.getLogger("RegModel")
-
-
-def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.warning(report_id, msg)
-    else:
-        logger.warning(msg)
-
-
-def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.error(report_id, msg)
-    else:
-        logger.error(msg)
 
 
 def _first_progression_overlap(

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -12,6 +12,7 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_elem_kind_e,
     uvm_endianness_e,
     uvm_hier_e,
+    uvm_reg_map_addr_range,
 )
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._s14_15_python_sequences import uvm_sequence, uvm_sequence_base
@@ -52,6 +53,7 @@ class uvm_reg_map_info:
         self.addr: list[uvm_reg_addr_t] = list()
         self.frontdoor: uvm_reg_frontdoor = None
         self.mem_range: uvm_reg_map_addr_range = None
+        self.stride: int = 1
         self.is_initialized: bool = False
 
 
@@ -95,7 +97,7 @@ class uvm_reg_map(uvm_object):
         self._mems_info: dict[uvm_mem, uvm_reg_map_info] = dict()
         self._regs_by_offset: dict[uvm_reg_addr_t, uvm_reg] = dict()
         self._regs_by_offset_wo: dict[uvm_reg_addr_t, uvm_reg] = dict()
-        self._mems_by_offset: dict[uvm_reg_map_addr_range, uvm_mem] = dict()
+        self._mems_by_offset: dict[uvm_reg_addr_t, uvm_mem] = dict()
         self._policy: uvm_reg_transaction_order_policy = None
 
     def _init_address_map(self) -> None:
@@ -145,7 +147,7 @@ class uvm_reg_map(uvm_object):
                     # TODO: check memory overlap uvm_reg_map.svh:1619
                 self._regs_info[reg].addr = reg_addrs
         for mem, mem_info in self._mems_info.items():
-            raise NotImplementedError
+            self._initialize_memory(mem, mem_info)
         if bus_width == 0:
             bus_width = self._n_bytes
         self._system_n_bytes = bus_width
@@ -217,8 +219,79 @@ class uvm_reg_map(uvm_object):
         rights: str = "RW",
         unmapped: bool = False,
         frontdoor: uvm_reg_frontdoor = None,
-    ):
-        raise NotImplementedError
+    ) -> None:
+        if mem in self._mems_info:
+            logger.error(
+                f"Memory {repr(mem.get_name())} has already been added "
+                f"to map {repr(self.get_full_name())}"
+            )
+            return
+        if mem.get_parent() is not self.get_parent():
+            logger.error(
+                f"Memory {repr(mem.get_name())} may not be added to "
+                f"address map {repr(self.get_full_name())}: they are not "
+                "in the same block"
+            )
+            return
+        rights = rights.upper()
+        if rights not in ("RW", "RO", "WO"):
+            logger.error(
+                f"Memory {repr(mem.get_name())} has invalid map rights "
+                f"{repr(rights)}; using 'RW'"
+            )
+            rights = "RW"
+        info = uvm_reg_map_info()
+        info.offset = offset
+        info.rights = rights
+        info.unmapped = unmapped
+        info.frontdoor = frontdoor
+        info.stride = max(
+            1, ceildiv(mem.get_n_bytes(), self.get_addr_unit_bytes())
+        )
+        self._mems_info[mem] = info
+        mem.add_map(self)
+
+    def _memory_element_addresses(
+        self, mem: uvm_mem, info: uvm_reg_map_info, element_offset: int
+    ) -> list[uvm_reg_addr_t]:
+        _, addresses = self.get_physical_addresses(
+            info.offset + element_offset * info.stride, 0, mem.get_n_bytes()
+        )
+        return addresses
+
+    def _initialize_memory(self, mem: uvm_mem, info: uvm_reg_map_info) -> None:
+        root_map = self.get_root_map()
+        info.is_initialized = True
+        if info.unmapped:
+            info.addr = []
+            info.mem_range = None
+            return
+
+        occupied = []
+        for element_offset in range(mem.get_size()):
+            occupied.extend(
+                self._memory_element_addresses(mem, info, element_offset)
+            )
+        info.addr = self._memory_element_addresses(mem, info, 0)
+        info.mem_range = uvm_reg_map_addr_range(
+            min(occupied), max(occupied), info.stride
+        )
+        for addr in occupied:
+            other_mem = root_map._mems_by_offset.get(addr)
+            if other_mem is not None and other_mem is not mem:
+                logger.warning(
+                    f"In map {repr(self.get_full_name())} memory "
+                    f"{repr(mem.get_full_name())} overlaps memory "
+                    f"{repr(other_mem.get_full_name())} at 0x{addr:X}"
+                )
+            reg = root_map._regs_by_offset.get(addr)
+            if reg is not None:
+                logger.warning(
+                    f"In map {repr(self.get_full_name())} memory "
+                    f"{repr(mem.get_full_name())} overlaps register "
+                    f"{repr(reg.get_full_name())} at 0x{addr:X}"
+                )
+            root_map._mems_by_offset[addr] = mem
 
     def add_submap(self, child_map: uvm_reg_map, offset: uvm_reg_addr_t) -> None:
         if not child_map:
@@ -387,7 +460,18 @@ class uvm_reg_map(uvm_object):
     def _set_mem_offset(
         self, mem: uvm_mem, offset: uvm_reg_addr_t, unmapped: bool
     ) -> None:
-        raise NotImplementedError
+        if mem not in self._mems_info:
+            logger.error(
+                f"Cannot modify offset of memory {repr(mem.get_full_name())} "
+                f"in address map {repr(self.get_full_name())}: memory is not mapped"
+            )
+            return
+        info = self._mems_info[mem]
+        info.offset = offset if not unmapped else -1
+        info.unmapped = unmapped
+        info.is_initialized = False
+        if self.get_parent().is_locked():
+            self.get_root_map()._init_address_map()
 
     def get_full_name(self) -> str:
         parent = self.get_parent()
@@ -507,8 +591,23 @@ class uvm_reg_map(uvm_object):
             )
         return map_info
 
-    def get_mem_map_info(self, mem: uvm_mem, error: bool) -> uvm_reg_map_info:
-        raise NotImplementedError
+    def get_mem_map_info(
+        self, mem: uvm_mem, error: bool = True
+    ) -> uvm_reg_map_info | None:
+        if mem not in self._mems_info:
+            if error:
+                logger.error(
+                    f"Memory {repr(mem.get_name())} not in map "
+                    f"{repr(self.get_full_name())}"
+                )
+            return None
+        info = self._mems_info[mem]
+        if not info.is_initialized:
+            logger.warning(
+                f"Map {repr(self.get_full_name())} does not seem to be "
+                "initialized correctly; check that the top register model is locked"
+            )
+        return info
 
     def get_size(self) -> int:
         raise NotImplementedError
@@ -539,8 +638,14 @@ class uvm_reg_map(uvm_object):
             return self._regs_by_offset[offset]
         return None
 
-    def get_mem_by_offset(self, offset: uvm_reg_addr_t) -> uvm_mem:
-        raise NotImplementedError
+    def get_mem_by_offset(self, offset: uvm_reg_addr_t) -> uvm_mem | None:
+        if not self.get_parent().is_locked():
+            logger.error(
+                "Cannot get memory by offset: block "
+                f"{repr(self.get_parent().get_full_name())} is not locked"
+            )
+            return None
+        return self.get_root_map()._mems_by_offset.get(offset)
 
     def set_auto_predict(self, on: bool = True) -> None:
         self._auto_predict = on
@@ -605,15 +710,24 @@ class uvm_reg_map(uvm_object):
         access_kind: uvm_access_e,
         adapter: uvm_reg_adapter,
     ) -> uvm_reg_bus_op:
-        reg = rw.get_element()
-        bus_width, addrs, byte_offset = self._get_physical_addresses_to_map(
-            self._regs_info[reg].offset, 0x0, reg.get_n_bytes(), None, None
-        )
+        element = rw.get_element()
+        if rw.get_element_kind() == uvm_elem_kind_e.UVM_MEM:
+            info = self._mems_info[element]
+            addrs = self._memory_element_addresses(
+                element, info, rw.get_offset()
+            )
+            bus_width = self.get_n_bytes()
+            byte_offset = 0
+        else:
+            info = self._regs_info[element]
+            bus_width, addrs, byte_offset = self._get_physical_addresses_to_map(
+                info.offset, 0x0, element.get_n_bytes(), None, None
+            )
         bus_op = uvm_reg_bus_op()
         bus_op.kind = access_kind
         bus_op.addr = addrs[0]
         bus_op.data = rw.get_value()
-        bus_op.n_bits = min(reg.get_n_bits(), bus_width * 8)
+        bus_op.n_bits = min(element.get_n_bits(), bus_width * 8)
         bus_op.status = rw.get_status()
         if adapter.supports_byte_enable:
             byte_offset = int(byte_offset)

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -16,14 +16,14 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_hier_e,
     uvm_reg_map_addr_range,
 )
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_error as _report_error,
+)
+from pyuvm._reg.uvm_reg_reporting import (
+    uvm_reg_report_warning as _report_warning,
+)
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._s14_15_python_sequences import uvm_sequence, uvm_sequence_base
-from pyuvm.uvm_reporting import (
-    uvm_report_error as _report_error,
-)
-from pyuvm.uvm_reporting import (
-    uvm_report_warning as _report_warning,
-)
 
 if TYPE_CHECKING:
     from pyuvm import (

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import warnings
+from dataclasses import dataclass
+from math import gcd
 from typing import TYPE_CHECKING, ClassVar
 
 from pyuvm._error_classes import UVMFatalError
@@ -43,6 +45,169 @@ __all__ = [
     "uvm_reg_map",
 ]
 logger = logging.getLogger("RegModel")
+
+
+def _first_progression_overlap(
+    first_a: int,
+    stride_a: int,
+    count_a: int,
+    first_b: int,
+    stride_b: int,
+    count_b: int,
+) -> int | None:
+    """Return the first address shared by two finite arithmetic progressions.
+
+    A mapped memory is represented by one progression per physical byte lane.
+    For example, a lane whose first address is 0x100 and whose element stride
+    is four occupies 0x100, 0x104, 0x108, ... .  Map initialization needs to
+    know whether two such lanes ever occupy the same address so that it can
+    report memory-to-memory overlap accurately.
+
+    Merely comparing the minimum and maximum addresses is insufficient because
+    the progressions can contain holes.  Expanding every memory element into a
+    dictionary would preserve those holes, but would also consume storage
+    proportional to memory depth.  This helper instead solves
+
+        first_a + stride_a * i == first_b + stride_b * j
+
+    for finite index ranges using the greatest common divisor and the Chinese
+    Remainder Theorem.  The GCD test determines whether the infinite
+    progressions can intersect; the modular inverse produces one intersection;
+    and ``period`` advances that solution to the first address inside both
+    finite ranges.
+
+    A zero stride represents a progression containing only one distinct
+    address, which occurs for a one-element memory.  The explicit zero-stride
+    cases also avoid taking a modular inverse with a zero modulus.
+
+    Returns:
+        The lowest shared address within both finite progressions, or ``None``
+        when they do not intersect.
+    """
+    last_a = first_a + stride_a * (count_a - 1)
+    last_b = first_b + stride_b * (count_b - 1)
+    lower = max(first_a, first_b)
+    upper = min(last_a, last_b)
+    if lower > upper:
+        return None
+    if stride_a == 0:
+        if stride_b == 0:
+            return first_a if first_a == first_b else None
+        delta = first_a - first_b
+        return first_a if delta >= 0 and delta % stride_b == 0 else None
+    if stride_b == 0:
+        delta = first_b - first_a
+        return first_b if delta >= 0 and delta % stride_a == 0 else None
+
+    common = gcd(stride_a, stride_b)
+    difference = first_b - first_a
+    if difference % common:
+        return None
+    reduced_b = stride_b // common
+    multiplier = 0
+    if reduced_b > 1:
+        multiplier = (
+            (difference // common)
+            * pow(stride_a // common, -1, reduced_b)
+        ) % reduced_b
+    period = stride_a * reduced_b
+    candidate = (first_a + stride_a * multiplier) % period
+    if candidate < lower:
+        candidate += ((lower - candidate + period - 1) // period) * period
+    return candidate if candidate <= upper else None
+
+
+@dataclass(frozen=True)
+class _uvm_mem_address_set:
+    """Compact description of all physical addresses occupied by a memory.
+
+    ``uvm_reg_map.get_physical_addresses()`` can return several addresses for
+    one memory element, typically one per bus byte lane.  ``first_addresses``
+    stores those addresses for element zero, while ``element_strides`` stores
+    the difference between the corresponding addresses of elements zero and
+    one.  Each pair therefore describes one finite arithmetic progression
+    containing ``size`` addresses.
+
+    The register map uses this descriptor for three operations:
+
+    * ``contains()`` resolves a bus address to its mapped memory without
+      incorrectly filling gaps between strided elements.
+    * ``first_overlap()`` detects exact memory-to-memory collisions during map
+      initialization.
+    * The ``min`` and ``max`` bounds provide a cheap rejection test before the
+      exact progression calculations.
+
+    Keeping one descriptor per memory makes lookup metadata proportional to
+    the number and width of mapped memories, rather than their total number of
+    elements.  This is important for models containing very large memories.
+    """
+
+    mem: uvm_mem
+    first_addresses: tuple[uvm_reg_addr_t, ...]
+    element_strides: tuple[int, ...]
+    size: int
+    min: uvm_reg_addr_t
+    max: uvm_reg_addr_t
+
+    @classmethod
+    def create(
+        cls,
+        mem: uvm_mem,
+        first_addresses: list[uvm_reg_addr_t],
+        second_addresses: list[uvm_reg_addr_t] | None,
+    ) -> _uvm_mem_address_set:
+        if second_addresses is None:
+            strides = tuple(0 for _ in first_addresses)
+        else:
+            strides = tuple(
+                second - first
+                for first, second in zip(first_addresses, second_addresses)
+            )
+        final_addresses = [
+            first + stride * (mem.get_size() - 1)
+            for first, stride in zip(first_addresses, strides)
+        ]
+        all_bounds = [*first_addresses, *final_addresses]
+        return cls(
+            mem,
+            tuple(first_addresses),
+            strides,
+            mem.get_size(),
+            min(all_bounds),
+            max(all_bounds),
+        )
+
+    def contains(self, address: uvm_reg_addr_t) -> bool:
+        if address < self.min or address > self.max:
+            return False
+        for first, stride in zip(self.first_addresses, self.element_strides):
+            if stride == 0:
+                if address == first:
+                    return True
+                continue
+            delta = address - first
+            if delta >= 0 and delta % stride == 0 and delta // stride < self.size:
+                return True
+        return False
+
+    def first_overlap(self, other: _uvm_mem_address_set) -> int | None:
+        if self.max < other.min or other.max < self.min:
+            return None
+        for first_a, stride_a in zip(self.first_addresses, self.element_strides):
+            for first_b, stride_b in zip(
+                other.first_addresses, other.element_strides
+            ):
+                overlap = _first_progression_overlap(
+                    first_a,
+                    stride_a,
+                    self.size,
+                    first_b,
+                    stride_b,
+                    other.size,
+                )
+                if overlap is not None:
+                    return overlap
+        return None
 
 
 class uvm_reg_map_info:
@@ -97,7 +262,7 @@ class uvm_reg_map(uvm_object):
         self._mems_info: dict[uvm_mem, uvm_reg_map_info] = dict()
         self._regs_by_offset: dict[uvm_reg_addr_t, uvm_reg] = dict()
         self._regs_by_offset_wo: dict[uvm_reg_addr_t, uvm_reg] = dict()
-        self._mems_by_offset: dict[uvm_reg_addr_t, uvm_mem] = dict()
+        self._mems_by_offset: dict[uvm_mem, _uvm_mem_address_set] = dict()
         self._policy: uvm_reg_transaction_order_policy = None
 
     def _init_address_map(self) -> None:
@@ -267,31 +432,33 @@ class uvm_reg_map(uvm_object):
             info.mem_range = None
             return
 
-        occupied = []
-        for element_offset in range(mem.get_size()):
-            occupied.extend(
-                self._memory_element_addresses(mem, info, element_offset)
-            )
         info.addr = self._memory_element_addresses(mem, info, 0)
-        info.mem_range = uvm_reg_map_addr_range(
-            min(occupied), max(occupied), info.stride
+        second_addresses = None
+        if mem.get_size() > 1:
+            second_addresses = self._memory_element_addresses(mem, info, 1)
+        address_set = _uvm_mem_address_set.create(
+            mem, info.addr, second_addresses
         )
-        for addr in occupied:
-            other_mem = root_map._mems_by_offset.get(addr)
-            if other_mem is not None and other_mem is not mem:
+        info.mem_range = uvm_reg_map_addr_range(
+            address_set.min, address_set.max, info.stride
+        )
+        for other_mem, other_set in root_map._mems_by_offset.items():
+            overlap = address_set.first_overlap(other_set)
+            if overlap is not None and other_mem is not mem:
                 logger.warning(
                     f"In map {repr(self.get_full_name())} memory "
                     f"{repr(mem.get_full_name())} overlaps memory "
-                    f"{repr(other_mem.get_full_name())} at 0x{addr:X}"
+                    f"{repr(other_mem.get_full_name())} at 0x{overlap:X}"
                 )
-            reg = root_map._regs_by_offset.get(addr)
-            if reg is not None:
-                logger.warning(
-                    f"In map {repr(self.get_full_name())} memory "
-                    f"{repr(mem.get_full_name())} overlaps register "
-                    f"{repr(reg.get_full_name())} at 0x{addr:X}"
-                )
-            root_map._mems_by_offset[addr] = mem
+        for addr, reg in root_map._regs_by_offset.items():
+            if not address_set.contains(addr):
+                continue
+            logger.warning(
+                f"In map {repr(self.get_full_name())} memory "
+                f"{repr(mem.get_full_name())} overlaps register "
+                f"{repr(reg.get_full_name())} at 0x{addr:X}"
+            )
+        root_map._mems_by_offset[mem] = address_set
 
     def add_submap(self, child_map: uvm_reg_map, offset: uvm_reg_addr_t) -> None:
         if not child_map:
@@ -440,13 +607,13 @@ class uvm_reg_map(uvm_object):
                 else:
                     root_map._regs_by_offset[addr] = reg
 
-                for range in root_map._mems_by_offset.keys():
-                    if addr >= range.min and addr <= range.max:
+                for mem, address_set in root_map._mems_by_offset.items():
+                    if address_set.contains(addr):
                         logger.warning(
                             f"In map {repr(self.get_full_name())} "
                             f"register {repr(reg.get_full_name())} "
-                            "overlaps with address range of memory"
-                            f"{repr(root_map._mems_by_offset[range].get_full_name())} "
+                            "overlaps with memory "
+                            f"{repr(mem.get_full_name())} "
                             f": 0x{addr:X}"
                         )
             info.addr = addrs
@@ -645,7 +812,11 @@ class uvm_reg_map(uvm_object):
                 f"{repr(self.get_parent().get_full_name())} is not locked"
             )
             return None
-        return self.get_root_map()._mems_by_offset.get(offset)
+        address_sets = self.get_root_map()._mems_by_offset.values()
+        for address_set in reversed(tuple(address_sets)):
+            if address_set.contains(offset):
+                return address_set.mem
+        return None
 
     def set_auto_predict(self, on: bool = True) -> None:
         self._auto_predict = on

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -18,6 +18,7 @@ from pyuvm._reg.uvm_reg_model import (
 )
 from pyuvm._s05_base_classes import uvm_object
 from pyuvm._s14_15_python_sequences import uvm_sequence, uvm_sequence_base
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
 
 if TYPE_CHECKING:
     from pyuvm import (
@@ -45,6 +46,20 @@ __all__ = [
     "uvm_reg_map",
 ]
 logger = logging.getLogger("RegModel")
+
+
+def _report_warning(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.warning(report_id, msg)
+    else:
+        logger.warning(msg)
+
+
+def _report_error(obj: uvm_object, report_id: str, msg: str) -> None:
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.error(report_id, msg)
+    else:
+        logger.error(msg)
 
 
 def _first_progression_overlap(
@@ -107,8 +122,7 @@ def _first_progression_overlap(
     multiplier = 0
     if reduced_b > 1:
         multiplier = (
-            (difference // common)
-            * pow(stride_a // common, -1, reduced_b)
+            (difference // common) * pow(stride_a // common, -1, reduced_b)
         ) % reduced_b
     period = stride_a * reduced_b
     candidate = (first_a + stride_a * multiplier) % period
@@ -194,9 +208,7 @@ class _uvm_mem_address_set:
         if self.max < other.min or other.max < self.min:
             return None
         for first_a, stride_a in zip(self.first_addresses, self.element_strides):
-            for first_b, stride_b in zip(
-                other.first_addresses, other.element_strides
-            ):
+            for first_b, stride_b in zip(other.first_addresses, other.element_strides):
                 overlap = _first_progression_overlap(
                     first_a,
                     stride_a,
@@ -301,11 +313,13 @@ class uvm_reg_map(uvm_object):
                             # uvm_reg_read_only_cb.add(other_reg)
                             # uvm_reg_write_only_cb.add(reg)
                         else:
-                            logger.warning(
+                            _report_warning(
+                                self,
+                                "REG_MAP",
                                 f"In map {repr(self.get_full_name())} "
                                 f"register {repr(reg.get_full_name())} maps "
                                 "to the same address as register "
-                                f"{repr(other_reg.get_full_name())}: 0x{addr:X}"
+                                f"{repr(other_reg.get_full_name())}: 0x{addr:X}",
                             )
                     else:
                         root_map._regs_by_offset[addr] = reg
@@ -358,15 +372,19 @@ class uvm_reg_map(uvm_object):
         frontdoor: uvm_reg_frontdoor = None,
     ) -> None:
         if rg in self._regs_info:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Register {repr(rg.get_name())} has already been added "
-                f"to map {repr(self.get_full_name())}"
+                f"to map {repr(self.get_full_name())}",
             )
         if rg.get_parent() != self.get_parent():
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Register {repr(rg.get_name())} may not be added to "
                 f"the address map {repr(self.get_full_name())}: they  "
-                "are not in the same block"
+                "are not in the same block",
             )
         rg.add_map(self)
         info = uvm_reg_map_info()
@@ -386,23 +404,29 @@ class uvm_reg_map(uvm_object):
         frontdoor: uvm_reg_frontdoor = None,
     ) -> None:
         if mem in self._mems_info:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Memory {repr(mem.get_name())} has already been added "
-                f"to map {repr(self.get_full_name())}"
+                f"to map {repr(self.get_full_name())}",
             )
             return
         if mem.get_parent() is not self.get_parent():
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Memory {repr(mem.get_name())} may not be added to "
                 f"address map {repr(self.get_full_name())}: they are not "
-                "in the same block"
+                "in the same block",
             )
             return
         rights = rights.upper()
         if rights not in ("RW", "RO", "WO"):
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Memory {repr(mem.get_name())} has invalid map rights "
-                f"{repr(rights)}; using 'RW'"
+                f"{repr(rights)}; using 'RW'",
             )
             rights = "RW"
         info = uvm_reg_map_info()
@@ -410,9 +434,7 @@ class uvm_reg_map(uvm_object):
         info.rights = rights
         info.unmapped = unmapped
         info.frontdoor = frontdoor
-        info.stride = max(
-            1, ceildiv(mem.get_n_bytes(), self.get_addr_unit_bytes())
-        )
+        info.stride = max(1, ceildiv(mem.get_n_bytes(), self.get_addr_unit_bytes()))
         self._mems_info[mem] = info
         mem.add_map(self)
 
@@ -436,45 +458,52 @@ class uvm_reg_map(uvm_object):
         second_addresses = None
         if mem.get_size() > 1:
             second_addresses = self._memory_element_addresses(mem, info, 1)
-        address_set = _uvm_mem_address_set.create(
-            mem, info.addr, second_addresses
-        )
+        address_set = _uvm_mem_address_set.create(mem, info.addr, second_addresses)
         info.mem_range = uvm_reg_map_addr_range(
             address_set.min, address_set.max, info.stride
         )
         for other_mem, other_set in root_map._mems_by_offset.items():
             overlap = address_set.first_overlap(other_set)
             if overlap is not None and other_mem is not mem:
-                logger.warning(
+                _report_warning(
+                    self,
+                    "REG_MAP",
                     f"In map {repr(self.get_full_name())} memory "
                     f"{repr(mem.get_full_name())} overlaps memory "
-                    f"{repr(other_mem.get_full_name())} at 0x{overlap:X}"
+                    f"{repr(other_mem.get_full_name())} at 0x{overlap:X}",
                 )
         for addr, reg in root_map._regs_by_offset.items():
             if not address_set.contains(addr):
                 continue
-            logger.warning(
+            _report_warning(
+                self,
+                "REG_MAP",
                 f"In map {repr(self.get_full_name())} memory "
                 f"{repr(mem.get_full_name())} overlaps register "
-                f"{repr(reg.get_full_name())} at 0x{addr:X}"
+                f"{repr(reg.get_full_name())} at 0x{addr:X}",
             )
         root_map._mems_by_offset[mem] = address_set
 
     def add_submap(self, child_map: uvm_reg_map, offset: uvm_reg_addr_t) -> None:
         if not child_map:
-            logger.error("Child map cannot be None")
+            _report_error(self, "REG_MAP", "Child map cannot be None")
+            return
         parent_map = child_map.get_parent_map()
         if parent_map:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Map {repr(child_map.get_full_name())} is already a child "
-                f"of map {repr(parent_map.get_full_name())}"
+                f"of map {repr(parent_map.get_full_name())}",
             )
         child_n_bytes = child_map.get_n_bytes(uvm_hier_e.UVM_NO_HIER)
         if self._n_bytes > child_n_bytes:
-            logger.warning(
+            _report_warning(
+                self,
+                "REG_MAP",
                 f"Adding {child_n_bytes}-bytes submap to "
                 f"{repr(child_map.get_full_name())} {self._n_bytes}-bytes map "
-                f"parent map {repr(self.get_full_name())}"
+                f"parent map {repr(self.get_full_name())}",
             )
         child_map._add_parent_map(self, offset)
         self.set_submap_offset(child_map, offset)
@@ -483,7 +512,7 @@ class uvm_reg_map(uvm_object):
         self, sequencer: uvm_sequencer, adapter: uvm_reg_adapter = None
     ) -> None:
         if not sequencer:
-            logger.error("None value specified for bus sequencer")
+            _report_error(self, "REG_MAP", "None value specified for bus sequencer")
             return
         if not adapter:
             logger.info(
@@ -496,7 +525,7 @@ class uvm_reg_map(uvm_object):
 
     def set_submap_offset(self, submap: uvm_reg_map, offset: uvm_reg_addr_t) -> None:
         if not submap:
-            logger.error("set_submap_offset: submap cannot be None")
+            _report_error(self, "REG_MAP", "set_submap_offset: submap cannot be None")
             return
         self._submaps[submap] = offset
         if self._parent.is_locked():
@@ -504,15 +533,18 @@ class uvm_reg_map(uvm_object):
             root_map._init_address_map()
 
     def get_submap_offset(self, submap: uvm_reg_map) -> uvm_reg_addr_t:
+        if submap is None:
+            _report_error(self, "REG_MAP", "get_submap_offset: submap cannot be None")
+            return -1
         try:
             return self._submaps[submap]
         except KeyError:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Map {repr(submap.get_full_name())} is not a submap of map "
-                f"{repr(self.get_full_name())}"
+                f"{repr(self.get_full_name())}",
             )
-        except TypeError:
-            logger.error("get_submap_offset: submap cannot be None")
         return -1
 
     def set_base_addr(self, offset: uvm_reg_addr_t) -> None:
@@ -524,12 +556,14 @@ class uvm_reg_map(uvm_object):
 
     def _add_parent_map(self, parent_map: uvm_reg_map, offset: uvm_reg_addr_t) -> None:
         if not parent_map:
-            logger.error("Parent map cannot be None")
+            _report_error(self, "REG_MAP", "Parent map cannot be None")
             return
         if self._parent_map:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Map {repr(self.get_full_name())} is already a submap "
-                f"of map {repr(self._parent_map.get_full_name())}"
+                f"of map {repr(self._parent_map.get_full_name())}",
             )
             return
         parent_map._submaps[self] = offset
@@ -542,11 +576,13 @@ class uvm_reg_map(uvm_object):
         self, reg: uvm_reg, offset: uvm_reg_addr_t, unmapped: bool
     ) -> None:
         if reg not in self._regs_info:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Cannot modify offset of register "
                 f"{repr(reg.get_full_name())} in address map "
                 f"{repr(self.get_full_name())} register is not "
-                "mapped in that address map"
+                "mapped in that address map",
             )
             return
         info = self._regs_info[reg]
@@ -597,24 +633,28 @@ class uvm_reg_map(uvm_object):
                         # uvm_reg_read_only_cbs::remove(reg2);
                         # uvm_reg_write_only_cbs::remove(reg2);
                     else:
-                        logger.warning(
+                        _report_warning(
+                            self,
+                            "REG_MAP",
                             f"In map {repr(self.get_full_name())} "
                             f" register {repr(reg.get_full_name())} maps to same "
                             f"address as register "
                             f"{repr(root_map._regs_by_offset[addr].get_full_name())} "
-                            f": 0x{addr:X}"
+                            f": 0x{addr:X}",
                         )
                 else:
                     root_map._regs_by_offset[addr] = reg
 
                 for mem, address_set in root_map._mems_by_offset.items():
                     if address_set.contains(addr):
-                        logger.warning(
+                        _report_warning(
+                            self,
+                            "REG_MAP",
                             f"In map {repr(self.get_full_name())} "
                             f"register {repr(reg.get_full_name())} "
                             "overlaps with memory "
                             f"{repr(mem.get_full_name())} "
-                            f": 0x{addr:X}"
+                            f": 0x{addr:X}",
                         )
             info.addr = addrs
         if unmapped:
@@ -628,9 +668,11 @@ class uvm_reg_map(uvm_object):
         self, mem: uvm_mem, offset: uvm_reg_addr_t, unmapped: bool
     ) -> None:
         if mem not in self._mems_info:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 f"Cannot modify offset of memory {repr(mem.get_full_name())} "
-                f"in address map {repr(self.get_full_name())}: memory is not mapped"
+                f"in address map {repr(self.get_full_name())}: memory is not mapped",
             )
             return
         info = self._mems_info[mem]
@@ -745,16 +787,20 @@ class uvm_reg_map(uvm_object):
     ) -> uvm_reg_map_info | None:
         if rg not in self._regs_info:
             if error:
-                logger.error(
-                    f"Register {repr(rg.get_name())} not in map {repr(self.get_full_name())}"
+                _report_error(
+                    self,
+                    "REG_MAP",
+                    f"Register {repr(rg.get_name())} not in map {repr(self.get_full_name())}",
                 )
             return
         map_info = self._regs_info[rg]
         if not map_info.is_initialized:
-            logger.warning(
+            _report_warning(
+                self,
+                "REG_MAP",
                 f"Map {repr(self.get_full_name())} does not seem to "
                 "initialized correctly, check that the top "
-                "register model is locked()"
+                "register model is locked()",
             )
         return map_info
 
@@ -763,16 +809,20 @@ class uvm_reg_map(uvm_object):
     ) -> uvm_reg_map_info | None:
         if mem not in self._mems_info:
             if error:
-                logger.error(
+                _report_error(
+                    self,
+                    "REG_MAP",
                     f"Memory {repr(mem.get_name())} not in map "
-                    f"{repr(self.get_full_name())}"
+                    f"{repr(self.get_full_name())}",
                 )
             return None
         info = self._mems_info[mem]
         if not info.is_initialized:
-            logger.warning(
+            _report_warning(
+                self,
+                "REG_MAP",
                 f"Map {repr(self.get_full_name())} does not seem to be "
-                "initialized correctly; check that the top register model is locked"
+                "initialized correctly; check that the top register model is locked",
             )
         return info
 
@@ -794,9 +844,11 @@ class uvm_reg_map(uvm_object):
         self, offset: uvm_reg_addr_t, read: bool = True
     ) -> uvm_reg | None:
         if not self.get_parent().is_locked():
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 "Cannot get register by offset : block "
-                f"{repr(self.get_parent().get_full_name())} is not locked"
+                f"{repr(self.get_parent().get_full_name())} is not locked",
             )
             return None
         if not read and offset in self._regs_by_offset_wo:
@@ -807,9 +859,11 @@ class uvm_reg_map(uvm_object):
 
     def get_mem_by_offset(self, offset: uvm_reg_addr_t) -> uvm_mem | None:
         if not self.get_parent().is_locked():
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 "Cannot get memory by offset: block "
-                f"{repr(self.get_parent().get_full_name())} is not locked"
+                f"{repr(self.get_parent().get_full_name())} is not locked",
             )
             return None
         address_sets = self.get_root_map()._mems_by_offset.values()
@@ -884,9 +938,7 @@ class uvm_reg_map(uvm_object):
         element = rw.get_element()
         if rw.get_element_kind() == uvm_elem_kind_e.UVM_MEM:
             info = self._mems_info[element]
-            addrs = self._memory_element_addresses(
-                element, info, rw.get_offset()
-            )
+            addrs = self._memory_element_addresses(element, info, rw.get_offset())
             bus_width = self.get_n_bytes()
             byte_offset = 0
         else:
@@ -1074,10 +1126,12 @@ class uvm_reg_map(uvm_object):
         ):
             local_addr = lbase_addr2 * n_addrs
         else:
-            logger.error(
+            _report_error(
+                self,
+                "REG_MAP",
                 "Map has no specified endianness. Cannot access "
                 f"{repr(n_bytes)} bytes register via its {repr(bus_width)} "
-                f"byte {repr(self.get_full_name())} interface"
+                f"byte {repr(self.get_full_name())} interface",
             )
 
         # Scale into upper map's address space

--- a/pyuvm/_reg/uvm_reg_model.py
+++ b/pyuvm/_reg/uvm_reg_model.py
@@ -146,9 +146,11 @@ class uvm_reg_frontdoor:
         raise NotImplementedError
 
 
+@dataclass(frozen=True)
 class uvm_reg_map_addr_range:
-    def __init__(self):
-        raise NotImplementedError
+    min: uvm_reg_addr_t
+    max: uvm_reg_addr_t
+    stride: int = 1
 
 
 class uvm_object_string_pool(uvm_object):

--- a/pyuvm/_reg/uvm_reg_reporting.py
+++ b/pyuvm/_reg/uvm_reg_reporting.py
@@ -1,0 +1,27 @@
+"""Shared reporting helpers for the register abstraction layer."""
+
+import logging
+from typing import Any
+
+from pyuvm.uvm_reporting import get_sv_uvm_style_reporting_enabled
+
+_reg_model_logger = logging.getLogger("RegModel")
+
+
+def uvm_reg_report_warning(obj: Any, report_id: str, msg: str) -> None:
+    """Issue a RAL warning through SV-UVM reporting or the RegModel logger."""
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.warning(report_id, msg)
+    else:
+        _reg_model_logger.warning(msg)
+
+
+def uvm_reg_report_error(obj: Any, report_id: str, msg: str) -> None:
+    """Issue a RAL error through SV-UVM reporting or the RegModel logger."""
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.error(report_id, msg)
+    else:
+        _reg_model_logger.error(msg)
+
+
+__all__ = ["uvm_reg_report_error", "uvm_reg_report_warning"]

--- a/pyuvm/uvm_reporting/__init__.py
+++ b/pyuvm/uvm_reporting/__init__.py
@@ -4,7 +4,6 @@
 
 """UVM reporting helpers."""
 
-import logging
 import os
 from typing import Any
 
@@ -26,7 +25,6 @@ def _parse_bool(value: Any) -> bool:
 
 
 _sv_uvm_style_reporting_enabled = _parse_bool(os.getenv(_ENV_VAR, "0"))
-_reg_model_logger = logging.getLogger("RegModel")
 
 
 def set_sv_uvm_style_reporting_enabled(enabled: bool) -> None:
@@ -41,22 +39,6 @@ def get_sv_uvm_style_reporting_enabled() -> bool:
     if plusarg_value is not None:
         return _parse_bool(plusarg_value)
     return _sv_uvm_style_reporting_enabled
-
-
-def uvm_report_warning(obj: Any, report_id: str, msg: str) -> None:
-    """Issue a warning through SV-UVM reporting or the RegModel logger."""
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.warning(report_id, msg)
-    else:
-        _reg_model_logger.warning(msg)
-
-
-def uvm_report_error(obj: Any, report_id: str, msg: str) -> None:
-    """Issue an error through SV-UVM reporting or the RegModel logger."""
-    if get_sv_uvm_style_reporting_enabled():
-        obj.uvm_report.error(report_id, msg)
-    else:
-        _reg_model_logger.error(msg)
 
 
 from pyuvm.uvm_reporting.uvm_verbosity import (
@@ -90,7 +72,5 @@ __all__ = [
     "resolve_uvm_verbosity",
     "get_sv_uvm_style_reporting_enabled",
     "set_sv_uvm_style_reporting_enabled",
-    "uvm_report_error",
-    "uvm_report_warning",
     "uvm_reporter",
 ]

--- a/pyuvm/uvm_reporting/__init__.py
+++ b/pyuvm/uvm_reporting/__init__.py
@@ -4,6 +4,7 @@
 
 """UVM reporting helpers."""
 
+import logging
 import os
 from typing import Any
 
@@ -25,6 +26,7 @@ def _parse_bool(value: Any) -> bool:
 
 
 _sv_uvm_style_reporting_enabled = _parse_bool(os.getenv(_ENV_VAR, "0"))
+_reg_model_logger = logging.getLogger("RegModel")
 
 
 def set_sv_uvm_style_reporting_enabled(enabled: bool) -> None:
@@ -39,6 +41,22 @@ def get_sv_uvm_style_reporting_enabled() -> bool:
     if plusarg_value is not None:
         return _parse_bool(plusarg_value)
     return _sv_uvm_style_reporting_enabled
+
+
+def uvm_report_warning(obj: Any, report_id: str, msg: str) -> None:
+    """Issue a warning through SV-UVM reporting or the RegModel logger."""
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.warning(report_id, msg)
+    else:
+        _reg_model_logger.warning(msg)
+
+
+def uvm_report_error(obj: Any, report_id: str, msg: str) -> None:
+    """Issue an error through SV-UVM reporting or the RegModel logger."""
+    if get_sv_uvm_style_reporting_enabled():
+        obj.uvm_report.error(report_id, msg)
+    else:
+        _reg_model_logger.error(msg)
 
 
 from pyuvm.uvm_reporting.uvm_verbosity import (
@@ -72,5 +90,7 @@ __all__ = [
     "resolve_uvm_verbosity",
     "get_sv_uvm_style_reporting_enabled",
     "set_sv_uvm_style_reporting_enabled",
+    "uvm_report_error",
+    "uvm_report_warning",
     "uvm_reporter",
 ]

--- a/tests/pytests/reg/test_uvm_mem_construction.py
+++ b/tests/pytests/reg/test_uvm_mem_construction.py
@@ -1,0 +1,157 @@
+import io
+import logging
+
+import pytest
+
+from pyuvm import uvm_hier_e, uvm_mem, uvm_reg_block
+from pyuvm._error_classes import UVMFatalError
+from pyuvm.uvm_reporting import set_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting.uvm_report_server import (
+    uvm_report_policy,
+    uvm_report_server,
+)
+
+
+def test_memory_construction_normalizes_shape_access_and_width():
+    mem = uvm_mem("storage", 16, 13, "ro")
+
+    assert mem.get_name() == "storage"
+    assert mem.get_size() == 16
+    assert mem.get_n_bits() == 13
+    assert mem.get_n_bytes() == 2
+    assert mem.get_access() == "RO"
+    assert mem.get_max_size() >= 13
+
+
+@pytest.mark.parametrize(
+    ("size", "n_bits", "expected_message"),
+    [
+        (0, 8, "cannot have fewer than 1 location"),
+        (4, 0, "cannot have fewer than 1 bit"),
+    ],
+)
+def test_memory_construction_repairs_non_positive_dimensions(
+    size, n_bits, expected_message, caplog
+):
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        mem = uvm_mem("invalid_shape", size, n_bits)
+
+    assert mem.get_size() >= 1
+    assert mem.get_n_bits() >= 1
+    assert expected_message in caplog.text
+
+
+def test_memory_construction_repairs_unsupported_access(caplog):
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        mem = uvm_mem("invalid_access", 4, 8, "write_once")
+
+    assert mem.get_access() == "RW"
+    assert "can only have 'RW' or 'RO' access" in caplog.text
+
+
+def test_memory_configure_requires_a_parent():
+    mem = uvm_mem("orphan", 4, 8)
+
+    with pytest.raises(UVMFatalError, match="parent is None"):
+        mem.configure(None)
+
+
+def test_memory_configure_registers_with_block_and_name_lookup():
+    block = uvm_reg_block("top")
+    mem = uvm_mem("storage", 16, 32)
+
+    mem.configure(block)
+
+    assert mem.get_parent() is block
+    assert mem.get_block() is block
+    assert mem.get_full_name() == "top.storage"
+    assert block.get_memories(uvm_hier_e.UVM_NO_HIER) == [mem]
+    assert block.get_mem_by_name("storage") is mem
+    assert mem._mam is None
+
+
+def test_memory_enumeration_honors_hierarchy():
+    top = uvm_reg_block("top")
+    child = uvm_reg_block("child")
+    child.configure(top)
+    local_mem = uvm_mem("local", 2, 8)
+    child_mem = uvm_mem("nested", 2, 8)
+    local_mem.configure(top)
+    child_mem.configure(child)
+
+    assert top.get_memories(uvm_hier_e.UVM_NO_HIER) == [local_mem]
+    assert top.get_memories() == [local_mem, child_mem]
+    assert top.get_mem_by_name("nested") is child_mem
+
+
+def test_lock_model_locks_memory():
+    block = uvm_reg_block("top")
+    mem = uvm_mem("storage", 4, 8)
+    mem.configure(block)
+
+    block.lock_model()
+
+    assert block.is_locked()
+    assert mem._locked
+
+
+def test_configuring_memory_into_locked_block_is_rejected(caplog):
+    block = uvm_reg_block("top")
+    block.lock_model()
+    mem = uvm_mem("late", 4, 8)
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        mem.configure(block)
+
+    assert block.get_memories() == []
+    assert "Cannot add memory to a locked block model" in caplog.text
+
+
+def test_configuring_same_memory_twice_is_rejected(caplog):
+    block = uvm_reg_block("top")
+    mem = uvm_mem("duplicate", 4, 8)
+    mem.configure(block)
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        mem.configure(block)
+
+    assert block.get_memories() == [mem]
+    assert "has already been registered" in caplog.text
+
+
+def test_memory_constructor_errors_use_sv_uvm_reporting_when_enabled():
+    root_logger = logging.getLogger("uvm")
+    old_level = root_logger.level
+    old_propagate = root_logger.propagate
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+
+    set_sv_uvm_style_reporting_enabled(True)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.propagate = False
+    manager = uvm_report_server.create(
+        policy=uvm_report_policy(max_quit_count=0),
+        root_logger=root_logger,
+    )
+
+    try:
+        mem = uvm_mem("invalid", 0, 0, "unsupported")
+
+        assert mem.get_size() == 1
+        assert mem.get_n_bits() == 1
+        assert mem.get_access() == "RW"
+        output = stream.getvalue()
+        assert "[MEM_SIZE] Memory 'invalid' cannot have fewer than 1 location" in output
+        assert "[MEM_WIDTH] Memory 'invalid' cannot have fewer than 1 bit" in output
+        assert "[MEM_ACCESS] Memory 'invalid' can only have 'RW' or 'RO'" in output
+        assert manager.get_stats().error_count == 3
+    finally:
+        manager.shutdown()
+        manager.clear_counts()
+        manager.catcher.clear()
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(old_level)
+        root_logger.propagate = old_propagate
+        set_sv_uvm_style_reporting_enabled(False)

--- a/tests/pytests/reg/test_uvm_mem_construction.py
+++ b/tests/pytests/reg/test_uvm_mem_construction.py
@@ -3,7 +3,7 @@ import logging
 
 import pytest
 
-from pyuvm import uvm_hier_e, uvm_mem, uvm_reg_block
+from pyuvm import uvm_endianness_e, uvm_hier_e, uvm_mem, uvm_reg, uvm_reg_block
 from pyuvm._error_classes import UVMFatalError
 from pyuvm.uvm_reporting import set_sv_uvm_style_reporting_enabled
 from pyuvm.uvm_reporting.uvm_report_server import (
@@ -155,3 +155,147 @@ def test_memory_constructor_errors_use_sv_uvm_reporting_when_enabled():
         root_logger.setLevel(old_level)
         root_logger.propagate = old_propagate
         set_sv_uvm_style_reporting_enabled(False)
+
+
+def test_memory_offset_warning_uses_sv_uvm_reporting_when_enabled():
+    root_logger = logging.getLogger("uvm")
+    old_level = root_logger.level
+    old_propagate = root_logger.propagate
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+
+    set_sv_uvm_style_reporting_enabled(True)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.propagate = False
+    manager = uvm_report_server.create(
+        policy=uvm_report_policy(max_quit_count=0),
+        root_logger=root_logger,
+    )
+
+    try:
+        block = uvm_reg_block("top")
+        reg_map = block.create_map(
+            "map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
+        )
+        mem = uvm_mem("storage", 4, 8)
+        mem.configure(block)
+        reg_map.add_mem(mem, 0)
+        block.lock_model()
+
+        assert mem.get_addresses(-1, reg_map) == (-1, [])
+        assert (
+            "[MEM_OFFSET] Offset 0x-1 lies outside of memory 'storage'"
+            in stream.getvalue()
+        )
+        assert manager.get_stats().warning_count == 1
+    finally:
+        manager.shutdown()
+        manager.clear_counts()
+        manager.catcher.clear()
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(old_level)
+        root_logger.propagate = old_propagate
+        set_sv_uvm_style_reporting_enabled(False)
+
+
+def test_block_and_map_diagnostics_use_sv_uvm_reporting_when_enabled():
+    root_logger = logging.getLogger("uvm")
+    old_level = root_logger.level
+    old_propagate = root_logger.propagate
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+
+    set_sv_uvm_style_reporting_enabled(True)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.propagate = False
+    manager = uvm_report_server.create(
+        policy=uvm_report_policy(max_quit_count=0),
+        root_logger=root_logger,
+    )
+
+    try:
+        block = uvm_reg_block("top")
+        reg_map = block.create_map(
+            "map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
+        )
+        other_block = uvm_reg_block("other")
+        other_map = other_block.create_map(
+            "other_map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
+        )
+
+        block.set_default_map(other_map)
+        block.get_map_by_name("missing")
+
+        first = uvm_mem("first", 2, 8)
+        second = uvm_mem("second", 2, 8)
+        first.configure(block)
+        second.configure(block)
+        reg_map.add_mem(first, 0)
+        reg_map.add_mem(first, 0)
+        reg_map.add_mem(second, 0)
+        block.lock_model()
+
+        output = stream.getvalue()
+        assert "[REG_BLOCK] Map 'other_map' does not exist in block" in output
+        assert "[REG_MAP] Memory 'first' has already been added" in output
+        assert "[REG_MAP] In map 'top.map' memory 'top.second' overlaps" in output
+        assert manager.get_stats().error_count == 2
+        assert manager.get_stats().warning_count == 2
+    finally:
+        manager.shutdown()
+        manager.clear_counts()
+        manager.catcher.clear()
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(old_level)
+        root_logger.propagate = old_propagate
+        set_sv_uvm_style_reporting_enabled(False)
+
+
+def test_block_diagnostic_paths_are_reported(caplog):
+    block = uvm_reg_block("diagnostic_block")
+    child = uvm_reg_block("child")
+    child.configure(block)
+    reg_map = block.create_map(
+        "map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
+    )
+    reg = uvm_reg("reg", 8)
+    reg.configure(block)
+    mem = uvm_mem("mem", 1, 8)
+    mem.configure(block)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        block._add_block(child)
+        block._add_map(reg_map)
+        block._add_register(reg)
+        empty_block = uvm_reg_block("empty")
+        empty_block.get_block_by_name("missing")
+        empty_block.get_map_by_name("missing")
+        empty_block.get_reg_by_name("missing")
+        empty_block.get_field_by_name("missing")
+        empty_block.get_mem_by_name("missing")
+        empty_block.get_vreg_by_name("missing")
+        empty_block.get_vfield_by_name("missing")
+
+        block.lock_model()
+        block._add_block(uvm_reg_block("late_child"))
+        block._add_map(reg_map)
+        block._add_register(uvm_reg("late_reg", 8))
+        block._add_memory(uvm_mem("late_mem", 1, 8))
+
+    assert "already been registered" in caplog.text
+    assert "Unable to locate virtual field" in caplog.text
+    assert "Cannot add memory to a locked block model" in caplog.text
+
+
+def test_duplicate_root_name_diagnostic_is_reported(monkeypatch, caplog):
+    monkeypatch.setattr(uvm_reg_block, "_root_names", ["duplicate", "duplicate"])
+    block = uvm_reg_block("duplicate")
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        block.lock_model()
+
+    assert "There are 2 root register models" in caplog.text

--- a/tests/pytests/reg/test_uvm_mem_construction.py
+++ b/tests/pytests/reg/test_uvm_mem_construction.py
@@ -182,7 +182,7 @@ def test_memory_offset_warning_uses_sv_uvm_reporting_when_enabled():
         reg_map.add_mem(mem, 0)
         block.lock_model()
 
-        assert mem.get_addresses(-1, reg_map) == (-1, [])
+        assert mem.get_addresses(-1, reg_map) == (None, [])
         assert (
             "[MEM_OFFSET] Offset 0x-1 lies outside of memory 'storage'"
             in stream.getvalue()

--- a/tests/pytests/reg/test_uvm_mem_construction.py
+++ b/tests/pytests/reg/test_uvm_mem_construction.py
@@ -176,9 +176,7 @@ def test_memory_offset_warning_uses_sv_uvm_reporting_when_enabled():
 
     try:
         block = uvm_reg_block("top")
-        reg_map = block.create_map(
-            "map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
-        )
+        reg_map = block.create_map("map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN)
         mem = uvm_mem("storage", 4, 8)
         mem.configure(block)
         reg_map.add_mem(mem, 0)
@@ -219,9 +217,7 @@ def test_block_and_map_diagnostics_use_sv_uvm_reporting_when_enabled():
 
     try:
         block = uvm_reg_block("top")
-        reg_map = block.create_map(
-            "map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
-        )
+        reg_map = block.create_map("map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN)
         other_block = uvm_reg_block("other")
         other_map = other_block.create_map(
             "other_map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
@@ -259,9 +255,7 @@ def test_block_diagnostic_paths_are_reported(caplog):
     block = uvm_reg_block("diagnostic_block")
     child = uvm_reg_block("child")
     child.configure(block)
-    reg_map = block.create_map(
-        "map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN
-    )
+    reg_map = block.create_map("map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN)
     reg = uvm_reg("reg", 8)
     reg.configure(block)
     mem = uvm_mem("mem", 1, 8)

--- a/tests/pytests/reg/test_uvm_mem_frontdoor.py
+++ b/tests/pytests/reg/test_uvm_mem_frontdoor.py
@@ -1,5 +1,4 @@
 import pytest
-
 from async_helpers import run_pytest_coro
 from test_uvm_reg_frontdoor_adapter import (
     AsyncNoopLock,

--- a/tests/pytests/reg/test_uvm_mem_frontdoor.py
+++ b/tests/pytests/reg/test_uvm_mem_frontdoor.py
@@ -1,0 +1,217 @@
+import pytest
+
+from async_helpers import run_pytest_coro
+from test_uvm_reg_frontdoor_adapter import (
+    AsyncNoopLock,
+    MockSequencer,
+    RecordingAdapter,
+)
+
+from pyuvm import (
+    uvm_access_e,
+    uvm_door_e,
+    uvm_endianness_e,
+    uvm_mem,
+    uvm_reg_block,
+    uvm_status_e,
+)
+
+
+def build_memory(
+    *,
+    size=4,
+    n_bits=16,
+    access="RW",
+    rights="RW",
+    unmapped=False,
+    adapter=None,
+    sequencer=None,
+):
+    block = uvm_reg_block("mem_block")
+    reg_map = block.create_map(
+        "map", 0x1000, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    mem = uvm_mem("storage", size, n_bits, access)
+    mem.configure(block)
+    reg_map.add_mem(mem, 0x20, rights=rights, unmapped=unmapped)
+    block.lock_model()
+    mem._atomic = AsyncNoopLock()
+    if sequencer is not None:
+        reg_map.set_sequencer(sequencer, adapter)
+    return reg_map, mem
+
+
+def test_memory_write_and_read_use_selected_element_address():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer(read_data=0xBEEF)
+    reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
+
+    write_status = run_pytest_coro(
+        mem.write(2, 0x1234, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+    read_status, value = run_pytest_coro(
+        mem.read(1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert write_status == uvm_status_e.UVM_IS_OK
+    assert read_status == uvm_status_e.UVM_IS_OK
+    assert value == 0xBEEF
+    write_op, read_op = adapter.reg2bus_ops
+    assert write_op.kind == uvm_access_e.UVM_WRITE
+    assert write_op.addr == 0x1024
+    assert write_op.data == 0x1234
+    assert write_op.n_bits == 16
+    assert write_op.byte_en == 0x3
+    assert read_op.kind == uvm_access_e.UVM_READ
+    assert read_op.addr == 0x1022
+    assert read_op.n_bits == 16
+
+
+@pytest.mark.parametrize("offset", [-1, 4])
+def test_out_of_range_access_does_not_reach_adapter(offset):
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
+
+    status = run_pytest_coro(
+        mem.write(offset, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert adapter.reg2bus_ops == []
+
+
+def test_unmapped_access_does_not_reach_adapter():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(
+        unmapped=True, adapter=adapter, sequencer=sequencer
+    )
+
+    status, value = run_pytest_coro(
+        mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert value == 0
+    assert adapter.reg2bus_ops == []
+
+
+def test_read_only_memory_rejects_write_before_adapter():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(
+        access="RO", adapter=adapter, sequencer=sequencer
+    )
+
+    status = run_pytest_coro(
+        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert adapter.reg2bus_ops == []
+
+
+def test_read_only_map_rights_reject_write_before_adapter():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(
+        rights="RO", adapter=adapter, sequencer=sequencer
+    )
+
+    status = run_pytest_coro(
+        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert mem.get_rights(reg_map) == "RO"
+    assert mem.get_access(reg_map) == "RO"
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert adapter.reg2bus_ops == []
+
+
+def test_wide_memory_rejects_unsupported_multibeat_access():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(
+        n_bits=64, adapter=adapter, sequencer=sequencer
+    )
+
+    status = run_pytest_coro(
+        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert adapter.reg2bus_ops == []
+
+
+def test_adapter_status_and_read_mask_are_propagated():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer(
+        read_data=0x1FFFF, read_status=uvm_status_e.UVM_NOT_OK
+    )
+    reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
+
+    status, value = run_pytest_coro(
+        mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert value == 0xFFFF
+
+
+def test_default_door_and_default_map_are_resolved():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer(read_data=0x1234)
+    reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
+
+    status, value = run_pytest_coro(mem.read(0))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert value == 0x1234
+    assert adapter.reg2bus_ops[-1].addr == 0x1020
+
+
+def test_non_frontdoor_access_is_rejected_before_adapter():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
+
+    status = run_pytest_coro(
+        mem.write(0, 1, uvm_door_e.UVM_BACKDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert adapter.reg2bus_ops == []
+
+
+def test_access_through_unrelated_map_is_rejected():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
+    other_block = uvm_reg_block("other")
+    other_map = other_block.create_map(
+        "other_map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+
+    status = run_pytest_coro(
+        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, other_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert adapter.reg2bus_ops == []
+
+
+def test_write_only_map_rights_reject_read_before_adapter():
+    adapter = RecordingAdapter()
+    sequencer = MockSequencer()
+    reg_map, mem = build_memory(
+        rights="WO", adapter=adapter, sequencer=sequencer
+    )
+
+    status, value = run_pytest_coro(
+        mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert value == 0
+    assert adapter.reg2bus_ops == []

--- a/tests/pytests/reg/test_uvm_mem_frontdoor.py
+++ b/tests/pytests/reg/test_uvm_mem_frontdoor.py
@@ -48,9 +48,7 @@ def test_memory_write_and_read_use_selected_element_address():
     write_status = run_pytest_coro(
         mem.write(2, 0x1234, uvm_door_e.UVM_FRONTDOOR, reg_map)
     )
-    read_status, value = run_pytest_coro(
-        mem.read(1, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    read_status, value = run_pytest_coro(mem.read(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert write_status == uvm_status_e.UVM_IS_OK
     assert read_status == uvm_status_e.UVM_IS_OK
@@ -72,9 +70,7 @@ def test_out_of_range_access_does_not_reach_adapter(offset):
     sequencer = MockSequencer()
     reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
 
-    status = run_pytest_coro(
-        mem.write(offset, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    status = run_pytest_coro(mem.write(offset, 1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert adapter.reg2bus_ops == []
@@ -83,13 +79,9 @@ def test_out_of_range_access_does_not_reach_adapter(offset):
 def test_unmapped_access_does_not_reach_adapter():
     adapter = RecordingAdapter()
     sequencer = MockSequencer()
-    reg_map, mem = build_memory(
-        unmapped=True, adapter=adapter, sequencer=sequencer
-    )
+    reg_map, mem = build_memory(unmapped=True, adapter=adapter, sequencer=sequencer)
 
-    status, value = run_pytest_coro(
-        mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    status, value = run_pytest_coro(mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert value == 0
@@ -99,13 +91,9 @@ def test_unmapped_access_does_not_reach_adapter():
 def test_read_only_memory_rejects_write_before_adapter():
     adapter = RecordingAdapter()
     sequencer = MockSequencer()
-    reg_map, mem = build_memory(
-        access="RO", adapter=adapter, sequencer=sequencer
-    )
+    reg_map, mem = build_memory(access="RO", adapter=adapter, sequencer=sequencer)
 
-    status = run_pytest_coro(
-        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    status = run_pytest_coro(mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert adapter.reg2bus_ops == []
@@ -114,13 +102,9 @@ def test_read_only_memory_rejects_write_before_adapter():
 def test_read_only_map_rights_reject_write_before_adapter():
     adapter = RecordingAdapter()
     sequencer = MockSequencer()
-    reg_map, mem = build_memory(
-        rights="RO", adapter=adapter, sequencer=sequencer
-    )
+    reg_map, mem = build_memory(rights="RO", adapter=adapter, sequencer=sequencer)
 
-    status = run_pytest_coro(
-        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    status = run_pytest_coro(mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert mem.get_rights(reg_map) == "RO"
     assert mem.get_access(reg_map) == "RO"
@@ -131,13 +115,9 @@ def test_read_only_map_rights_reject_write_before_adapter():
 def test_wide_memory_rejects_unsupported_multibeat_access():
     adapter = RecordingAdapter()
     sequencer = MockSequencer()
-    reg_map, mem = build_memory(
-        n_bits=64, adapter=adapter, sequencer=sequencer
-    )
+    reg_map, mem = build_memory(n_bits=64, adapter=adapter, sequencer=sequencer)
 
-    status = run_pytest_coro(
-        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    status = run_pytest_coro(mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert adapter.reg2bus_ops == []
@@ -145,14 +125,10 @@ def test_wide_memory_rejects_unsupported_multibeat_access():
 
 def test_adapter_status_and_read_mask_are_propagated():
     adapter = RecordingAdapter()
-    sequencer = MockSequencer(
-        read_data=0x1FFFF, read_status=uvm_status_e.UVM_NOT_OK
-    )
+    sequencer = MockSequencer(read_data=0x1FFFF, read_status=uvm_status_e.UVM_NOT_OK)
     reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
 
-    status, value = run_pytest_coro(
-        mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    status, value = run_pytest_coro(mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert value == 0xFFFF
@@ -175,9 +151,7 @@ def test_non_frontdoor_access_is_rejected_before_adapter():
     sequencer = MockSequencer()
     reg_map, mem = build_memory(adapter=adapter, sequencer=sequencer)
 
-    status = run_pytest_coro(
-        mem.write(0, 1, uvm_door_e.UVM_BACKDOOR, reg_map)
-    )
+    status = run_pytest_coro(mem.write(0, 1, uvm_door_e.UVM_BACKDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert adapter.reg2bus_ops == []
@@ -192,9 +166,7 @@ def test_access_through_unrelated_map_is_rejected():
         "other_map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
     )
 
-    status = run_pytest_coro(
-        mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, other_map)
-    )
+    status = run_pytest_coro(mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, other_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert adapter.reg2bus_ops == []
@@ -203,13 +175,9 @@ def test_access_through_unrelated_map_is_rejected():
 def test_write_only_map_rights_reject_read_before_adapter():
     adapter = RecordingAdapter()
     sequencer = MockSequencer()
-    reg_map, mem = build_memory(
-        rights="WO", adapter=adapter, sequencer=sequencer
-    )
+    reg_map, mem = build_memory(rights="WO", adapter=adapter, sequencer=sequencer)
 
-    status, value = run_pytest_coro(
-        mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map)
-    )
+    status, value = run_pytest_coro(mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
     assert status == uvm_status_e.UVM_NOT_OK
     assert value == 0

--- a/tests/pytests/reg/test_uvm_mem_mapping.py
+++ b/tests/pytests/reg/test_uvm_mem_mapping.py
@@ -1,0 +1,278 @@
+import logging
+
+import pytest
+
+from pyuvm import (
+    uvm_endianness_e,
+    uvm_mem,
+    uvm_reg,
+    uvm_reg_block,
+)
+
+
+def make_map(name="top", base=0, n_bytes=4, byte_addressing=True):
+    block = uvm_reg_block(name)
+    reg_map = block.create_map(
+        "map",
+        base,
+        n_bytes,
+        uvm_endianness_e.UVM_LITTLE_ENDIAN,
+        byte_addressing,
+    )
+    return block, reg_map
+
+
+def add_memory(block, reg_map, name="mem", size=4, n_bits=16, offset=0x10):
+    mem = uvm_mem(name, size, n_bits)
+    mem.configure(block)
+    reg_map.add_mem(mem, offset)
+    return mem
+
+
+def test_add_mem_records_map_info_and_membership():
+    block, reg_map = make_map(base=0x100)
+    mem = add_memory(block, reg_map, offset=0x20)
+
+    block.lock_model()
+    info = reg_map.get_mem_map_info(mem)
+
+    assert mem.get_maps([]) == [reg_map]
+    assert mem.get_n_maps() == 1
+    assert mem.is_in_map(reg_map)
+    assert reg_map.get_memories() == [mem]
+    assert info.offset == 0x20
+    assert info.rights == "RW"
+    assert info.stride == 2
+    assert info.addr == [0x120]
+    assert info.mem_range.min == 0x120
+    assert info.mem_range.max == 0x126
+    assert info.is_initialized
+
+
+def test_byte_addressed_memory_offsets_addresses_and_stride_holes():
+    block, reg_map = make_map(base=0x100, byte_addressing=True)
+    mem = add_memory(block, reg_map, size=3, n_bits=16, offset=0x20)
+    block.lock_model()
+
+    assert mem.get_offset(0, reg_map) == 0x20
+    assert mem.get_offset(2, reg_map) == 0x24
+    assert mem.get_address(0, reg_map) == 0x120
+    assert mem.get_address(1, reg_map) == 0x122
+    assert mem.get_addresses(2, reg_map) == (4, [0x124])
+    assert reg_map.get_mem_by_offset(0x120) is mem
+    assert reg_map.get_mem_by_offset(0x122) is mem
+    assert reg_map.get_mem_by_offset(0x121) is None
+    assert reg_map.get_mem_by_offset(0x123) is None
+
+
+def test_word_addressed_memory_uses_map_address_units():
+    block, reg_map = make_map(base=0x40, n_bytes=4, byte_addressing=False)
+    mem = add_memory(block, reg_map, size=3, n_bits=32, offset=0x8)
+    block.lock_model()
+
+    assert reg_map.get_mem_map_info(mem).stride == 1
+    assert mem.get_offset(2, reg_map) == 0xA
+    assert mem.get_address(0, reg_map) == 0x48
+    assert mem.get_address(2, reg_map) == 0x4A
+    assert reg_map.get_mem_by_offset(0x49) is mem
+
+
+def test_wide_memory_elements_occupy_each_bus_address():
+    block, reg_map = make_map(base=0x100, n_bytes=4, byte_addressing=False)
+    mem = add_memory(block, reg_map, size=2, n_bits=64, offset=0x4)
+    block.lock_model()
+
+    assert reg_map.get_mem_map_info(mem).stride == 2
+    assert mem.get_addresses(0, reg_map) == (4, [0x104, 0x105])
+    assert mem.get_addresses(1, reg_map) == (4, [0x106, 0x107])
+    for address in range(0x104, 0x108):
+        assert reg_map.get_mem_by_offset(address) is mem
+
+
+def test_unmapped_memory_has_no_addresses_or_lookup_entries():
+    block, reg_map = make_map()
+    mem = uvm_mem("unmapped", 4, 32)
+    mem.configure(block)
+    reg_map.add_mem(mem, 0x10, unmapped=True)
+    block.lock_model()
+
+    info = reg_map.get_mem_map_info(mem)
+    assert info.unmapped
+    assert info.addr == []
+    assert info.mem_range is None
+    assert mem.get_offset(0, reg_map) == -1
+    assert mem.get_addresses(0, reg_map) == (-1, [])
+    assert reg_map.get_mem_by_offset(0x10) is None
+
+
+def test_set_mem_offset_rebuilds_locked_lookup():
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map, size=2, n_bits=32, offset=0x10)
+    block.lock_model()
+
+    mem.set_offset(reg_map, 0x20)
+
+    assert reg_map.get_mem_by_offset(0x10) is None
+    assert reg_map.get_mem_by_offset(0x20) is mem
+    assert mem.get_address(1, reg_map) == 0x24
+
+
+def test_actual_memory_and_register_overlap_is_reported(caplog):
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map, size=2, n_bits=16, offset=0x10)
+    reg = uvm_reg("overlap", 32)
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x12)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        block.lock_model()
+
+    assert "overlaps register" in caplog.text
+    # The stride hole at 0x11 remains unoccupied and produces no false overlap.
+    assert reg_map.get_mem_by_offset(0x11) is None
+
+
+def test_non_overlapping_memories_can_share_bounding_interval_without_warning(caplog):
+    block, reg_map = make_map()
+    even = add_memory(block, reg_map, "even", size=3, n_bits=16, offset=0x10)
+    odd = add_memory(block, reg_map, "odd", size=3, n_bits=16, offset=0x11)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        block.lock_model()
+
+    assert "overlaps memory" not in caplog.text
+    assert reg_map.get_mem_by_offset(0x10) is even
+    assert reg_map.get_mem_by_offset(0x11) is odd
+
+
+def test_memory_lookup_translates_through_hierarchical_submap():
+    top, root_map = make_map(
+        "top", base=0x100, n_bytes=4, byte_addressing=False
+    )
+    child = uvm_reg_block("child")
+    child.configure(top)
+    child_map = child.create_map(
+        "child_map",
+        0,
+        4,
+        uvm_endianness_e.UVM_LITTLE_ENDIAN,
+        False,
+    )
+    root_map.add_submap(child_map, 0x20)
+    mem = add_memory(child, child_map, size=2, n_bits=32, offset=0x4)
+
+    top.lock_model()
+
+    assert mem.get_address(0, root_map) == 0x124
+    assert mem.get_address(1, root_map) == 0x125
+    assert root_map.get_mem_by_offset(0x124) is mem
+    assert root_map.get_mem_by_offset(0x125) is mem
+
+
+def test_add_mem_rejects_duplicate_and_different_parent_and_repairs_rights(caplog):
+    block, reg_map = make_map()
+    mem = uvm_mem("mem", 2, 8)
+    mem.configure(block)
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        reg_map.add_mem(mem, 0, rights="invalid")
+        reg_map.add_mem(mem, 4)
+
+        other_block = uvm_reg_block("other")
+        other_mem = uvm_mem("other_mem", 2, 8)
+        other_mem.configure(other_block)
+        reg_map.add_mem(other_mem, 8)
+
+    assert reg_map.get_mem_map_info(mem).rights == "RW"
+    assert "invalid map rights" in caplog.text
+    assert "has already been added" in caplog.text
+    assert "not in the same block" in caplog.text
+
+
+def test_overlapping_memories_are_reported(caplog):
+    block, reg_map = make_map()
+    first = add_memory(block, reg_map, "first", size=2, n_bits=32, offset=0x10)
+    second = add_memory(block, reg_map, "second", size=2, n_bits=32, offset=0x14)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        block.lock_model()
+
+    assert "overlaps memory" in caplog.text
+    assert reg_map.get_mem_by_offset(0x10) is first
+    assert reg_map.get_mem_by_offset(0x14) is second
+
+
+def test_set_offset_for_unmapped_memory_and_memory_absent_from_map(caplog):
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map, offset=0x10)
+    absent = uvm_mem("absent", 2, 8)
+    absent.configure(block)
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        reg_map._set_mem_offset(absent, 0x20, False)
+
+    mem.set_offset(reg_map, 0, unmapped=True)
+
+    assert "memory is not mapped" in caplog.text
+    assert reg_map.get_mem_map_info(mem).unmapped
+    assert reg_map.get_mem_by_offset(0x10) is None
+
+
+def test_map_info_and_lookup_diagnostics_before_lock(caplog):
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map)
+    absent = uvm_mem("absent", 2, 8)
+    absent.configure(block)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        assert reg_map.get_mem_map_info(mem) is not None
+    assert "does not seem to be initialized" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        assert reg_map.get_mem_map_info(absent) is None
+        assert reg_map.get_mem_map_info(absent, error=False) is None
+        assert reg_map.get_mem_by_offset(0x10) is None
+    assert "not in map" in caplog.text
+    assert "is not locked" in caplog.text
+
+
+@pytest.mark.parametrize("offset", [-1, 4])
+def test_get_offset_out_of_range_returns_minus_one(offset, caplog):
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map, size=4)
+    block.lock_model()
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        assert mem.get_offset(offset, reg_map) == -1
+    assert "lies outside of memory" in caplog.text
+
+
+def test_get_offset_returns_minus_one_when_memory_has_no_map():
+    mem = uvm_mem("loose", 2, 8)
+
+    assert mem.get_offset() == -1
+
+
+def test_memory_map_selection_and_incompatible_rights_diagnostics(caplog):
+    block = uvm_reg_block("top")
+    first_map = block.create_map(
+        "first", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    second_map = block.create_map(
+        "second", 0x100, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    mem = uvm_mem("storage", 2, 8, "RO")
+    mem.configure(block)
+    first_map.add_mem(mem, 0, rights="WO")
+    second_map.add_mem(mem, 0, rights="RW")
+
+    with caplog.at_level(logging.ERROR, logger="RegModel"):
+        mem.set_offset(None, 4)
+        assert mem.get_access(first_map) == "RO"
+        mem._access = "INVALID"
+        assert mem.get_access(first_map) == "INVALID"
+
+    assert "Set offset requires a map" in caplog.text
+    assert "restricted to WO" in caplog.text
+    assert "invalid access mode" in caplog.text

--- a/tests/pytests/reg/test_uvm_mem_mapping.py
+++ b/tests/pytests/reg/test_uvm_mem_mapping.py
@@ -8,6 +8,10 @@ from pyuvm import (
     uvm_reg,
     uvm_reg_block,
 )
+from pyuvm._reg.uvm_reg_map import (
+    _first_progression_overlap,
+    _uvm_mem_address_set,
+)
 
 
 def make_map(name="top", base=0, n_bytes=4, byte_addressing=True):
@@ -119,7 +123,7 @@ def test_set_mem_offset_rebuilds_locked_lookup():
 
 def test_actual_memory_and_register_overlap_is_reported(caplog):
     block, reg_map = make_map()
-    mem = add_memory(block, reg_map, size=2, n_bits=16, offset=0x10)
+    add_memory(block, reg_map, size=2, n_bits=16, offset=0x10)
     reg = uvm_reg("overlap", 32)
     reg.configure(block)
     reg_map.add_reg(reg, 0x12)
@@ -276,3 +280,94 @@ def test_memory_map_selection_and_incompatible_rights_diagnostics(caplog):
     assert "Set offset requires a map" in caplog.text
     assert "restricted to WO" in caplog.text
     assert "invalid access mode" in caplog.text
+
+
+def test_large_memory_uses_one_compact_lookup_descriptor():
+    block, reg_map = make_map(base=0x100, byte_addressing=True)
+    size = 10_000_000
+    mem = add_memory(
+        block,
+        reg_map,
+        name="large",
+        size=size,
+        n_bits=16,
+        offset=0x20,
+    )
+
+    block.lock_model()
+
+    assert len(reg_map._mems_by_offset) == 1
+    descriptor = reg_map._mems_by_offset[mem]
+    assert descriptor.size == size
+    assert descriptor.first_addresses == (0x120,)
+    assert descriptor.element_strides == (2,)
+    last_address = 0x120 + (size - 1) * 2
+    assert descriptor.max == last_address
+    assert reg_map.get_mem_by_offset(last_address) is mem
+    assert reg_map.get_mem_by_offset(last_address - 1) is None
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        ((0, 2, 2, 10, 2, 2), None),
+        ((5, 0, 1, 5, 0, 1), 5),
+        ((5, 0, 1, 6, 0, 1), None),
+        ((6, 0, 1, 0, 2, 5), 6),
+        ((5, 0, 1, 0, 2, 5), None),
+        ((6, 2, 5, 6, 0, 1), 6),
+        ((6, 2, 5, 5, 0, 1), None),
+        ((0, 4, 5, 2, 4, 5), None),
+        ((0, 4, 10, 6, 6, 10), 12),
+        ((0, 4, 10, 0, 6, 10), 0),
+        ((4, 2, 10, 8, 4, 5), 8),
+        ((0, 4, 2, 6, 6, 1), None),
+    ],
+)
+def test_finite_progression_overlap_cases(args, expected):
+    assert _first_progression_overlap(*args) == expected
+
+
+def test_single_element_address_descriptor_membership_and_disjoint_overlap():
+    mem = uvm_mem("single", 1, 64)
+    descriptor = _uvm_mem_address_set.create(mem, [0x10, 0x11], None)
+    other_mem = uvm_mem("other", 1, 8)
+    other = _uvm_mem_address_set.create(other_mem, [0x20], None)
+
+    assert descriptor.element_strides == (0, 0)
+    assert descriptor.contains(0x10)
+    assert descriptor.contains(0x11)
+    assert not descriptor.contains(0x12)
+    assert not descriptor.contains(0x0F)
+    assert descriptor.first_overlap(other) is None
+
+
+def test_non_overlapping_register_and_memory_paths_are_ignored():
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map, size=2, n_bits=32, offset=0x10)
+    reg = uvm_reg("reg", 32)
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x30)
+    block.lock_model()
+
+    reg.set_offset(reg_map, 0x40)
+
+    assert reg_map.get_mem_by_offset(0x10) is mem
+    assert reg_map.get_reg_by_offset(0x40) is reg
+
+
+def test_single_element_map_descriptor_and_register_remap_overlap(caplog):
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map, size=1, n_bits=32, offset=0x10)
+    reg = uvm_reg("reg", 32)
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x30)
+    block.lock_model()
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        reg.set_offset(reg_map, 0x10)
+
+    descriptor = reg_map._mems_by_offset[mem]
+    assert descriptor.element_strides == (0,)
+    assert descriptor.contains(0x10)
+    assert "overlaps with memory" in caplog.text

--- a/tests/pytests/reg/test_uvm_mem_mapping.py
+++ b/tests/pytests/reg/test_uvm_mem_mapping.py
@@ -163,9 +163,7 @@ def test_non_overlapping_memories_can_share_bounding_interval_without_warning(ca
 
 
 def test_memory_lookup_translates_through_hierarchical_submap():
-    top, root_map = make_map(
-        "top", base=0x100, n_bytes=4, byte_addressing=False
-    )
+    top, root_map = make_map("top", base=0x100, n_bytes=4, byte_addressing=False)
     child = uvm_reg_block("child")
     child.configure(top)
     child_map = child.create_map(

--- a/tests/pytests/reg/test_uvm_mem_mapping.py
+++ b/tests/pytests/reg/test_uvm_mem_mapping.py
@@ -62,11 +62,24 @@ def test_byte_addressed_memory_offsets_addresses_and_stride_holes():
     assert mem.get_offset(2, reg_map) == 0x24
     assert mem.get_address(0, reg_map) == 0x120
     assert mem.get_address(1, reg_map) == 0x122
-    assert mem.get_addresses(2, reg_map) == (4, [0x124])
+    assert mem.get_addresses(2, reg_map) == (2, [0x124])
     assert reg_map.get_mem_by_offset(0x120) is mem
     assert reg_map.get_mem_by_offset(0x122) is mem
     assert reg_map.get_mem_by_offset(0x121) is None
     assert reg_map.get_mem_by_offset(0x123) is None
+
+
+def test_memory_address_introspection_rejects_negative_offset(caplog):
+    block, reg_map = make_map()
+    mem = add_memory(block, reg_map)
+    block.lock_model()
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        assert mem.get_offset(-1, reg_map) == -1
+        assert mem.get_address(-1, reg_map) == -1
+        assert mem.get_addresses(-1, reg_map) == (-1, [])
+
+    assert "Offset 0x-1 lies outside of memory 'mem'" in caplog.text
 
 
 def test_word_addressed_memory_uses_map_address_units():
@@ -354,6 +367,82 @@ def test_non_overlapping_register_and_memory_paths_are_ignored():
 
     assert reg_map.get_mem_by_offset(0x10) is mem
     assert reg_map.get_reg_by_offset(0x40) is reg
+
+
+def test_memory_lookup_diagnostic_paths_are_reported(caplog):
+    mem = uvm_mem("mem", 2, 8)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        assert mem.get_vreg_by_name("missing") is None
+        assert mem.get_vfield_by_name("missing") is None
+        assert mem.get_addresses(0) == (-1, [])
+
+    assert "Unable to find virtual register" in caplog.text
+    assert "Unable to find virtual field" in caplog.text
+    assert "not found in map" in caplog.text
+
+
+def test_register_map_diagnostic_paths_are_reported(caplog):
+    block, reg_map = make_map(n_bytes=4)
+    other_block, other_map = make_map(name="other", n_bytes=2)
+    reg = uvm_reg("reg", 8)
+    reg.configure(block)
+    other_reg = uvm_reg("other_reg", 8)
+    other_reg.configure(other_block)
+    missing_reg = uvm_reg("missing_reg", 8)
+    missing_reg.configure(block)
+    mem = uvm_mem("mem", 1, 8)
+    mem.configure(block)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        reg_map.add_reg(reg, 0)
+        reg_map.add_reg(reg, 0)
+        reg_map.add_reg(other_reg, 4)
+        reg_map.get_reg_map_info(reg)
+        reg_map.get_reg_map_info(missing_reg)
+        reg_map.get_mem_map_info(mem)
+        assert reg_map.get_reg_by_offset(0) is None
+        assert reg_map.get_mem_by_offset(0) is None
+        reg_map._set_reg_offset(missing_reg, 4, False)
+        reg_map.set_sequencer(None)
+        reg_map.set_submap_offset(None, 0)
+        assert reg_map.get_submap_offset(other_map) == -1
+        assert reg_map.get_submap_offset(None) == -1
+        other_map._add_parent_map(None, 0)
+
+        reg_map.add_submap(other_map, 0x10)
+        reg_map.add_submap(other_map, 0x20)
+
+        reg_map.add_submap(None, 0)
+
+        reg_map._endian = None
+        with pytest.raises(TypeError):
+            reg_map.get_physical_addresses(0, 0, 1)
+
+    assert "has already been added" in caplog.text
+    assert "not in map" in caplog.text
+    assert "None value specified for bus sequencer" in caplog.text
+    assert "already a child" in caplog.text
+    assert "Map has no specified endianness" in caplog.text
+
+
+def test_register_overlap_diagnostics_are_reported(caplog):
+    block, reg_map = make_map()
+    first = uvm_reg("first", 32)
+    second = uvm_reg("second", 32)
+    third = uvm_reg("third", 32)
+    first.configure(block)
+    second.configure(block)
+    third.configure(block)
+    reg_map.add_reg(first, 0x10)
+    reg_map.add_reg(second, 0x20)
+    reg_map.add_reg(third, 0x10)
+
+    with caplog.at_level(logging.WARNING, logger="RegModel"):
+        block.lock_model()
+        second.set_offset(reg_map, 0x10)
+
+    assert "maps to same address" in caplog.text
 
 
 def test_single_element_map_descriptor_and_register_remap_overlap(caplog):

--- a/tests/pytests/reg/test_uvm_mem_mapping.py
+++ b/tests/pytests/reg/test_uvm_mem_mapping.py
@@ -75,9 +75,9 @@ def test_memory_address_introspection_rejects_negative_offset(caplog):
     block.lock_model()
 
     with caplog.at_level(logging.WARNING, logger="RegModel"):
-        assert mem.get_offset(-1, reg_map) == -1
-        assert mem.get_address(-1, reg_map) == -1
-        assert mem.get_addresses(-1, reg_map) == (-1, [])
+        assert mem.get_offset(-1, reg_map) is None
+        assert mem.get_address(-1, reg_map) is None
+        assert mem.get_addresses(-1, reg_map) == (None, [])
 
     assert "Offset 0x-1 lies outside of memory 'mem'" in caplog.text
 
@@ -117,8 +117,8 @@ def test_unmapped_memory_has_no_addresses_or_lookup_entries():
     assert info.unmapped
     assert info.addr == []
     assert info.mem_range is None
-    assert mem.get_offset(0, reg_map) == -1
-    assert mem.get_addresses(0, reg_map) == (-1, [])
+    assert mem.get_offset(0, reg_map) is None
+    assert mem.get_addresses(0, reg_map) == (None, [])
     assert reg_map.get_mem_by_offset(0x10) is None
 
 
@@ -259,14 +259,14 @@ def test_get_offset_out_of_range_returns_minus_one(offset, caplog):
     block.lock_model()
 
     with caplog.at_level(logging.WARNING, logger="RegModel"):
-        assert mem.get_offset(offset, reg_map) == -1
+        assert mem.get_offset(offset, reg_map) is None
     assert "lies outside of memory" in caplog.text
 
 
 def test_get_offset_returns_minus_one_when_memory_has_no_map():
     mem = uvm_mem("loose", 2, 8)
 
-    assert mem.get_offset() == -1
+    assert mem.get_offset() is None
 
 
 def test_memory_map_selection_and_incompatible_rights_diagnostics(caplog):
@@ -373,7 +373,7 @@ def test_memory_lookup_diagnostic_paths_are_reported(caplog):
     with caplog.at_level(logging.WARNING, logger="RegModel"):
         assert mem.get_vreg_by_name("missing") is None
         assert mem.get_vfield_by_name("missing") is None
-        assert mem.get_addresses(0) == (-1, [])
+        assert mem.get_addresses(0) == (None, [])
 
     assert "Unable to find virtual register" in caplog.text
     assert "Unable to find virtual field" in caplog.text

--- a/tests/pytests/reg/test_uvm_reg_field_access.py
+++ b/tests/pytests/reg/test_uvm_reg_field_access.py
@@ -1,3 +1,4 @@
+import io
 import itertools
 import logging
 
@@ -15,6 +16,8 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_predict_e,
     uvm_status_e,
 )
+from pyuvm.uvm_reporting import set_sv_uvm_style_reporting_enabled
+from pyuvm.uvm_reporting.uvm_report_server import uvm_report_server
 
 
 class AsyncNoopLock:
@@ -256,6 +259,44 @@ def test_field_poke_returns_parent_peek_error_without_write():
     assert status == uvm_status_e.UVM_NOT_OK
     assert len(reg.read_items) == 1
     assert reg.write_items == []
+
+
+def test_field_diagnostics_use_sv_uvm_reporting_when_enabled():
+    root_logger = logging.getLogger("uvm")
+    old_level = root_logger.level
+    old_propagate = root_logger.propagate
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.NOTSET)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+
+    set_sv_uvm_style_reporting_enabled(True)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.propagate = False
+    manager = uvm_report_server.create(root_logger=root_logger)
+
+    try:
+        _, _, reg = build_reg(SpyFieldAccessReg())
+        reg.low.set(0x1AB)
+        reg.next_status = uvm_status_e.UVM_NOT_OK
+
+        status = run_pytest_coro(reg.low.poke(0x12, kind="RTL"))
+
+        assert status == uvm_status_e.UVM_NOT_OK
+        output = stream.getvalue()
+        assert "[FIELD_VALUE_WIDTH] Specified value (0x1AB)" in output
+        assert "[FIELD_POKE] uvm_reg_field::poke()" in output
+        assert manager.get_stats().warning_count == 1
+        assert manager.get_stats().error_count == 1
+    finally:
+        manager.shutdown()
+        manager.clear_counts()
+        manager.catcher.clear()
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(old_level)
+        root_logger.propagate = old_propagate
+        set_sv_uvm_style_reporting_enabled(False)
 
 
 def test_field_individual_accessibility_defaults_to_false():


### PR DESCRIPTION
# TL;DR

Adds constructible RAL memories, block and map integration, exact memory address lookup, and single-element frontdoor reads and writes through the existing register-map adapter and sequencer path.

Mapped memories use compact, stride-aware address descriptors, allowing large memories to be represented without creating one Python lookup entry per memory location.

This PR supersedes #393 with exact address semantics, shared register/memory bus transport, and 100% patch coverage.

# Summary

This PR builds on the register and frontdoor foundation merged in #402 the practical memory behavior needed for pyuvm register models.

It covers:
- constructible `uvm_mem` objects with validated size, element width, and access policy
- memory registration and lookup through `uvm_reg_block`
- memory mapping through `uvm_reg_map.add_mem`
- map offset, rights, unmapped state, element stride, address metadata, and initialization state
- `uvm_mem.get_offset`, `get_address`, and `get_addresses`
- byte-addressed, word-addressed, and hierarchical memory address translation
- exact address lookup through `uvm_reg_map.get_mem_by_offset`
- exact register/memory and memory/memory overlap diagnostics
- dynamic memory remapping and unmapping after the model is locked
- single-element memory reads and writes through the configured adapter and sequencer
- map-level `RW`, `RO`, and `WO` access restrictions
- bounds and unmapped-access validation before adapter activity
- propagation of bus address, data, bit width, byte enable, and response status
- atomic serialization using `cocotb.triggers.Lock`
- SV-UVM-style warning and error reporting when enabled
- recoverable UVM address-query behavior for invalid or unavailable addresses

# RFC Alignment

This continues the staged RAL direction introduced in RFC #399 and builds on the foundation merged in #402.

The implementation is split into three commits:
1. Implement RAL memory support
2. Make RAL memory mapping scalable
3. Refine memory address introspection

The intent is not to complete every UVM memory feature in one PR. This change establishes a tested and scalable memory foundation for later frontdoor, backdoor, sequence, predictor, and virtual-register work.

# PR #393

This PR supersedes #393.

PR #393 established the initial direction for `uvm_mem` construction, map plumbing, and frontdoor access. This implementation carries that work forward while addressing the issues identified during review:
- expands patch coverage from 27% to 100%
- uses awaited cocotb locks for atomic memory operations
- validates bounds, map rights, unmapped state, adapter setup, and sequencer setup before bus activity
- shares bus-operation construction and response handling with register access
- preserves holes in strided address maps
- detects register/memory overlaps as well as memory/memory overlaps
- avoids lookup storage proportional to memory depth

The burst and custom-frontdoor implementations from #393 are not included because those features require their own transaction, callback, and failure semantics.

# Scalable Address Mapping

A memory location may occupy one or more physical bus addresses, and consecutive locations may be separated by an address stride.

A simple minimum/maximum range is insufficient because it treats holes between strided locations as occupied. Expanding every location into a dictionary is exact, but consumes memory proportional to the modeled memory depth.

This PR instead stores a compact descriptor for each mapped memory:
- the physical address of each byte lane for element zero
- the address stride of each lane between elements
- the number of memory elements
- minimum and maximum bounds for fast rejection

Lookup membership is calculated mathematically. Memory/memory overlap is detected by finding intersections between finite arithmetic progressions using GCD and modular arithmetic.

The resulting metadata is proportional to the number and width of mapped memories rather than their depth. A regression locks and queries a 10-million-element memory without creating 10 million lookup entries.

# UVM Behavior

The implementation follows the relevant UVM memory and map behavior within the supported scope:
- intrinsic memory access is `RW` or `RO`
- per-map rights may be `RW`, `RO`, or `WO`
- memories may appear in multiple address maps
- logical memory offsets are translated into external physical addresses
- `get_mem_by_offset` is available after model locking
- memories do not maintain desired or mirrored state
- failed address-introspection queries are recoverable and use the UVM `-1`
  sentinel rather than terminating the simulation
- invalid operations return `UVM_NOT_OK` without invoking the adapter

Memory elements wider than the map bus are currently rejected with a useful diagnostic. Generic multi-beat memory transport is deferred rather than being partially implemented.

# Deliberate Scope Boundaries

This PR does not implement:

- burst reads and writes
- user-defined memory frontdoor sequences
- `peek` and `poke`
- base memory backdoor dispatch
- inherited block backdoors
- functional HDL-path access
- memory allocation manager and regions
- virtual registers and virtual fields
- memory callbacks and functional coverage
- sparse desired or mirrored memory state
- generic multi-beat memory elements

These remain follow-on RAL work.

# Compatibility

The implementation preserves pyuvm's existing enum and transaction conventions, including:
- `uvm_status_e`
- `uvm_door_e`
- `uvm_access_e`
- `uvm_elem_kind_e`
- `uvm_reg_item`
- `uvm_reg_bus_op`

Existing register frontdoor behavior continues to use the same shared adapter and sequencer machinery.

Standard `RegModel` logging remains the default. When SV-UVM-style reporting is enabled, new memory diagnostics are routed through `uvm_report` with stable report IDs.

# Implementation Notes

- `pyuvm/_reg/uvm_mem.py`
  - validates and constructs memories
  - registers memories with their parent blocks
  - implements address introspection
  - creates memory access items
  - validates bounds, rights, mappings, and supported width
  - performs single-element frontdoor reads and writes
  - routes diagnostics through the configured reporting system

- `pyuvm/_reg/uvm_reg_block.py`
  - adds private memory registration analogous to register registration

- `pyuvm/_reg/uvm_reg_map.py`
  - implements memory map configuration and lookup
  - adds compact stride-aware memory address descriptors
  - detects exact register/memory and memory/memory overlaps
  - rebuilds memory metadata after remapping
  - generalizes bus-operation construction for registers and memories
  - centralizes request/response handling through the adapter and sequencer

- `pyuvm/_reg/uvm_reg_model.py`
  - adds immutable memory address-range metadata

# Tests Added

New focused RAL memory coverage includes:

- `tests/pytests/reg/test_uvm_mem_construction.py`
- `tests/pytests/reg/test_uvm_mem_mapping.py`
- `tests/pytests/reg/test_uvm_mem_frontdoor.py`

The tests cover:

- valid and invalid memory construction
- block registration and hierarchical lookup
- standard and SV-UVM-style diagnostics
- map membership, rights, remapping, and unmapping
- byte-addressed and word-addressed maps
- hierarchical map translation
- exact stride-hole lookup
- register/memory and memory/memory overlaps
- single-element and very large memories
- bounds and access-policy rejection
- adapter request and response handling
- byte enables, data width, address, value, and status propagation
- missing adapter and sequencer diagnostics
- atomic memory access behavior