### PR TITLE
feat: add non-blocking sequence item polling

### DIFF
--- a/pyuvm/_s12_uvm_tlm_interfaces.py
+++ b/pyuvm/_s12_uvm_tlm_interfaces.py
@@ -100,6 +100,7 @@ class uvm_port_base(uvm_export_base):
         "put_req",
         "put_response",
         "get_next_item",
+        "try_next_item",
         "item_done",
         "get_response",
     ]

--- a/pyuvm/_s14_15_python_sequences.py
+++ b/pyuvm/_s14_15_python_sequences.py
@@ -7,6 +7,7 @@
 # SystemVerilog features.
 
 
+from cocotb.queue import QueueEmpty
 from cocotb.triggers import Event as CocotbEvent
 
 from pyuvm._error_classes import UVMFatalError, UVMSequenceError
@@ -227,6 +228,24 @@ class uvm_seq_item_export(uvm_blocking_put_export):
         await self.current_item.item_ready.wait()
         return self.current_item
 
+    def try_next_item(self):
+        """Return the next queued sequence item without waiting.
+
+        ``None`` means the request queue is empty. Like ``get_next_item``, this
+        method tracks the returned item until ``item_done`` is called.
+        """
+        if self.current_item is not None:
+            raise UVMSequenceError(
+                "You must call item_done() before calling try_next_item again"
+            )
+        try:
+            self.current_item = self.req_q.get_nowait()
+        except QueueEmpty:
+            return None
+        self.current_item.start_condition.set()
+        self.current_item.start_condition.clear()
+        return self.current_item
+
     def item_done(self, rsp=None):
         """
         Signal that the item has been completed. If ``rsp`` is not ``None``
@@ -300,6 +319,14 @@ class uvm_seq_item_port(uvm_port_base):
         """
         try:
             return await self.export.get_next_item()
+        except AttributeError:
+            assert self.export is not None, "export is not connected"
+            raise
+
+    def try_next_item(self):
+        """Return the next sequence item immediately, or ``None`` if empty."""
+        try:
+            return self.export.try_next_item()
         except AttributeError:
             assert self.export is not None, "export is not connected"
             raise

--- a/pyuvm/_s14_15_python_sequences.py
+++ b/pyuvm/_s14_15_python_sequences.py
@@ -229,10 +229,11 @@ class uvm_seq_item_export(uvm_blocking_put_export):
         return self.current_item
 
     def try_next_item(self):
-        """Return the next queued sequence item without waiting.
+        """Return ``(success, item)`` for the next queued sequence item.
 
-        ``None`` means the request queue is empty. Like ``get_next_item``, this
-        method tracks the returned item until ``item_done`` is called.
+        ``(False, None)`` means the request queue is empty. Like
+        ``get_next_item``, this method tracks the returned item until
+        ``item_done`` is called.
         """
         if self.current_item is not None:
             raise UVMSequenceError(
@@ -241,10 +242,10 @@ class uvm_seq_item_export(uvm_blocking_put_export):
         try:
             self.current_item = self.req_q.get_nowait()
         except QueueEmpty:
-            return None
+            return False, None
         self.current_item.start_condition.set()
         self.current_item.start_condition.clear()
-        return self.current_item
+        return True, self.current_item
 
     def item_done(self, rsp=None):
         """
@@ -324,7 +325,7 @@ class uvm_seq_item_port(uvm_port_base):
             raise
 
     def try_next_item(self):
-        """Return the next sequence item immediately, or ``None`` if empty."""
+        """Return ``(success, item)`` immediately, or ``(False, None)`` if empty."""
         try:
             return self.export.try_next_item()
         except AttributeError:

--- a/tests/pytests/test_uvm_seq_item_port.py
+++ b/tests/pytests/test_uvm_seq_item_port.py
@@ -13,18 +13,24 @@ def make_connected_port():
     return port, export
 
 
-def test_try_next_item_returns_available_sequence_item():
+def test_try_next_item_returns_success_and_available_sequence_item():
     port, export = make_connected_port()
     item = uvm_sequence_item("item")
     export.req_q.put_nowait(item)
 
-    assert port.try_next_item() is item
+    success, result = port.try_next_item()
+
+    assert success is True
+    assert result is item
     assert export.current_item is item
 
     port.item_done()
 
 
-def test_try_next_item_returns_none_when_sequence_queue_is_empty():
+def test_try_next_item_returns_failure_tuple_when_sequence_queue_is_empty():
     port, _export = make_connected_port()
 
-    assert port.try_next_item() is None
+    success, result = port.try_next_item()
+
+    assert success is False
+    assert result is None

--- a/tests/pytests/test_uvm_seq_item_port.py
+++ b/tests/pytests/test_uvm_seq_item_port.py
@@ -1,0 +1,30 @@
+import pytest
+
+from pyuvm import uvm_root, uvm_seq_item_export, uvm_seq_item_port, uvm_sequence_item
+
+pytestmark = pytest.mark.usefixtures("initialize_pyuvm")
+
+
+def make_connected_port():
+    root = uvm_root()
+    port = uvm_seq_item_port("seq_item_port", root)
+    export = uvm_seq_item_export("seq_item_export", root)
+    port.connect(export)
+    return port, export
+
+
+def test_try_next_item_returns_available_sequence_item():
+    port, export = make_connected_port()
+    item = uvm_sequence_item("item")
+    export.req_q.put_nowait(item)
+
+    assert port.try_next_item() is item
+    assert export.current_item is item
+
+    port.item_done()
+
+
+def test_try_next_item_returns_none_when_sequence_queue_is_empty():
+    port, _export = make_connected_port()
+
+    assert port.try_next_item() is None

--- a/tests/pytests/test_uvm_seq_item_port.py
+++ b/tests/pytests/test_uvm_seq_item_port.py
@@ -1,6 +1,12 @@
 import pytest
 
-from pyuvm import uvm_root, uvm_seq_item_export, uvm_seq_item_port, uvm_sequence_item
+from pyuvm import (
+    UVMSequenceError,
+    uvm_root,
+    uvm_seq_item_export,
+    uvm_seq_item_port,
+    uvm_sequence_item,
+)
 
 pytestmark = pytest.mark.usefixtures("initialize_pyuvm")
 
@@ -34,3 +40,30 @@ def test_try_next_item_returns_failure_tuple_when_sequence_queue_is_empty():
 
     assert success is False
     assert result is None
+
+
+def test_try_next_item_raises_error_if_called_twice_without_item_done():
+    port, export = make_connected_port()
+    item = uvm_sequence_item("item")
+    export.req_q.put_nowait(item)
+
+    success, result = port.try_next_item()
+
+    assert success is True
+    assert result is item
+
+    with pytest.raises(
+        UVMSequenceError,
+        match="You must call item_done\\(\\) before calling try_next_item again",
+    ):
+        port.try_next_item()
+
+    port.item_done()
+
+
+def test_try_next_item_raises_assertion_error_if_export_is_disconnected():
+    root = uvm_root()
+    port = uvm_seq_item_port("seq_item_port", root)
+
+    with pytest.raises(AssertionError, match="export is not connected"):
+        port.try_next_item()


### PR DESCRIPTION
## Summary
- Add non-blocking `try_next_item()` support to the sequence-item port/export.
- Return a (success, item) tuple while preserving current-item and completion semantics.
- Add connected-port tests for available and empty queues.

Fixes https://github.com/pyuvm/pyuvm/issues/421

## Validation
- `uv run pytest` (605 passed, 7 expected failures)
- `uv run ruff check`