### PR TITLE
[pyral, core] Implement RAL sequence and frontdoor foundations

### DIFF
--- a/pyuvm/__init__.py
+++ b/pyuvm/__init__.py
@@ -79,13 +79,12 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_reg_cvr_t,
     uvm_reg_data_logic_t,
     uvm_reg_data_t,
-    uvm_reg_frontdoor,
     uvm_reg_map_addr_range,
     uvm_reg_mem_test_e,
     uvm_status_e,
 )
 from pyuvm._reg.uvm_reg_predictor import uvm_reg_predictor
-from pyuvm._reg.uvm_reg_sequence import uvm_reg_sequence
+from pyuvm._reg.uvm_reg_sequence import uvm_reg_frontdoor, uvm_reg_sequence
 from pyuvm._reg.uvm_vreg import (
     uvm_vreg,
     uvm_vreg_cb,

--- a/pyuvm/_reg/uvm_reg_model.py
+++ b/pyuvm/_reg/uvm_reg_model.py
@@ -26,7 +26,6 @@ __all__ = [
     "uvm_reg_mem_test_e",
     "uvm_hdl_path_concat",
     "uvm_reg_backdoor",
-    "uvm_reg_frontdoor",
     "uvm_reg_map_addr_range",
     "uvm_object_string_pool",
 ]
@@ -138,11 +137,6 @@ class uvm_hdl_path_concat(uvm_object):
 class uvm_reg_backdoor(uvm_object):
     def __init__(self, name: str = ""):
         super().__init__(name)
-        raise NotImplementedError
-
-
-class uvm_reg_frontdoor:
-    def __init__(self):
         raise NotImplementedError
 
 

--- a/pyuvm/_reg/uvm_reg_sequence.py
+++ b/pyuvm/_reg/uvm_reg_sequence.py
@@ -5,27 +5,28 @@ from typing import TYPE_CHECKING
 
 from cocotb.triggers import Lock
 
+from pyuvm._error_classes import UVMSequenceError
+from pyuvm._reg.uvm_mem import uvm_mem
+from pyuvm._reg.uvm_reg import uvm_reg
+from pyuvm._reg.uvm_reg_item import uvm_reg_item
 from pyuvm._reg.uvm_reg_model import (
+    uvm_access_e,
     uvm_check_e,
     uvm_door_e,
+    uvm_status_e,
 )
+from pyuvm._reg.uvm_reg_reporting import uvm_reg_report_error as _report_error
 from pyuvm._s14_15_python_sequences import uvm_sequence
+from pyuvm._utility_classes import current_task
 
 if TYPE_CHECKING:
-    from pyuvm._reg import uvm_mem
-    from pyuvm._reg.uvm_reg import uvm_reg
-    from pyuvm._reg.uvm_reg_item import uvm_reg_item
     from pyuvm._reg.uvm_reg_map import uvm_reg_map
     from pyuvm._reg.uvm_reg_model import (
         uvm_reg_addr_t,
         uvm_reg_data_t,
-        uvm_status_e,
     )
     from pyuvm._s05_base_classes import uvm_object
-    from pyuvm._s14_15_python_sequences import (
-        uvm_sequence_base,
-        uvm_sequencer_base,
-    )
+    from pyuvm._s14_15_python_sequences import uvm_sequencer_base
 
 __all__ = ["uvm_reg_sequence", "uvm_reg_frontdoor"]
 logger = logging.getLogger("RegModel")
@@ -34,13 +35,68 @@ logger = logging.getLogger("RegModel")
 class uvm_reg_sequence(uvm_sequence):
     def __init__(self, name: str = "uvm_reg_sequence_inst"):
         super().__init__(name)
-        raise NotImplementedError
+        self.model = None
+        self.adapter = None
+        self.reg_seqr = None
 
     async def body(self):
-        raise NotImplementedError
+        if self.reg_seqr is None:
+            _report_error(
+                self,
+                "REG_SEQUENCE",
+                f"Translation sequence {self.get_full_name()!r} has no "
+                "upstream register sequencer configured",
+            )
+            return
+
+        while True:
+            rw = await self.reg_seqr.get_next_item()
+            original_parent = getattr(rw, "parent", None)
+            try:
+                if not isinstance(rw, uvm_reg_item):
+                    raise UVMSequenceError(
+                        "Register translation sequence received an item that is "
+                        "not a uvm_reg_item"
+                    )
+                rw.set_parent_sequence(self)
+                await self.do_reg_item(rw)
+            finally:
+                if isinstance(rw, uvm_reg_item):
+                    rw.set_parent_sequence(original_parent)
+                self.reg_seqr.item_done()
 
     async def do_reg_item(self, rw: uvm_reg_item) -> None:
-        raise NotImplementedError
+        if not isinstance(rw, uvm_reg_item):
+            raise UVMSequenceError("do_reg_item() requires a uvm_reg_item")
+        if self.sequencer is None:
+            raise UVMSequenceError(
+                "Register translation sequence has no downstream sequencer"
+            )
+        if self.adapter is None:
+            raise UVMSequenceError("Register translation sequence has no adapter")
+        local_map = rw.get_local_map()
+        if local_map is None:
+            raise UVMSequenceError(
+                "Register translation item has no selected local map"
+            )
+        if rw.get_kind() == uvm_access_e.UVM_WRITE:
+            await local_map.do_bus_write(rw, self.sequencer, self.adapter)
+        elif rw.get_kind() == uvm_access_e.UVM_READ:
+            await local_map.do_bus_read(rw, self.sequencer, self.adapter)
+        else:
+            raise UVMSequenceError(
+                f"Unsupported register translation access kind: {rw.get_kind()!r}"
+            )
+
+    def _valid_target(self, target, expected_type: type, kind: str) -> bool:
+        if isinstance(target, expected_type):
+            return True
+        _report_error(
+            self,
+            "REG_SEQUENCE",
+            f"{kind} convenience helper requires a valid {expected_type.__name__}",
+        )
+        return False
 
     async def write_reg(
         self,
@@ -53,7 +109,9 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        if not self._valid_target(rg, uvm_reg, "Register"):
+            return uvm_status_e.UVM_NOT_OK
+        return await rg.write(value, path, map, self, prior, extension, fname, lineno)
 
     async def read_reg(
         self,
@@ -65,7 +123,9 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        if not self._valid_target(rg, uvm_reg, "Register"):
+            return uvm_status_e.UVM_NOT_OK, 0
+        return await rg.read(path, map, self, prior, extension, fname, lineno)
 
     async def poke_reg(
         self,
@@ -76,7 +136,10 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "poke_reg() requires register backdoor support, which is deferred "
+            "to the backdoor milestone"
+        )
 
     async def peek_reg(
         self,
@@ -86,7 +149,10 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "peek_reg() requires register backdoor support, which is deferred "
+            "to the backdoor milestone"
+        )
 
     async def update_reg(
         self,
@@ -98,7 +164,9 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        if not self._valid_target(rg, uvm_reg, "Register"):
+            return uvm_status_e.UVM_NOT_OK
+        return await rg.update(path, map, self, prior, extension, fname, lineno)
 
     async def mirror_reg(
         self,
@@ -111,7 +179,9 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        if not self._valid_target(rg, uvm_reg, "Register"):
+            return uvm_status_e.UVM_NOT_OK
+        return await rg.mirror(check, path, map, self, prior, extension, fname, lineno)
 
     async def write_mem(
         self,
@@ -125,7 +195,11 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        if not self._valid_target(mem, uvm_mem, "Memory"):
+            return uvm_status_e.UVM_NOT_OK
+        return await mem.write(
+            offset, value, path, map, self, prior, extension, fname, lineno
+        )
 
     async def read_mem(
         self,
@@ -138,7 +212,9 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        if not self._valid_target(mem, uvm_mem, "Memory"):
+            return uvm_status_e.UVM_NOT_OK, 0
+        return await mem.read(offset, path, map, self, prior, extension, fname, lineno)
 
     async def poke_mem(
         self,
@@ -150,7 +226,10 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> uvm_status_e:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "poke_mem() requires memory backdoor support, which is deferred "
+            "to the backdoor milestone"
+        )
 
     async def peek_mem(
         self,
@@ -161,7 +240,10 @@ class uvm_reg_sequence(uvm_sequence):
         fname: str = "",
         lineno: int = 0,
     ) -> tuple[uvm_status_e, uvm_reg_data_t]:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "peek_mem() requires memory backdoor support, which is deferred "
+            "to the backdoor milestone"
+        )
 
 
 class uvm_reg_frontdoor(uvm_reg_sequence):
@@ -169,24 +251,46 @@ class uvm_reg_frontdoor(uvm_reg_sequence):
         super().__init__(name)
         self.rw_info = None
         self._atomic = Lock()
+        self._atomic_owner = None
+
+    @staticmethod
+    def _current_task():
+        return current_task()
+
+    async def body(self):
+        raise UVMSequenceError(
+            "uvm_reg_frontdoor.body() must be overridden by a derived frontdoor"
+        )
 
     async def atomic_lock(self):
+        owner = self._current_task()
+        if self._atomic_owner is owner and owner is not None:
+            return
         await self._atomic.acquire()
+        self._atomic_owner = owner
 
     def atomic_unlock(self):
-        if not self._atomic.locked():
+        owner = self._current_task()
+        if not self._atomic.locked() or self._atomic_owner is not owner:
             logger.warning(
                 f"Attempt to unlock frontdoor "
-                f"{repr(self.get_full_name())} when it wasn't locked!"
+                f"{repr(self.get_full_name())} by a task that does not own it"
             )
+            return
+        self._atomic_owner = None
         self._atomic.release()
 
     async def start(
         self,
-        sequencer: uvm_sequencer_base,
-        parent_sequence: uvm_sequence_base = None,
-        this_priority: int = -1,
+        seqr: uvm_sequencer_base = None,
         call_pre_post: bool = True,
     ) -> None:
-        # TODO: implement guard check. See official UVM implementation
-        super().start(sequencer, parent_sequence, this_priority, call_pre_post)
+        owner = self._current_task()
+        acquired_here = self._atomic_owner is not owner or owner is None
+        if acquired_here:
+            await self.atomic_lock()
+        try:
+            await super().start(seqr, call_pre_post)
+        finally:
+            if acquired_here:
+                self.atomic_unlock()

--- a/tests/pytests/reg/test_uvm_reg_sequence.py
+++ b/tests/pytests/reg/test_uvm_reg_sequence.py
@@ -1,0 +1,439 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from async_helpers import run_pytest_coro
+
+import pyuvm
+from pyuvm import (
+    UVMSequenceError,
+    uvm_access_e,
+    uvm_check_e,
+    uvm_door_e,
+    uvm_mem,
+    uvm_reg,
+    uvm_reg_frontdoor,
+    uvm_reg_item,
+    uvm_reg_sequence,
+    uvm_status_e,
+)
+from pyuvm._reg.uvm_reg_sequence import (
+    uvm_reg_frontdoor as sequence_uvm_reg_frontdoor,
+)
+from pyuvm._s05_base_classes import uvm_object
+
+
+class StopTranslation(Exception):
+    pass
+
+
+class OneItemUpstream:
+    def __init__(self, item):
+        self.item = item
+        self.item_done_calls = 0
+        self.get_calls = 0
+
+    async def get_next_item(self):
+        self.get_calls += 1
+        if self.get_calls == 1:
+            return self.item
+        raise StopTranslation
+
+    def item_done(self):
+        self.item_done_calls += 1
+
+
+class RecordingMap:
+    def __init__(self):
+        self.calls = []
+
+    async def do_bus_write(self, rw, sequencer, adapter):
+        self.calls.append(("write", rw, sequencer, adapter))
+
+    async def do_bus_read(self, rw, sequencer, adapter):
+        self.calls.append(("read", rw, sequencer, adapter))
+
+
+class AsyncLock:
+    def __init__(self):
+        self.acquire_calls = 0
+        self.release_calls = 0
+        self._locked = False
+
+    async def acquire(self):
+        self.acquire_calls += 1
+        self._locked = True
+
+    def release(self):
+        self.release_calls += 1
+        self._locked = False
+
+    def locked(self):
+        return self._locked
+
+
+class RecordingFrontdoor(uvm_reg_frontdoor):
+    def __init__(self):
+        super().__init__("recording_frontdoor")
+        self.body_calls = 0
+        self.task = object()
+        self._current_task = lambda: self.task
+
+    async def body(self):
+        self.body_calls += 1
+
+
+def test_sequence_and_frontdoor_construct_with_expected_defaults():
+    sequence = uvm_reg_sequence()
+    frontdoor = uvm_reg_frontdoor()
+
+    assert sequence.model is None
+    assert sequence.adapter is None
+    assert sequence.reg_seqr is None
+    assert frontdoor.rw_info is None
+
+
+def test_top_level_frontdoor_is_sequence_implementation():
+    assert pyuvm.uvm_reg_frontdoor is sequence_uvm_reg_frontdoor
+
+
+def test_translation_body_processes_and_finishes_upstream_item():
+    original_parent = object()
+    rw = uvm_reg_item("rw")
+    rw.set_parent_sequence(original_parent)
+    upstream = OneItemUpstream(rw)
+    sequence = uvm_reg_sequence()
+    sequence.reg_seqr = upstream
+    seen_parents = []
+
+    async def record_item(item):
+        seen_parents.append(item.get_parent_sequence())
+
+    sequence.do_reg_item = record_item
+
+    with pytest.raises(StopTranslation):
+        run_pytest_coro(sequence.body())
+
+    assert seen_parents == [sequence]
+    assert rw.get_parent_sequence() is original_parent
+    assert upstream.item_done_calls == 1
+
+
+def test_translation_body_restores_parent_and_finishes_after_failure():
+    original_parent = object()
+    rw = uvm_reg_item("rw")
+    rw.set_parent_sequence(original_parent)
+    upstream = OneItemUpstream(rw)
+    sequence = uvm_reg_sequence()
+    sequence.reg_seqr = upstream
+
+    async def fail_item(_item):
+        raise RuntimeError("bus failure")
+
+    sequence.do_reg_item = fail_item
+
+    with pytest.raises(RuntimeError, match="bus failure"):
+        run_pytest_coro(sequence.body())
+
+    assert rw.get_parent_sequence() is original_parent
+    assert upstream.item_done_calls == 1
+
+
+def test_translation_body_rejects_non_register_item_and_finishes_it():
+    upstream = OneItemUpstream(object())
+    sequence = uvm_reg_sequence()
+    sequence.reg_seqr = upstream
+
+    with pytest.raises(UVMSequenceError, match="not a uvm_reg_item"):
+        run_pytest_coro(sequence.body())
+
+    assert upstream.item_done_calls == 1
+
+
+def test_translation_body_without_upstream_reports_and_returns(caplog):
+    sequence = uvm_reg_sequence()
+
+    run_pytest_coro(sequence.body())
+
+    assert "no upstream register sequencer" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        (uvm_access_e.UVM_WRITE, "write"),
+        (uvm_access_e.UVM_READ, "read"),
+    ],
+)
+def test_do_reg_item_uses_selected_map_bus_path(kind, expected):
+    sequence = uvm_reg_sequence()
+    sequence.sequencer = object()
+    sequence.adapter = object()
+    local_map = RecordingMap()
+    rw = uvm_reg_item("rw")
+    rw.set_kind(kind)
+    rw.set_local_map(local_map)
+
+    run_pytest_coro(sequence.do_reg_item(rw))
+
+    assert local_map.calls == [(expected, rw, sequence.sequencer, sequence.adapter)]
+
+
+@pytest.mark.parametrize(
+    ("configure", "message"),
+    [
+        (lambda seq, rw: setattr(seq, "sequencer", None), "downstream sequencer"),
+        (lambda seq, rw: setattr(seq, "adapter", None), "no adapter"),
+        (lambda seq, rw: rw.set_local_map(None), "no selected local map"),
+        (
+            lambda seq, rw: rw.set_kind(uvm_access_e.UVM_BURST_WRITE),
+            "Unsupported register translation access kind",
+        ),
+    ],
+)
+def test_do_reg_item_rejects_incomplete_or_unsupported_requests(configure, message):
+    sequence = uvm_reg_sequence()
+    sequence.sequencer = object()
+    sequence.adapter = object()
+    rw = uvm_reg_item("rw")
+    rw.set_kind(uvm_access_e.UVM_WRITE)
+    rw.set_local_map(RecordingMap())
+    configure(sequence, rw)
+
+    with pytest.raises(UVMSequenceError, match=message):
+        run_pytest_coro(sequence.do_reg_item(rw))
+
+
+def test_do_reg_item_rejects_non_register_item():
+    sequence = uvm_reg_sequence()
+
+    with pytest.raises(UVMSequenceError, match="requires a uvm_reg_item"):
+        run_pytest_coro(sequence.do_reg_item(object()))
+
+
+def test_register_convenience_helpers_delegate_all_arguments():
+    sequence = uvm_reg_sequence("helper_sequence")
+    reg = uvm_reg("reg", 32)
+    reg.write = AsyncMock(return_value=uvm_status_e.UVM_IS_OK)
+    reg.read = AsyncMock(return_value=(uvm_status_e.UVM_IS_OK, 0x55))
+    reg.update = AsyncMock(return_value=uvm_status_e.UVM_HAS_X)
+    reg.mirror = AsyncMock(return_value=uvm_status_e.UVM_NOT_OK)
+    reg_map = object()
+    extension = uvm_object("extension")
+
+    write_status = run_pytest_coro(
+        sequence.write_reg(
+            reg, 0xAA, uvm_door_e.UVM_FRONTDOOR, reg_map, 7, extension, "a.py", 9
+        )
+    )
+    read_result = run_pytest_coro(
+        sequence.read_reg(
+            reg, uvm_door_e.UVM_FRONTDOOR, reg_map, 8, extension, "b.py", 10
+        )
+    )
+    update_status = run_pytest_coro(
+        sequence.update_reg(
+            reg, uvm_door_e.UVM_FRONTDOOR, reg_map, 9, extension, "c.py", 11
+        )
+    )
+    mirror_status = run_pytest_coro(
+        sequence.mirror_reg(
+            reg,
+            uvm_check_e.UVM_CHECK,
+            uvm_door_e.UVM_FRONTDOOR,
+            reg_map,
+            10,
+            extension,
+            "d.py",
+            12,
+        )
+    )
+
+    assert write_status == uvm_status_e.UVM_IS_OK
+    assert read_result == (uvm_status_e.UVM_IS_OK, 0x55)
+    assert update_status == uvm_status_e.UVM_HAS_X
+    assert mirror_status == uvm_status_e.UVM_NOT_OK
+    reg.write.assert_awaited_once_with(
+        0xAA, uvm_door_e.UVM_FRONTDOOR, reg_map, sequence, 7, extension, "a.py", 9
+    )
+    reg.read.assert_awaited_once_with(
+        uvm_door_e.UVM_FRONTDOOR, reg_map, sequence, 8, extension, "b.py", 10
+    )
+    reg.update.assert_awaited_once_with(
+        uvm_door_e.UVM_FRONTDOOR, reg_map, sequence, 9, extension, "c.py", 11
+    )
+    reg.mirror.assert_awaited_once_with(
+        uvm_check_e.UVM_CHECK,
+        uvm_door_e.UVM_FRONTDOOR,
+        reg_map,
+        sequence,
+        10,
+        extension,
+        "d.py",
+        12,
+    )
+
+
+def test_memory_convenience_helpers_delegate_all_arguments():
+    sequence = uvm_reg_sequence("helper_sequence")
+    mem = uvm_mem("mem", 4, 16, "RW")
+    mem.write = AsyncMock(return_value=uvm_status_e.UVM_IS_OK)
+    mem.read = AsyncMock(return_value=(uvm_status_e.UVM_HAS_X, 0x1234))
+    reg_map = object()
+    extension = uvm_object("extension")
+
+    write_status = run_pytest_coro(
+        sequence.write_mem(
+            mem,
+            2,
+            0x5678,
+            uvm_door_e.UVM_FRONTDOOR,
+            reg_map,
+            3,
+            extension,
+            "mem.py",
+            14,
+        )
+    )
+    read_result = run_pytest_coro(
+        sequence.read_mem(
+            mem,
+            1,
+            uvm_door_e.UVM_FRONTDOOR,
+            reg_map,
+            4,
+            extension,
+            "mem.py",
+            15,
+        )
+    )
+
+    assert write_status == uvm_status_e.UVM_IS_OK
+    assert read_result == (uvm_status_e.UVM_HAS_X, 0x1234)
+    mem.write.assert_awaited_once_with(
+        2,
+        0x5678,
+        uvm_door_e.UVM_FRONTDOOR,
+        reg_map,
+        sequence,
+        3,
+        extension,
+        "mem.py",
+        14,
+    )
+    mem.read.assert_awaited_once_with(
+        1,
+        uvm_door_e.UVM_FRONTDOOR,
+        reg_map,
+        sequence,
+        4,
+        extension,
+        "mem.py",
+        15,
+    )
+
+
+def test_invalid_convenience_targets_report_and_return_failure(caplog):
+    sequence = uvm_reg_sequence()
+
+    write_status = run_pytest_coro(sequence.write_reg(None, 1))
+    read_status = run_pytest_coro(sequence.read_reg(None))
+    update_status = run_pytest_coro(sequence.update_reg(None))
+    mirror_status = run_pytest_coro(sequence.mirror_reg(None))
+    mem_write_status = run_pytest_coro(sequence.write_mem(None, 0, 1))
+    mem_read_status = run_pytest_coro(sequence.read_mem(None, 0))
+
+    assert write_status == uvm_status_e.UVM_NOT_OK
+    assert read_status == (uvm_status_e.UVM_NOT_OK, 0)
+    assert update_status == uvm_status_e.UVM_NOT_OK
+    assert mirror_status == uvm_status_e.UVM_NOT_OK
+    assert mem_write_status == uvm_status_e.UVM_NOT_OK
+    assert mem_read_status == (uvm_status_e.UVM_NOT_OK, 0)
+    assert caplog.text.count("requires a valid") == 6
+
+
+@pytest.mark.parametrize(
+    ("method", "args", "boundary"),
+    [
+        ("poke_reg", (None, 1), "register backdoor support"),
+        ("peek_reg", (None,), "register backdoor support"),
+        ("poke_mem", (None, 0, 1), "memory backdoor support"),
+        ("peek_mem", (None, 0), "memory backdoor support"),
+    ],
+)
+def test_peek_and_poke_helpers_are_explicit_backdoor_boundaries(method, args, boundary):
+    sequence = uvm_reg_sequence()
+
+    with pytest.raises(NotImplementedError, match=boundary):
+        run_pytest_coro(getattr(sequence, method)(*args))
+
+
+def test_base_frontdoor_body_requires_override():
+    frontdoor = uvm_reg_frontdoor()
+    frontdoor._atomic = AsyncLock()
+    frontdoor._current_task = asyncio.current_task
+
+    with pytest.raises(UVMSequenceError, match="must be overridden"):
+        run_pytest_coro(frontdoor.start())
+
+    assert frontdoor._atomic.acquire_calls == 1
+    assert frontdoor._atomic.release_calls == 1
+
+
+def test_frontdoor_start_awaits_body_and_automatically_locks():
+    frontdoor = RecordingFrontdoor()
+    frontdoor._atomic = AsyncLock()
+
+    run_pytest_coro(frontdoor.start())
+
+    assert frontdoor.body_calls == 1
+    assert frontdoor._atomic.acquire_calls == 1
+    assert frontdoor._atomic.release_calls == 1
+    assert frontdoor._atomic_owner is None
+
+
+def test_frontdoor_start_does_not_reacquire_task_owned_lock():
+    frontdoor = RecordingFrontdoor()
+    frontdoor._atomic = AsyncLock()
+
+    async def run_locked():
+        await frontdoor.atomic_lock()
+        await frontdoor.atomic_lock()
+        await frontdoor.start()
+        assert frontdoor._atomic.locked()
+        frontdoor.atomic_unlock()
+
+    asyncio.run(run_locked())
+
+    assert frontdoor.body_calls == 1
+    assert frontdoor._atomic.acquire_calls == 1
+    assert frontdoor._atomic.release_calls == 1
+
+
+def test_frontdoor_current_task_uses_cocotb_task(monkeypatch):
+    task = object()
+    monkeypatch.setattr("pyuvm._reg.uvm_reg_sequence.current_task", lambda: task)
+
+    assert uvm_reg_frontdoor._current_task() is task
+
+
+def test_only_owning_task_can_unlock_frontdoor(caplog):
+    frontdoor = RecordingFrontdoor()
+    frontdoor._atomic = AsyncLock()
+
+    async def exercise():
+        await frontdoor.atomic_lock()
+
+        async def other_task():
+            frontdoor.task = object()
+            frontdoor.atomic_unlock()
+
+        await asyncio.create_task(other_task())
+        assert frontdoor._atomic.locked()
+        frontdoor.task = frontdoor._atomic_owner
+        frontdoor.atomic_unlock()
+
+    asyncio.run(exercise())
+
+    assert "does not own it" in caplog.text
+    assert frontdoor._atomic.release_calls == 1


### PR DESCRIPTION
# TL;DR

Implements one part of usable `uvm_reg_sequence` foundations, register and memory convenience helpers, layered register-transaction translation, and a constructible `uvm_reg_frontdoor` with cocotb task-owned locking.

This also removes the duplicate unusable `uvm_reg_frontdoor` placeholder and makes the sequence-derived implementation the authoritative top-level export.

# Summary

This PR builds on the register frontdoor foundation merged in #402 and the memory mapping and access support merged in #412.

It covers:

- constructible `uvm_reg_sequence` objects
- `model`, `adapter`, and `reg_seqr` sequence configuration
- both standard roles of `uvm_reg_sequence`:
  - a convenience base for user-defined register-model sequences
  - a layered register-to-bus translation sequence
- translation through the selected local map's `do_bus_write()` and `do_bus_read()` paths
- guaranteed upstream-item completion and parent restoration
- explicit validation of translation configuration and access kinds
- register convenience helpers:
  - `write_reg`
  - `read_reg`
  - `update_reg`
  - `mirror_reg`
- memory convenience helpers:
  - `write_mem`
  - `read_mem`
- target validation with centralized RAL diagnostics and standard failure results
- an awaited, Pythonic `uvm_reg_frontdoor.start()` implementation
- cocotb current-task ownership for frontdoor locking
- protection against non-owner unlocks and same-task lock reacquisition
- an explicit requirement for derived frontdoors to override `body()`
- top-level export of the sequence-derived `uvm_reg_frontdoor`
- explicit deferred-backdoor boundaries for register and memory peek/poke helpers

# RFC Alignment

This continues the staged RAL direction introduced in RFC #399 and builds on:

- #402: foundational register APIs and built-in register frontdoor access
- #412: memory mapping and built-in single-element memory frontdoor access

# Register Translation Sequences

`uvm_reg_sequence` now supports its layered translation role.

The default translation `body()`:

1. acquires a `uvm_reg_item` from the configured upstream register sequencer
2. temporarily installs the translation sequence as the item's parent
3. dispatches the operation through `do_reg_item()`
4. restores the original parent in `finally`
5. completes every acquired upstream item, including failure paths

`do_reg_item()` uses the item's selected local map and the sequence's configured downstream sequencer and adapter.

Writes are dispatched through `uvm_reg_map.do_bus_write()`, and reads are dispatched through `uvm_reg_map.do_bus_read()`. This reuses the established register-map transport rather than introducing a second adapter protocol implementation.

Missing downstream sequencers, adapters, local maps, invalid items, and unsupported access kinds raise `UVMSequenceError`.

Starting the default translation body without `reg_seqr` reports a centralized RAL error and returns rather than waiting indefinitely.

# Deliberate Scope Boundaries

This PR does not implement custom-frontdoor routing.

In particular, it does not yet:

- route `uvm_reg.read()` or `uvm_reg.write()` through a configured custom frontdoor
- route `uvm_mem.read()` or `uvm_mem.write()` through a configured custom frontdoor
- populate and execute frontdoor `rw_info` from originating element operations
- implement root-map sequencer fallback for element access
- support intentionally unmapped entries through custom frontdoors
- prove built-in and custom-frontdoor result equivalence
- implement wider-than-bus custom physical access
- implement shared-frontdoor concurrency at the register or memory routing layer

The following also remain deferred:

- register and memory peek/poke completion
- base backdoor dispatch
- HDL-path access
- memory bursts
- generic built-in multi-beat transport
- predictor completion
- callbacks and coverage
- memory allocation management
- virtual registers and virtual fields

Peek and poke convenience helpers raise `NotImplementedError` with messages identifying the deferred backdoor milestone.

# Tests Added

New focused coverage is provided by:

- `tests/pytests/reg/test_uvm_reg_sequence.py`

The tests cover:

- sequence and frontdoor construction
- default sequence attributes
- public import identity
- upstream register-item acquisition and completion
- original-parent restoration
- translation cleanup after exceptions
- invalid upstream items
- missing translation configuration
- read and write dispatch through the selected local map
- unsupported access kinds
- propagation of every convenience-helper argument
- register and memory helper return values
- invalid-target diagnostics and failure results
- explicit peek/poke backdoor boundaries
- required frontdoor `body()` override
- awaited frontdoor execution
- automatic frontdoor locking
- same-task lock reuse
- non-owner unlock rejection
- cocotb task identity use
