### PR TITLE
test: make repo top importable from any test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 VERILOG_SIM ?= icarus
 VHDL_SIM ?= ghdl
 
+# Put the repo top on the test PYTHONPATH (issue #406) so any test or
+# testbench can pull code from another directory as a namespace package,
+# e.g. `from examples.TinyALU.testbench import ...`.
+export PYTHONPATH := $(abspath .):$(PYTHONPATH)
+
 # Opt into coverage collection by setting COVERAGE=1.
 COVERAGE ?=
 ifeq ($(COVERAGE),1)

--- a/examples/TinyALU/testbench.py
+++ b/examples/TinyALU/testbench.py
@@ -1,20 +1,13 @@
 import logging
 import random
 
-# All testbenches use tinyalu_utils, so store it in a central
-# place and add its path to the sys path so we can import it
-import sys
-from pathlib import Path
-
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import Combine
 
 import pyuvm
+from examples.TinyALU.tinyalu_utils import Ops, TinyAluBfm, alu_prediction
 from pyuvm import *
-
-sys.path.append(str(Path("..").resolve()))
-from tinyalu_utils import Ops, TinyAluBfm, alu_prediction
 
 # Sequence classes
 

--- a/examples/TinyALU_reg/testbench.py
+++ b/examples/TinyALU_reg/testbench.py
@@ -1,16 +1,13 @@
 import logging
+import os
 import random
-
-# All testbenches use tinyalu_utils, so store it in a central
-# place and add its path to the sys path so we can import it
-import sys
-from pathlib import Path
 
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import Combine
 
 import pyuvm
+from examples.TinyALU_reg.tinyalu_utils import Ops, TinyAluBfm, alu_prediction
 from pyuvm import (
     ConfigDB,
     UVMConfigItemNotFound,
@@ -40,11 +37,6 @@ from pyuvm import (
     uvm_test,
     uvm_tlm_analysis_fifo,
 )
-
-sys.path.append(str(Path("..").resolve()))
-import os
-
-from tinyalu_utils import Ops, TinyAluBfm, alu_prediction
 
 LANGUAGE = os.getenv("TOPLEVEL_LANG", "verilog")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,10 @@ ignore-words-list = [
 testpaths = [
     "tests/pytests",
 ]
+# Make the repo top importable from any test (issue #406), so a test can
+# pull code from any other test or example, e.g.
+# `from examples.TinyALU.testbench import ...`.
+pythonpath = ["."]
 markers = [
     "test_reg_get_name",
     "test_reg_configure",

--- a/tests/pytests/test_repo_imports.py
+++ b/tests/pytests/test_repo_imports.py
@@ -1,0 +1,18 @@
+"""Issue #406: the repo top is on the test PYTHONPATH.
+
+Any test in the repo should be able to pull code from any other test or
+example, e.g. `from examples.TinyALU.testbench import ...`. This test locks
+that namespace-package import path in place.
+"""
+
+from examples.TinyALU.testbench import Ops as TinyAluOps
+from examples.TinyALU.tinyalu_utils import Ops, alu_prediction
+
+
+def test_cross_test_import_via_repo_namespace():
+    assert TinyAluOps.ADD == 1
+
+
+def test_cross_test_import_of_shared_utils():
+    assert Ops.MUL == 4
+    assert alu_prediction(5, 3, Ops.ADD) == 8


### PR DESCRIPTION
## Summary

Fixes #406: the repo top is now part of the test's PYTHONPATH, so any test
can pull code from any other test or example — e.g.
`from examples.TinyALU.testbench import ...` — instead of reaching across
directories with relative `sys.path` hacks.

## Changes

- **`pyproject.toml`**: add the repo root to `[tool.pytest.ini_options]`
  `pythonpath` so every pytest run can import `tests` / `examples` as
  namespace packages.
- **`Makefile`**: export `PYTHONPATH` with the repo top so the cocotb
  sims (`make -C examples/TinyALU sim`, etc.) see the same root.
- **`examples/TinyALU/testbench.py`** and
  **`examples/TinyALU_reg/testbench.py`**: replace the
  `sys.path.append(str(Path("..").resolve()))` workaround with the
  canonical namespace import (`from examples.TinyALU.tinyalu_utils import ...`),
  which is the direction suggested by the maintainer in the #398 thread.
- **`tests/pytests/test_repo_imports.py`**: regression tests locking the
  namespace-package import path in place.

## Validation

```sh
uv run pytest tests/pytests        # 609 passed, 7 xfailed
uv run ruff check                  # clean on changed files
uv run --no-sync make pytests      # CI path, 609 passed, 7 xfailed
```

No production behavior changed — this only touches test path setup and
the examples' import mechanics.
