### PR TITLE
[tests] Remove redundant TLM test wrapper

### DIFF
--- a/tests/cocotb_tests/t12_tlm/test.py
+++ b/tests/cocotb_tests/t12_tlm/test.py
@@ -1,6 +1,5 @@
 import inspect
 
-import cocotb
 import test_12_uvm_tlm_interfaces as test_mod
 
 import pyuvm
@@ -98,8 +97,3 @@ class AnalysisTest(uvm_test):
         assert self.data_list == self.subscriber.data
         assert self.data_list == self.export.data
         assert self.data_list == self.fifo.data
-
-
-@cocotb.test()
-async def run_test(_):
-    uvm_root().run_test(AnalysisTest)


### PR DESCRIPTION
Fixes #416.

Remove the duplicate cocotb wrapper from the t12_tlm test because AnalysisTest is already registered through @pyuvm.test(). 