### PR TITLE
[pyral, core] Support custom frontdoor 

### DIFF
--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -483,10 +483,10 @@ class uvm_mem(uvm_object):
             rw.set_status(uvm_status_e.UVM_NOT_OK)
             return None
         info = local_map.get_mem_map_info(self)
-        if info.unmapped or info.frontdoor is not None:
+        if info.unmapped and info.frontdoor is None:
             rw.set_status(uvm_status_e.UVM_NOT_OK)
             return None
-        if self.get_n_bytes() > local_map.get_n_bytes():
+        if info.frontdoor is None and self.get_n_bytes() > local_map.get_n_bytes():
             _report_error(
                 self,
                 "MEM_MULTIBEAT",
@@ -525,7 +525,10 @@ class uvm_mem(uvm_object):
         self._write_in_progress = True
         rw.set_status(uvm_status_e.UVM_IS_OK)
         try:
-            await rw.get_local_map().do_write(rw)
+            if info.frontdoor is None:
+                await rw.get_local_map().do_write(rw)
+            else:
+                await rw.get_local_map().do_frontdoor(rw, info.frontdoor)
         finally:
             self._write_in_progress = False
 
@@ -536,7 +539,10 @@ class uvm_mem(uvm_object):
         self._read_in_progress = True
         rw.set_status(uvm_status_e.UVM_IS_OK)
         try:
-            await rw.get_local_map().do_read(rw)
+            if info.frontdoor is None:
+                await rw.get_local_map().do_read(rw)
+            else:
+                await rw.get_local_map().do_frontdoor(rw, info.frontdoor)
             rw.set_value(rw.get_value() & ((1 << self._n_bits) - 1))
         finally:
             self._read_in_progress = False
@@ -548,10 +554,23 @@ class uvm_mem(uvm_object):
         fname: str = "",
         lineno: int = 0,
     ) -> None:
-        raise NotImplementedError
+        self._fname = fname
+        self._lineno = lineno
+        local_map = self.get_local_map(map)
+        if local_map is None:
+            return
+        info = local_map.get_mem_map_info(self)
+        if info is not None:
+            info.frontdoor = ftdr
 
     def get_frontdoor(self, map: uvm_reg_map = None) -> uvm_reg_frontdoor:
-        raise NotImplementedError
+        local_map = self.get_local_map(map)
+        if local_map is None:
+            return None
+        info = local_map.get_mem_map_info(self)
+        if info is None:
+            return None
+        return info.frontdoor
 
     def set_backdoor(
         self, bkdr: uvm_reg_backdoor, fname: str = "", lineno: int = 0

--- a/pyuvm/_reg/uvm_mem.py
+++ b/pyuvm/_reg/uvm_mem.py
@@ -563,7 +563,7 @@ class uvm_mem(uvm_object):
         if info is not None:
             info.frontdoor = ftdr
 
-    def get_frontdoor(self, map: uvm_reg_map = None) -> uvm_reg_frontdoor:
+    def get_frontdoor(self, map: uvm_reg_map = None) -> uvm_reg_frontdoor | None:
         local_map = self.get_local_map(map)
         if local_map is None:
             return None

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -705,6 +705,9 @@ class uvm_reg(uvm_object):
             rw.set_door(self._parent.get_default_door())
         if rw.get_door() == uvm_door_e.UVM_BACKDOOR:
             raise NotImplementedError
+        if rw.get_door() != uvm_door_e.UVM_FRONTDOOR:
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return False, None
         if rw.get_door() != uvm_door_e.UVM_BACKDOOR:
             tmp_map = rw.get_map()
             rw.set_local_map(self.get_local_map(tmp_map))
@@ -716,6 +719,22 @@ class uvm_reg(uvm_object):
             map_info = tmp_local_map.get_reg_map_info(self)
             if not map_info.frontdoor and map_info.unmapped:
                 # TODO: Error message
+                rw.set_status(uvm_status_e.UVM_NOT_OK)
+                return False, None
+            if rw.get_kind() == uvm_access_e.UVM_WRITE and map_info.rights == "RO":
+                _report_error(
+                    self,
+                    "REG_WRITE_RO",
+                    f"Cannot write read-only register {self.get_full_name()!r}",
+                )
+                rw.set_status(uvm_status_e.UVM_NOT_OK)
+                return False, None
+            if rw.get_kind() == uvm_access_e.UVM_READ and map_info.rights == "WO":
+                _report_error(
+                    self,
+                    "REG_READ_WO",
+                    f"Cannot read write-only register {self.get_full_name()!r}",
+                )
                 rw.set_status(uvm_status_e.UVM_NOT_OK)
                 return False, None
             if not tmp_map:
@@ -749,20 +768,18 @@ class uvm_reg(uvm_object):
         if not rc:
             return
         self._write_in_progress = True
-        value = rw.get_value() & (1 << self.get_n_bits()) - 1
-        rw.set_value(value)
-        rw.set_status(uvm_status_e.UVM_IS_OK)
-        # TODO: pre_write fields callbacks
-        # TODO: pre_write reg callbacks
-        door = rw.get_door()
-        if door == uvm_door_e.UVM_BACKDOOR:
-            await self._do_write_backdoor(rw, map_info)
-        elif door == uvm_door_e.UVM_FRONTDOOR:
+        try:
+            value = rw.get_value() & (1 << self.get_n_bits()) - 1
+            rw.set_value(value)
+            rw.set_status(uvm_status_e.UVM_IS_OK)
+            # TODO: pre_write fields callbacks
+            # TODO: pre_write reg callbacks
             await self._do_write_frontdoor(rw, map_info)
-        # TODO: post_write reg callbacks
-        # TODO: post_write fields callbacks
-        # TODO: report
-        self._write_in_progress = False
+            # TODO: post_write reg callbacks
+            # TODO: post_write fields callbacks
+            # TODO: report
+        finally:
+            self._write_in_progress = False
 
     async def _do_write_backdoor(
         self, rw: uvm_reg_item, map_info: uvm_reg_map_info
@@ -775,19 +792,13 @@ class uvm_reg(uvm_object):
         local_map = rw.get_local_map()
         system_map = local_map.get_root_map()
         self._set_is_busy(True)
-        # INFO: User frontdoor
-        if map_info.frontdoor is not None:
-            frontdoor = map_info.frontdoor
-            frontdoor.atomic_lock()
-            frontdoor.rw_info = rw
-            if frontdoor.sequencer is None:
-                frontdoor.sequencer = system_map.get_sequencer()
-            frontdoor.start(frontdoor.sequencer, rw.get_parent_sequence())
-            frontdoor.atomic_unlock()
-        # INFO: Built in frontdoor
-        else:
-            await local_map.do_write(rw)
-        self._set_is_busy(False)
+        try:
+            if map_info.frontdoor is not None:
+                await local_map.do_frontdoor(rw, map_info.frontdoor)
+            else:
+                await local_map.do_write(rw)
+        finally:
+            self._set_is_busy(False)
         if system_map.get_auto_predict() and rw.get_status() == uvm_status_e.UVM_IS_OK:
             if self._cover_on:
                 self.sample(rw.get_value(), -1, False, rw.get_map())
@@ -803,18 +814,16 @@ class uvm_reg(uvm_object):
         if not rc:
             return
         self._read_in_progress = True
-        rw.set_status(uvm_status_e.UVM_IS_OK)
-        # TODO: pre_read fields callbacks
-        # TODO: pre_read reg callbacks
-        door = rw.get_door()
-        if door == uvm_door_e.UVM_BACKDOOR:
-            await self._do_read_backdoor(rw, map_info)
-        elif door == uvm_door_e.UVM_FRONTDOOR:
+        try:
+            rw.set_status(uvm_status_e.UVM_IS_OK)
+            # TODO: pre_read fields callbacks
+            # TODO: pre_read reg callbacks
             await self._do_read_frontdoor(rw, map_info)
-        # TODO: post_read reg callbacks
-        # TODO: post_read fields callbacks
-        # TODO: report
-        self._read_in_progress = False
+            # TODO: post_read reg callbacks
+            # TODO: post_read fields callbacks
+            # TODO: report
+        finally:
+            self._read_in_progress = False
 
     async def _do_read_backdoor(
         self, rw: uvm_reg_item, map_info: uvm_reg_map_info
@@ -829,17 +838,13 @@ class uvm_reg(uvm_object):
         self._set_is_busy(True)
         if local_map.get_check_on_read():
             exp_value = self.get_mirrored_value()
-        if map_info.frontdoor:
-            frontdoor = map_info.frontdoor
-            frontdoor.atomic_lock()
-            frontdoor.rw_info = rw
-            if not frontdoor.sequencer:
-                frontdoor.sequencer = system_map.get_sequencer()
-            frontdoor.start(frontdoor.sequencer, rw.get_parent_sequence())
-            frontdoor.atomic_unlock()
-        else:  # Built-in frontdoor
-            await local_map.do_read(rw)
-        self._set_is_busy(False)
+        try:
+            if map_info.frontdoor:
+                await local_map.do_frontdoor(rw, map_info.frontdoor)
+            else:
+                await local_map.do_read(rw)
+        finally:
+            self._set_is_busy(False)
         if system_map.get_auto_predict() and rw.get_status() == uvm_status_e.UVM_IS_OK:
             if local_map.get_check_on_read():
                 self.do_check(exp_value, rw.get_value(), system_map)

--- a/pyuvm/_reg/uvm_reg.py
+++ b/pyuvm/_reg/uvm_reg.py
@@ -891,7 +891,7 @@ class uvm_reg(uvm_object):
         if map_info is not None:
             map_info.frontdoor = ftdr
 
-    def get_frontdoor(self, map: uvm_reg_map = None) -> uvm_reg_frontdoor:
+    def get_frontdoor(self, map: uvm_reg_map = None) -> uvm_reg_frontdoor | None:
         local_map = self.get_local_map(map)
         if local_map is None:
             return None

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -1011,7 +1011,7 @@ class uvm_reg_map(uvm_object):
 
     async def do_frontdoor(
         self, rw: uvm_reg_item, frontdoor: uvm_reg_frontdoor
-    ) -> bool:
+    ) -> None:
         prior_sequencer = frontdoor.sequencer
         sequencer = prior_sequencer
         if sequencer is None:
@@ -1023,22 +1023,14 @@ class uvm_reg_map(uvm_object):
                 if element is not None and hasattr(element, "get_full_name")
                 else rw.get_name()
             )
-            _report_error(
-                self,
-                "REG_FRONTDOOR",
+            raise UVMFatalError(
                 f"Custom frontdoor access to {element_name!r} has no sequencer; "
-                "configure the frontdoor sequencer or the root-map sequencer",
+                "configure the frontdoor sequencer or the root-map sequencer"
             )
-            rw.set_status(uvm_status_e.UVM_NOT_OK)
-            return False
         if not isinstance(sequencer, uvm_sequencer):
-            _report_error(
-                self,
-                "REG_FRONTDOOR",
-                f"Custom frontdoor sequencer {sequencer!r} is not a uvm_sequencer",
+            raise UVMFatalError(
+                f"Custom frontdoor sequencer {sequencer!r} is not a uvm_sequencer"
             )
-            rw.set_status(uvm_status_e.UVM_NOT_OK)
-            return False
 
         await frontdoor.atomic_lock()
         try:
@@ -1051,7 +1043,6 @@ class uvm_reg_map(uvm_object):
         finally:
             frontdoor.sequencer = prior_sequencer
             frontdoor.atomic_unlock()
-        return True
 
     def _get_bus_info(self, rw: uvm_reg_item) -> tuple[uvm_reg_map_info, int, int, int]:
         map_info = None

--- a/pyuvm/_reg/uvm_reg_map.py
+++ b/pyuvm/_reg/uvm_reg_map.py
@@ -15,6 +15,7 @@ from pyuvm._reg.uvm_reg_model import (
     uvm_endianness_e,
     uvm_hier_e,
     uvm_reg_map_addr_range,
+    uvm_status_e,
 )
 from pyuvm._reg.uvm_reg_reporting import (
     uvm_reg_report_error as _report_error,
@@ -23,13 +24,14 @@ from pyuvm._reg.uvm_reg_reporting import (
     uvm_reg_report_warning as _report_warning,
 )
 from pyuvm._s05_base_classes import uvm_object
-from pyuvm._s14_15_python_sequences import uvm_sequence, uvm_sequence_base
+from pyuvm._s14_15_python_sequences import (
+    uvm_sequence,
+    uvm_sequence_base,
+    uvm_sequencer,
+)
 
 if TYPE_CHECKING:
-    from pyuvm import (
-        uvm_sequencer,
-        uvm_sequencer_base,
-    )
+    from pyuvm import uvm_sequencer_base
     from pyuvm._reg.uvm_mem import uvm_mem
     from pyuvm._reg.uvm_reg import uvm_reg
     from pyuvm._reg.uvm_reg_adapter import uvm_reg_adapter
@@ -1006,6 +1008,50 @@ class uvm_reg_map(uvm_object):
     async def do_read(self, rw: uvm_reg_item) -> None:
         sequencer, adapter = self._get_bus_access_config(rw)
         await self.do_bus_read(rw, sequencer, adapter)
+
+    async def do_frontdoor(
+        self, rw: uvm_reg_item, frontdoor: uvm_reg_frontdoor
+    ) -> bool:
+        prior_sequencer = frontdoor.sequencer
+        sequencer = prior_sequencer
+        if sequencer is None:
+            sequencer = self.get_root_map().get_sequencer()
+        if sequencer is None:
+            element = rw.get_element()
+            element_name = (
+                element.get_full_name()
+                if element is not None and hasattr(element, "get_full_name")
+                else rw.get_name()
+            )
+            _report_error(
+                self,
+                "REG_FRONTDOOR",
+                f"Custom frontdoor access to {element_name!r} has no sequencer; "
+                "configure the frontdoor sequencer or the root-map sequencer",
+            )
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return False
+        if not isinstance(sequencer, uvm_sequencer):
+            _report_error(
+                self,
+                "REG_FRONTDOOR",
+                f"Custom frontdoor sequencer {sequencer!r} is not a uvm_sequencer",
+            )
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            return False
+
+        await frontdoor.atomic_lock()
+        try:
+            frontdoor.rw_info = rw
+            frontdoor.sequencer = sequencer
+            await frontdoor.start(sequencer)
+        except BaseException:
+            rw.set_status(uvm_status_e.UVM_NOT_OK)
+            raise
+        finally:
+            frontdoor.sequencer = prior_sequencer
+            frontdoor.atomic_unlock()
+        return True
 
     def _get_bus_info(self, rw: uvm_reg_item) -> tuple[uvm_reg_map_info, int, int, int]:
         map_info = None

--- a/pyuvm/_reg/uvm_reg_sequence.py
+++ b/pyuvm/_reg/uvm_reg_sequence.py
@@ -271,7 +271,12 @@ class uvm_reg_frontdoor(uvm_reg_sequence):
 
     def atomic_unlock(self):
         owner = self._current_task()
-        if not self._atomic.locked() or self._atomic_owner is not owner:
+        try:
+            locked = self._atomic.locked()
+        except TypeError:
+            # INFO: For backward compatibility with Cocotb <= 1.8
+            locked = self._atomic.locked
+        if not locked or self._atomic_owner is not owner:
             logger.warning(
                 f"Attempt to unlock frontdoor "
                 f"{repr(self.get_full_name())} by a task that does not own it"

--- a/tests/cocotb_tests/test_ral_read_write/test.py
+++ b/tests/cocotb_tests/test_ral_read_write/test.py
@@ -4,11 +4,14 @@ import textwrap
 from random import choice, randint
 
 import cocotb
+from cocotb.triggers import Timer
 
 from pyuvm import (
     uvm_analysis_port,
     uvm_driver,
     uvm_env,
+    uvm_mem,
+    uvm_reg_frontdoor,
     uvm_root,
     uvm_sequence,
     uvm_sequence_item,
@@ -248,6 +251,56 @@ class ral_test_rd(uvm_test):
         self.drop_objection()
 
 
+class shared_mem_frontdoor(uvm_reg_frontdoor):
+    def __init__(self):
+        super().__init__("shared_mem_frontdoor")
+        self.active = 0
+        self.max_active = 0
+        self.operations = []
+
+    async def body(self):
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        rw = self.rw_info
+        try:
+            await Timer(1, "us")
+            self.operations.append((rw.get_element(), rw.get_offset(), rw.get_value()))
+            rw.set_status(uvm_status_e.UVM_IS_OK)
+        finally:
+            self.active -= 1
+
+
 @cocotb.test()
 async def test_start(dut):
     await uvm_root().run_test("ral_test_rd")
+
+
+@cocotb.test()
+async def test_shared_custom_frontdoor_serializes_memory_operations(dut):
+    block = uvm_reg_block("shared_block")
+    reg_map = block.create_map("map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True)
+    frontdoor = shared_mem_frontdoor()
+    first = uvm_mem("first", 2, 16, "RW")
+    second = uvm_mem("second", 2, 16, "RW")
+    first.configure(block)
+    second.configure(block)
+    reg_map.add_mem(first, 0x10, frontdoor=frontdoor)
+    reg_map.add_mem(second, 0x20, frontdoor=frontdoor)
+    block.lock_model()
+    reg_map.set_sequencer(uvm_sequencer("shared_seqr"))
+
+    first_task = cocotb.start_soon(
+        first.write(0, 0x1111, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+    second_task = cocotb.start_soon(
+        second.write(1, 0x2222, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    results = [await first_task, await second_task]
+
+    assert results == [uvm_status_e.UVM_IS_OK, uvm_status_e.UVM_IS_OK]
+    assert frontdoor.max_active == 1
+    assert set(frontdoor.operations) == {
+        (first, 0, 0x1111),
+        (second, 1, 0x2222),
+    }

--- a/tests/pytests/reg/test_uvm_custom_frontdoor.py
+++ b/tests/pytests/reg/test_uvm_custom_frontdoor.py
@@ -13,6 +13,7 @@ from test_uvm_reg_frontdoor_adapter import (
 )
 
 from pyuvm import (
+    UVMFatalError,
     uvm_access_e,
     uvm_door_e,
     uvm_elem_kind_e,
@@ -346,40 +347,35 @@ def test_explicit_frontdoor_sequencer_precedes_root_map_sequencer():
     assert frontdoor.sequencer is explicit
 
 
-def test_missing_custom_frontdoor_sequencer_reports_failure(caplog):
+def test_missing_custom_frontdoor_sequencer_raises_fatal_error():
     frontdoor = StorageFrontdoor()
     reg_map, reg = build_register(frontdoor=frontdoor)
 
-    status = run_pytest_coro(reg.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    with pytest.raises(UVMFatalError, match="has no sequencer"):
+        run_pytest_coro(reg.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
-    assert status == uvm_status_e.UVM_NOT_OK
     assert frontdoor.snapshots == []
-    assert "has no sequencer" in caplog.text
 
 
-def test_missing_sequencer_diagnostic_handles_item_without_element(caplog):
+def test_missing_sequencer_exception_handles_item_without_element():
     frontdoor = StorageFrontdoor()
     reg_map, _ = build_register()
     rw = uvm_reg_item("standalone_item")
 
-    result = run_pytest_coro(reg_map.do_frontdoor(rw, frontdoor))
-
-    assert result is False
-    assert rw.get_status() == uvm_status_e.UVM_NOT_OK
-    assert "standalone_item" in caplog.text
+    with pytest.raises(UVMFatalError, match="standalone_item"):
+        run_pytest_coro(reg_map.do_frontdoor(rw, frontdoor))
 
 
-def test_invalid_custom_frontdoor_sequencer_is_rejected_before_activity(caplog):
+def test_invalid_custom_frontdoor_sequencer_raises_before_activity():
     frontdoor = StorageFrontdoor()
     frontdoor.sequencer = object()
     reg_map, reg = build_register(frontdoor=frontdoor)
 
-    status = run_pytest_coro(reg.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    with pytest.raises(UVMFatalError, match="is not a uvm_sequencer"):
+        run_pytest_coro(reg.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
 
-    assert status == uvm_status_e.UVM_NOT_OK
     assert frontdoor.snapshots == []
     assert frontdoor.rw_info is None
-    assert "is not a uvm_sequencer" in caplog.text
 
 
 @pytest.mark.parametrize("element_kind", ["reg", "mem"])

--- a/tests/pytests/reg/test_uvm_custom_frontdoor.py
+++ b/tests/pytests/reg/test_uvm_custom_frontdoor.py
@@ -1,0 +1,529 @@
+import asyncio
+from itertools import count
+
+import pytest
+from async_helpers import run_pytest_coro
+from test_uvm_mem_frontdoor import build_memory as build_builtin_memory
+from test_uvm_reg_frontdoor_adapter import (
+    AsyncNoopLock,
+    FrontdoorReg,
+    MockSequencer,
+    RecordingAdapter,
+    build_model,
+)
+
+from pyuvm import (
+    uvm_access_e,
+    uvm_door_e,
+    uvm_elem_kind_e,
+    uvm_endianness_e,
+    uvm_mem,
+    uvm_object,
+    uvm_reg_block,
+    uvm_reg_frontdoor,
+    uvm_reg_item,
+    uvm_sequence_item,
+    uvm_sequencer,
+    uvm_status_e,
+)
+
+
+class PhysicalItem(uvm_sequence_item):
+    def __init__(self, rw):
+        super().__init__("physical_item")
+        self.element = rw.get_element()
+        self.kind = rw.get_kind()
+        self.offset = rw.get_offset()
+        self.data = rw.get_value()
+        self.status = uvm_status_e.UVM_IS_OK
+
+
+class StorageSequencer(uvm_sequencer):
+    _instance_ids = count()
+
+    def __init__(self, name, storage=None, status=uvm_status_e.UVM_IS_OK):
+        super().__init__(f"{name}_{next(self._instance_ids)}")
+        self.storage = {} if storage is None else storage
+        self.status = status
+        self.items = []
+
+    @staticmethod
+    def _key(item):
+        offset = 0 if item.offset is None else item.offset
+        return item.element, offset
+
+    async def start_item(self, item):
+        self.items.append(item)
+
+    async def finish_item(self, item):
+        await asyncio.sleep(0)
+        item.status = self.status
+        if item.kind == uvm_access_e.UVM_WRITE:
+            self.storage[self._key(item)] = item.data
+        else:
+            item.data = self.storage.get(self._key(item), 0)
+
+
+class FrontdoorTestLock:
+    """Non-scheduling lock double for simulator-free routing tests."""
+
+    def __init__(self):
+        self._locked = False
+
+    async def acquire(self):
+        self._locked = True
+
+    def release(self):
+        self._locked = False
+
+    def locked(self):
+        return self._locked
+
+
+class StorageFrontdoor(uvm_reg_frontdoor):
+    def __init__(self, name="storage_frontdoor"):
+        super().__init__(name)
+        self.snapshots = []
+        self._atomic = FrontdoorTestLock()
+        self._current_task = asyncio.current_task
+
+    async def body(self):
+        rw = self.rw_info
+        self.snapshots.append(
+            {
+                "item": rw,
+                "element": rw.get_element(),
+                "element_kind": rw.get_element_kind(),
+                "kind": rw.get_kind(),
+                "offset": rw.get_offset(),
+                "map": rw.get_map(),
+                "local_map": rw.get_local_map(),
+                "parent": rw.get_parent_sequence(),
+                "priority": rw.get_priority(),
+                "extension": rw.get_extension(),
+                "fname": rw.get_fname(),
+                "lineno": rw.get_line(),
+                "sequencer": self.sequencer,
+            }
+        )
+        item = PhysicalItem(rw)
+        await self.start_item(item)
+        await self.finish_item(item)
+        rw.set_status(item.status)
+        if rw.get_kind() == uvm_access_e.UVM_READ:
+            rw.set_value(item.data)
+
+
+class FailingFrontdoor(StorageFrontdoor):
+    async def body(self):
+        raise RuntimeError("frontdoor failed")
+
+
+def build_register(
+    *,
+    rights="RW",
+    unmapped=False,
+    frontdoor=None,
+    sequencer=None,
+    auto_predict=False,
+):
+    block = uvm_reg_block("reg_block")
+    reg_map = block.create_map(
+        "map", 0x1000, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    reg = FrontdoorReg()
+    reg.configure(block)
+    reg_map.add_reg(reg, 0x20, rights=rights, unmapped=unmapped, frontdoor=frontdoor)
+    block.lock_model()
+    reg._atomic = AsyncNoopLock()
+    reg_map.set_auto_predict(auto_predict)
+    if sequencer is not None:
+        reg_map.set_sequencer(sequencer)
+    return reg_map, reg
+
+
+def build_memory(
+    *,
+    n_bits=16,
+    access="RW",
+    rights="RW",
+    unmapped=False,
+    frontdoor=None,
+    sequencer=None,
+):
+    block = uvm_reg_block("mem_block")
+    reg_map = block.create_map(
+        "map", 0x1000, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True
+    )
+    mem = uvm_mem("storage", 4, n_bits, access)
+    mem.configure(block)
+    reg_map.add_mem(mem, 0x20, rights=rights, unmapped=unmapped, frontdoor=frontdoor)
+    block.lock_model()
+    mem._atomic = AsyncNoopLock()
+    if sequencer is not None:
+        reg_map.set_sequencer(sequencer)
+    return reg_map, mem
+
+
+def test_register_custom_frontdoor_write_and_read_match_bus_results():
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer("reg_seqr")
+    reg_map, reg = build_register(frontdoor=frontdoor, sequencer=sequencer)
+
+    write_status = run_pytest_coro(
+        reg.write(0x1234_5678, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+    read_status, value = run_pytest_coro(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert write_status == uvm_status_e.UVM_IS_OK
+    assert read_status == uvm_status_e.UVM_IS_OK
+    assert value == 0x1234_5678
+    assert [item.kind for item in sequencer.items] == [
+        uvm_access_e.UVM_WRITE,
+        uvm_access_e.UVM_READ,
+    ]
+    assert frontdoor.sequencer is None
+
+
+def test_memory_custom_frontdoor_write_and_read_match_bus_results():
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer("mem_seqr")
+    reg_map, mem = build_memory(frontdoor=frontdoor, sequencer=sequencer)
+
+    write_status = run_pytest_coro(
+        mem.write(2, 0xBEEF, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+    read_status, value = run_pytest_coro(mem.read(2, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert write_status == uvm_status_e.UVM_IS_OK
+    assert read_status == uvm_status_e.UVM_IS_OK
+    assert value == 0xBEEF
+    assert frontdoor.snapshots[0]["element_kind"] == uvm_elem_kind_e.UVM_MEM
+    assert frontdoor.snapshots[0]["offset"] == 2
+
+
+@pytest.mark.parametrize("element_kind", ["reg", "mem"])
+def test_custom_and_builtin_frontdoors_have_equivalent_results(element_kind):
+    write_value = 0x1234
+    read_value = 0xBEEF
+    adapter = RecordingAdapter()
+    builtin_sequencer = MockSequencer(read_data=read_value)
+
+    if element_kind == "reg":
+        _, builtin_map, builtin_element = build_model(adapter, builtin_sequencer)
+        builtin_write = run_pytest_coro(
+            builtin_element.write(write_value, uvm_door_e.UVM_FRONTDOOR, builtin_map)
+        )
+        builtin_read = run_pytest_coro(
+            builtin_element.read(uvm_door_e.UVM_FRONTDOOR, builtin_map)
+        )
+    else:
+        builtin_map, builtin_element = build_builtin_memory(
+            adapter=adapter, sequencer=builtin_sequencer
+        )
+        builtin_write = run_pytest_coro(
+            builtin_element.write(1, write_value, uvm_door_e.UVM_FRONTDOOR, builtin_map)
+        )
+        builtin_read = run_pytest_coro(
+            builtin_element.read(1, uvm_door_e.UVM_FRONTDOOR, builtin_map)
+        )
+
+    frontdoor = StorageFrontdoor()
+    custom_sequencer = StorageSequencer("equivalence_seqr")
+    if element_kind == "reg":
+        custom_map, custom_element = build_register(
+            frontdoor=frontdoor, sequencer=custom_sequencer
+        )
+        custom_sequencer.storage[(custom_element, 0)] = read_value
+        custom_write = run_pytest_coro(
+            custom_element.write(write_value, uvm_door_e.UVM_FRONTDOOR, custom_map)
+        )
+        custom_sequencer.storage[(custom_element, 0)] = read_value
+        custom_read = run_pytest_coro(
+            custom_element.read(uvm_door_e.UVM_FRONTDOOR, custom_map)
+        )
+    else:
+        custom_map, custom_element = build_memory(
+            frontdoor=frontdoor, sequencer=custom_sequencer
+        )
+        custom_write = run_pytest_coro(
+            custom_element.write(1, write_value, uvm_door_e.UVM_FRONTDOOR, custom_map)
+        )
+        custom_sequencer.storage[(custom_element, 1)] = read_value
+        custom_read = run_pytest_coro(
+            custom_element.read(1, uvm_door_e.UVM_FRONTDOOR, custom_map)
+        )
+
+    assert custom_write == builtin_write == uvm_status_e.UVM_IS_OK
+    assert custom_read == builtin_read == (uvm_status_e.UVM_IS_OK, read_value)
+
+
+def test_memory_frontdoor_setter_and_getter_use_selected_map():
+    initial = StorageFrontdoor("initial")
+    replacement = StorageFrontdoor("replacement")
+    reg_map, mem = build_memory(frontdoor=initial)
+
+    assert mem.get_frontdoor(reg_map) is initial
+    assert mem.get_frontdoor() is initial
+
+    mem.set_frontdoor(replacement, reg_map, "frontdoor.py", 12)
+
+    assert mem.get_frontdoor(reg_map) is replacement
+    assert mem._fname == "frontdoor.py"
+    assert mem._lineno == 12
+
+
+def test_memory_frontdoor_helpers_handle_missing_map_and_map_info():
+    loose = uvm_mem("loose_mem", 1, 8)
+
+    assert loose.get_frontdoor() is None
+    loose.set_frontdoor(StorageFrontdoor("loose_frontdoor"))
+
+    block = uvm_reg_block("incomplete_block")
+    reg_map = block.create_map("map", 0, 4, uvm_endianness_e.UVM_LITTLE_ENDIAN, True)
+    incomplete = uvm_mem("incomplete_mem", 1, 8)
+    incomplete.configure(block)
+    incomplete.add_map(reg_map)
+
+    assert incomplete.get_frontdoor(reg_map) is None
+    incomplete.set_frontdoor(StorageFrontdoor("incomplete_frontdoor"), reg_map)
+    assert incomplete.get_frontdoor(reg_map) is None
+
+
+def test_rw_info_propagates_complete_originating_operation():
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer("info_seqr")
+    reg_map, mem = build_memory(frontdoor=frontdoor, sequencer=sequencer)
+    parent = object()
+    extension = uvm_object("extension")
+
+    status = run_pytest_coro(
+        mem.write(
+            3,
+            0x1234,
+            uvm_door_e.UVM_FRONTDOOR,
+            reg_map,
+            parent,
+            17,
+            extension,
+            "source.py",
+            42,
+        )
+    )
+
+    info = frontdoor.snapshots[0]
+    assert status == uvm_status_e.UVM_IS_OK
+    assert info["item"] is frontdoor.rw_info
+    assert info["element"] is mem
+    assert info["element_kind"] == uvm_elem_kind_e.UVM_MEM
+    assert info["kind"] == uvm_access_e.UVM_WRITE
+    assert info["offset"] == 3
+    assert info["map"] is reg_map
+    assert info["local_map"] is reg_map
+    assert info["parent"] is parent
+    assert info["priority"] == 17
+    assert info["extension"] is extension
+    assert info["fname"] == "source.py"
+    assert info["lineno"] == 42
+    assert info["sequencer"] is sequencer
+
+
+def test_explicit_frontdoor_sequencer_precedes_root_map_sequencer():
+    frontdoor = StorageFrontdoor()
+    explicit = StorageSequencer("explicit")
+    root = StorageSequencer("root")
+    frontdoor.sequencer = explicit
+    reg_map, reg = build_register(frontdoor=frontdoor, sequencer=root)
+    explicit.storage[(reg, 0)] = 0xA5A5
+    root.storage[(reg, 0)] = 0x5A5A
+
+    status, value = run_pytest_coro(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_IS_OK
+    assert value == 0xA5A5
+    assert len(explicit.items) == 1
+    assert root.items == []
+    assert frontdoor.sequencer is explicit
+
+
+def test_missing_custom_frontdoor_sequencer_reports_failure(caplog):
+    frontdoor = StorageFrontdoor()
+    reg_map, reg = build_register(frontdoor=frontdoor)
+
+    status = run_pytest_coro(reg.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert frontdoor.snapshots == []
+    assert "has no sequencer" in caplog.text
+
+
+def test_missing_sequencer_diagnostic_handles_item_without_element(caplog):
+    frontdoor = StorageFrontdoor()
+    reg_map, _ = build_register()
+    rw = uvm_reg_item("standalone_item")
+
+    result = run_pytest_coro(reg_map.do_frontdoor(rw, frontdoor))
+
+    assert result is False
+    assert rw.get_status() == uvm_status_e.UVM_NOT_OK
+    assert "standalone_item" in caplog.text
+
+
+def test_invalid_custom_frontdoor_sequencer_is_rejected_before_activity(caplog):
+    frontdoor = StorageFrontdoor()
+    frontdoor.sequencer = object()
+    reg_map, reg = build_register(frontdoor=frontdoor)
+
+    status = run_pytest_coro(reg.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert frontdoor.snapshots == []
+    assert frontdoor.rw_info is None
+    assert "is not a uvm_sequencer" in caplog.text
+
+
+@pytest.mark.parametrize("element_kind", ["reg", "mem"])
+def test_intentionally_unmapped_element_uses_custom_frontdoor(element_kind):
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer(f"{element_kind}_seqr")
+    if element_kind == "reg":
+        reg_map, element = build_register(
+            unmapped=True, frontdoor=frontdoor, sequencer=sequencer
+        )
+        result = run_pytest_coro(element.write(0x55, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    else:
+        reg_map, element = build_memory(
+            unmapped=True, frontdoor=frontdoor, sequencer=sequencer
+        )
+        result = run_pytest_coro(
+            element.write(1, 0x55, uvm_door_e.UVM_FRONTDOOR, reg_map)
+        )
+
+    assert result == uvm_status_e.UVM_IS_OK
+    assert len(sequencer.items) == 1
+
+
+@pytest.mark.parametrize("element_kind", ["reg", "mem"])
+def test_intentionally_unmapped_element_without_frontdoor_is_rejected(
+    element_kind,
+):
+    sequencer = StorageSequencer(f"{element_kind}_seqr")
+    if element_kind == "reg":
+        reg_map, element = build_register(unmapped=True, sequencer=sequencer)
+        result = run_pytest_coro(element.write(0x55, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    else:
+        reg_map, element = build_memory(unmapped=True, sequencer=sequencer)
+        result = run_pytest_coro(
+            element.write(1, 0x55, uvm_door_e.UVM_FRONTDOOR, reg_map)
+        )
+
+    assert result == uvm_status_e.UVM_NOT_OK
+    assert sequencer.items == []
+
+
+def test_wider_than_bus_memory_uses_custom_frontdoor():
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer("wide_seqr")
+    reg_map, mem = build_memory(n_bits=64, frontdoor=frontdoor, sequencer=sequencer)
+    value = 0x1234_5678_9ABC_DEF0
+
+    write_status = run_pytest_coro(
+        mem.write(1, value, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+    read_status, read_value = run_pytest_coro(
+        mem.read(1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    )
+
+    assert write_status == uvm_status_e.UVM_IS_OK
+    assert read_status == uvm_status_e.UVM_IS_OK
+    assert read_value == value
+
+
+def test_custom_frontdoor_status_and_read_mask_are_propagated():
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer(
+        "status_seqr",
+        status=uvm_status_e.UVM_HAS_X,
+    )
+    reg_map, mem = build_memory(frontdoor=frontdoor, sequencer=sequencer)
+    sequencer.storage[(mem, 0)] = 0x1FFFF
+
+    status, value = run_pytest_coro(mem.read(0, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert status == uvm_status_e.UVM_HAS_X
+    assert value == 0xFFFF
+
+
+@pytest.mark.parametrize(
+    ("rights", "operation", "report"),
+    [
+        ("RO", "write", "read-only register"),
+        ("WO", "read", "write-only register"),
+    ],
+)
+def test_register_map_rights_apply_before_custom_frontdoor(
+    rights, operation, report, caplog
+):
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer("rights_seqr")
+    reg_map, reg = build_register(
+        rights=rights, frontdoor=frontdoor, sequencer=sequencer
+    )
+
+    if operation == "write":
+        result = run_pytest_coro(reg.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    else:
+        result, _ = run_pytest_coro(reg.read(uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert result == uvm_status_e.UVM_NOT_OK
+    assert sequencer.items == []
+    assert report in caplog.text
+
+
+def test_register_non_frontdoor_path_is_rejected_before_custom_activity():
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer("path_seqr")
+    reg_map, reg = build_register(frontdoor=frontdoor, sequencer=sequencer)
+
+    status = run_pytest_coro(reg.write(1, uvm_door_e.UVM_PREDICT, reg_map))
+
+    assert status == uvm_status_e.UVM_NOT_OK
+    assert sequencer.items == []
+    assert frontdoor.snapshots == []
+
+
+def test_memory_validation_applies_before_custom_frontdoor(caplog):
+    frontdoor = StorageFrontdoor()
+    sequencer = StorageSequencer("validation_seqr")
+    reg_map, mem = build_memory(access="RO", frontdoor=frontdoor, sequencer=sequencer)
+
+    bounds_status = run_pytest_coro(mem.write(4, 1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+    rights_status = run_pytest_coro(mem.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map))
+
+    assert bounds_status == uvm_status_e.UVM_NOT_OK
+    assert rights_status == uvm_status_e.UVM_NOT_OK
+    assert sequencer.items == []
+    assert "outside" in caplog.text
+    assert "read-only memory" in caplog.text
+
+
+@pytest.mark.parametrize("element_kind", ["reg", "mem"])
+def test_frontdoor_exception_restores_state_and_is_reraised(element_kind):
+    frontdoor = FailingFrontdoor()
+    sequencer = StorageSequencer(f"{element_kind}_seqr")
+    if element_kind == "reg":
+        reg_map, element = build_register(frontdoor=frontdoor, sequencer=sequencer)
+        operation = element.write(1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+    else:
+        reg_map, element = build_memory(frontdoor=frontdoor, sequencer=sequencer)
+        operation = element.write(0, 1, uvm_door_e.UVM_FRONTDOOR, reg_map)
+
+    with pytest.raises(RuntimeError, match="frontdoor failed"):
+        run_pytest_coro(operation)
+
+    assert frontdoor.rw_info.get_status() == uvm_status_e.UVM_NOT_OK
+    assert frontdoor.sequencer is None
+    assert not frontdoor._atomic.locked()
+    assert not element._write_in_progress
+    if element_kind == "reg":
+        assert not element.is_busy()

--- a/tests/pytests/reg/test_uvm_reg_sequence.py
+++ b/tests/pytests/reg/test_uvm_reg_sequence.py
@@ -72,6 +72,12 @@ class AsyncLock:
         return self._locked
 
 
+class LegacyAsyncLock(AsyncLock):
+    @property
+    def locked(self):
+        return self._locked
+
+
 class RecordingFrontdoor(uvm_reg_frontdoor):
     def __init__(self):
         super().__init__("recording_frontdoor")
@@ -408,6 +414,17 @@ def test_frontdoor_start_does_not_reacquire_task_owned_lock():
     assert frontdoor.body_calls == 1
     assert frontdoor._atomic.acquire_calls == 1
     assert frontdoor._atomic.release_calls == 1
+
+
+def test_frontdoor_unlock_supports_legacy_cocotb_lock_property():
+    frontdoor = RecordingFrontdoor()
+    frontdoor._atomic = LegacyAsyncLock()
+
+    run_pytest_coro(frontdoor.start())
+
+    assert frontdoor._atomic.acquire_calls == 1
+    assert frontdoor._atomic.release_calls == 1
+    assert frontdoor._atomic_owner is None
 
 
 def test_frontdoor_current_task_uses_cocotb_task(monkeypatch):


### PR DESCRIPTION
# TL;DR

Implements support of custom-frontdoor routing for register and memory operations.

Configured user-defined frontdoors now receive the complete originating `uvm_reg_item`, run on the correct sequencer, and return status and read data to the caller. The implementation supports mapped and intentionally unmapped elements, wider-than-bus custom accesses, shared-frontdoor serialization, and exception-safe state cleanup.

# Summary

This PR builds on the register and memory frontdoor foundations merged in #402, #412, and #415.

It covers:

- register read/write routing through configured custom frontdoors
- memory read/write routing through configured custom frontdoors
- complete frontdoor `rw_info` propagation
- explicit-frontdoor sequencer precedence
- operation-local root-map sequencer fallback
- useful diagnostics for missing or invalid sequencers
- status and read-data propagation from the frontdoor
- mapped custom-frontdoor access
- intentionally unmapped custom-frontdoor access
- rejection of unmapped elements without a custom frontdoor
- wider-than-bus memory access through user-defined frontdoors
- preservation of the built-in frontdoor’s single-beat width restriction
- register access-right validation
- memory access-right, offset, and mapping validation
- shared-frontdoor serialization
- exception-safe restoration of frontdoor sequencer state
- exception-safe release of frontdoor locks and register/memory busy state

# RFC Alignment

This continues the staged RAL direction introduced in RFC #399 and builds on:

- #402: foundational register APIs and built-in register frontdoor access
- #412: memory mapping and built-in single-element memory frontdoor access
- #415: register sequences, convenience helpers, translation sequences, and constructible frontdoors

# Custom Frontdoor Routing

When a register or memory operation resolves to a map entry with a configured frontdoor, the selected local map now dispatches the operation through that frontdoor rather than through the built-in adapter path.

The frontdoor receives the original `uvm_reg_item` through `rw_info`. This preserves:

- element and element kind
- access kind
- register or memory value
- logical memory offset
- selected map and local map
- access path
- parent sequence
- extension
- priority
- source filename and line number

The frontdoor updates the same item, so status and read data return naturally to the originating `read()` or `write()` call.

A normally returning frontdoor body counts as completion. Frontdoors control the final operation status through `rw_info`.

# Sequencer Selection

Custom-frontdoor sequencer selection follows this precedence:

1. use the sequencer explicitly configured on the frontdoor
2. otherwise use the selected map’s root-map sequencer for that operation
3. if neither is available, report a RAL configuration error and return `UVM_NOT_OK`

The root-map fallback is operation-local. It does not permanently replace the frontdoor’s configured sequencer.

The selected sequencer must be a usable `uvm_sequencer`. Invalid sequencer objects are diagnosed before the frontdoor body starts.

# Mapping and Width Behavior

Custom frontdoors support both mapped and intentionally unmapped register and memory entries.

An intentionally unmapped entry is accepted only when it has a configured custom frontdoor. Without one, the operation is rejected.

The built-in memory frontdoor retains its single-beat restriction when the memory element is wider than the map bus. A custom frontdoor may implement that wider physical access itself because its protocol and beat decomposition are owned by the user-defined sequence.

# Validation and Cleanup

Normal element validation remains active before custom-frontdoor execution.

This includes:

- register RO/WO map rights
- memory access rights
- memory offset bounds
- declared-width masking
- map association
- supported access path
- rejection of unmapped entries without a frontdoor

Shared frontdoors are serialized so concurrent operations cannot replace each other’s `rw_info` or sequencer state.

Cleanup is protected with `finally` blocks. If a user frontdoor raises or is cancelled:

- the operation is marked `UVM_NOT_OK`
- the original sequencer is restored
- the frontdoor lock is released
- register and memory in-progress state is cleared
- register busy state is cleared
- the original exception is re-raised

# Deliberate Scope Boundaries

This PR does not implement:

- register or memory backdoor dispatch
- `peek` or `poke`
- HDL-path access
- inherited block backdoors
- memory bursts
- generic built-in multi-beat transport
- predictor completion
- memory desired or mirrored state
- memory allocation management
- virtual registers or virtual fields
- RAL callbacks
- RAL coverage

# Tests Added

New focused coverage is provided by:

- `tests/pytests/reg/test_uvm_custom_frontdoor.py`

The tests cover:

- register custom-frontdoor reads and writes
- memory custom-frontdoor reads and writes
- built-in and custom-frontdoor result equivalence
- complete `rw_info` propagation
- parent sequence, extension, priority, and source propagation
- explicit-frontdoor sequencer precedence
- root-map sequencer fallback
- missing and invalid sequencers
- mapped custom frontdoors
- intentionally unmapped custom frontdoors
- rejection of unmapped entries without a frontdoor
- wider-than-bus custom memory access
- built-in width-limit preservation
- register RO/WO validation
- memory access-right and offset validation
- read-data masking
- frontdoor failure status
- exception propagation and cleanup
- shared-frontdoor concurrency
- memory frontdoor setter/getter behavior